### PR TITLE
docs(agent): Gemstack topology migration — [frontend, backend, ml-ai]

### DIFF
--- a/.agent/ARCHITECTURE.md
+++ b/.agent/ARCHITECTURE.md
@@ -2,6 +2,12 @@
 
 _This document acts as the definitive anchor for understanding system design, data models, API contracts, and technology boundaries. Update this document during the Design and Review phases._
 
+## 0. Project Topology
+
+**Topology:** `[frontend, backend, ml-ai]`
+
+_Agents: Read the corresponding Gemstack topology profiles (`frontend.md`, `backend.md`, and `ml-ai.md`) from `~/.gemini/antigravity/global_workflows/` before proceeding with any workflow step. These profiles enforce component state coverage, data integrity testing, Evaluation-Driven Development (EDD), circuit breaker cost controls, and prompt versioning._
+
 ## 1. Tech Stack & Infrastructure
 - **Language / Runtime**: TypeScript ~5.8 / Node.js 22+
 - **Frontend**: React 19 via Vite 6, incorporating Tiptap for rich interaction composition, `cmdk` for the Command Palette, `react-router-dom` v7 for client-side routing, Framer Motion (`motion/react`) for layout animations, and Leaflet for interactive maps.
@@ -191,6 +197,22 @@ Failure to do this creates orphaned embedding vectors that corrupt KNN search re
 - **Date Utilities**: `date-fns` for formatting, `chrono-node` for NLP date parsing.
 - **Validation**: `zod` for runtime payload validation.
 - **Utilities**: `clsx` + `tailwind-merge` for class merging, `dompurify` for HTML sanitization, `papaparse` for CSV parsing, `eml-format` for .eml email parsing.
+
+### Model Ledger (ML/AI Topology)
+
+_Documents every LLM/ML model in use. Required by the ml-ai topology profile for Circuit Breaker calculations._
+
+| Model | Role | Cost (1M in / 1M out) | Context Window | Structured Output | Rate Limit (FREE) | Rate Limit (PAID) | Circuit Breaker Cost Cap |
+|-------|------|----------------------|----------------|-------------------|-------------------|-------------------|--------------------------|
+| `gemini-2.5-flash-lite` | Lite extraction, mentions, reranking, search expansion, daily insight | $0.075 / $0.40 | 1M tokens | Yes (JSON schema) | 10 RPM / 250K TPM / 500 RPD | 10K RPM / 10M TPM / ∞ RPD | $0.50/day |
+| `gemini-2.5-flash` | Flash reasoning, EML summaries, general structured tasks | $0.15 / $2.50 | 1M tokens | Yes (JSON schema) | 2 RPM / 250K TPM / 20 RPD | 2K RPM / 3M TPM / 100K RPD | $2.00/day |
+| `gemini-2.5-pro` | Pro — complex reasoning, AI search grounding (Pass 1) | $1.25 / $10.00 | 1M tokens | Yes (JSON schema) | 2 RPM / 4K TPM / 2 RPD | 1K RPM / 5M TPM / 50K RPD | $5.00/day |
+| `gemini-3.1-flash-lite-preview` | Preview lite — overflow capacity (PAID only) | $0.075 / $1.50 | 1M tokens | Yes (JSON schema) | N/A (paid only) | 10K RPM / 10M TPM / 350K RPD | $1.50/day |
+| `gemini-3-flash-preview` | Preview flash — overflow capacity (PAID only) | $0.15 / $3.00 | 1M tokens | Yes (JSON schema) | N/A (paid only) | 2K RPM / 3M TPM / 100K RPD | $3.00/day |
+| `gemini-3.1-pro-preview` | Preview pro — overflow capacity (PAID only) | $1.25 / $12.00 | 1M tokens | Yes (JSON schema) | N/A (paid only) | 1K RPM / 5M TPM / 50K RPD | $6.00/day |
+| `Xenova/all-MiniLM-L6-v2` | Local 384-dim embeddings for hybrid search (Transformers.js) | Free (local) | 256 tokens | N/A (embedding) | N/A (local) | N/A (local) | $0 |
+
+_Grounding RPD is a shared pool: 500 RPD (FREE) / 5,000 RPD (PAID) across all models._
 
 ## 6. Environment Variables
 

--- a/.agent/STATUS.md
+++ b/.agent/STATUS.md
@@ -22,3 +22,43 @@ No active feature in progress. Ready for the next ideation cycle.
 
 ## Relevant Files for Current Task
 _None — next feature not started._
+
+---
+
+## Stub Audit Tracker
+
+_Track mock/stub status across the frontend. Populated during Build phase, cleared during Ship._
+
+| Stub Location | Type | Real API Endpoint | Status |
+|---------------|------|-------------------|--------|
+| `server/ai/aiService.ts:76` — `parseContactRecord()` | isMockMode guard | Throws error (no mock data) | Production — graceful degradation |
+| `server/ai/aiService.ts:199` — `generateCatchMeUpBriefing()` | isMockMode mock data | `POST /api/contacts/:id/briefing` | Production — returns hardcoded 3-bullet briefing |
+| `server/ai/aiService.ts:262` — `extractMentions()` | isMockMode mock data | Inline AI call | Production — returns empty array |
+| `server/ai/aiService.ts:340` — `summarizeEmlEmail()` | isMockMode mock data | `POST /api/contacts/:id/interactions` | Production — returns hardcoded HTML summary |
+| `server/ai/aiService.ts:401` — `rerankCandidates()` | isMockMode mock data | `POST /api/search/semantic` | Production — returns first candidate |
+| `server/ai/aiService.ts:509` — `generateDailyInsight()` | isMockMode mock data | `GET /api/dashboard/insight` | Production — returns null |
+| `server/ai/aiService.ts:592` — `bulkParseContacts()` | isMockMode guard | Throws error (no mock data) | Production — graceful degradation |
+| `server/ai/aiService.ts:664` — `generateSearchExpansion()` | isMockMode guard | Inline AI call | Production — returns null |
+| `server/ai/aiService.ts:715` — `synthesizeSearchResults()` | isMockMode mock data | `POST /api/search/synthesize` | Production — returns templated string |
+| `src/views/ai-stats/components/SummaryBar.tsx:20` | Tier badge label | N/A (UI label) | Production — displays "Mock Mode" tier badge |
+
+_All stubs are production-grade graceful degradation paths (triggered when `GEMINI_API_KEY` is absent). No MSW mocking or dev-only fake data detected._
+
+---
+
+## Prompt Versioning Changelog
+
+_Track changes to LLM prompts so we can diff versions and rollback if evals degrade._
+
+| Version | Date | Change Description | Eval Score | Delta | File |
+|---------|------|--------------------|------------|-------|------|
+| v1.0 | 2026-04-16 | Baseline — contact record parsing (structured extraction from unstructured text) | — | — | `server/ai/aiService.ts:80-95` |
+| v1.0 | 2026-04-16 | Baseline — catch-me-up briefing (3-bullet executive brief from contact+timeline) | — | — | `server/ai/aiService.ts:209-230` |
+| v1.0 | 2026-04-16 | Baseline — mention extraction (NER for people in CRM notes) | — | — | `server/ai/aiService.ts:277-294` |
+| v1.0 | 2026-04-16 | Baseline — EML email summarization (raw .eml → HTML digest) | — | — | `server/ai/aiService.ts:346-360` |
+| v1.0 | 2026-04-16 | Baseline — reranker (precision-focused candidate filtering for Ask Contrack) | — | — | `server/ai/aiService.ts:412-427` |
+| v1.0 | 2026-04-16 | Baseline — daily insight (actionable CRM network insight from stats) | — | — | `server/ai/aiService.ts:515-529` |
+| v1.0 | 2026-04-16 | Baseline — search expansion / Doc2Query (write-time synonym generation) | — | — | `server/ai/aiService.ts:680` |
+| v1.0 | 2026-04-16 | Baseline — synthesis brief (executive summary of search results) | — | — | `server/ai/aiService.ts:739-753` |
+| v1.0 | 2026-04-16 | Baseline — AI Search research prompt (grounded contact research with disambiguation) | — | — | `server/services/aiSearch/promptTemplate.ts:31-188` |
+| v1.0 | 2026-04-16 | Baseline — AI Search extraction prompt (Pass 2 structured JSON extraction) | — | — | `server/services/aiSearch/strategies/twoPass.ts:120-140` |

--- a/.agent/TESTING.md
+++ b/.agent/TESTING.md
@@ -106,6 +106,156 @@ _Never mark a test as PASS without evidence._
 | AI Stats service | No tests | Add unit tests for `server/services/aiStatsService.ts` — recordInvocation, getSummary, getFeed, cleanup |
 | Frontend components | No tests | Consider React Testing Library for critical components (CommandPalette, ContactList, AIStatsView) |
 
+---
+
+## Backend Route Coverage Matrix
+
+_Populated by the SDET during the Trap phase. One row per API endpoint._
+
+| Endpoint | Method | 200 OK | 400 Bad Req | 401/403 Auth | 404 Not Found | Idempotent | Edge Cases |
+|----------|--------|--------|-------------|--------------|---------------|------------|------------|
+| `/api/contacts` | GET | | | | | | |
+| `/api/contacts` | POST | | | | | | |
+| `/api/contacts/:id` | GET | | | | | | |
+| `/api/contacts/:id` | PUT | | | | | | |
+| `/api/contacts/:id` | PATCH | | | | | | |
+| `/api/contacts/:id` | DELETE | | | | | | |
+| `/api/contacts/map` | GET | | | | | | |
+| `/api/contacts/archived` | GET | | | | | | |
+| `/api/contacts/bulk` | POST | | | | | | |
+| `/api/contacts/bulk-delete` | POST | | | | | | |
+| `/api/contacts/bulk-update` | PUT | | | | | | |
+| `/api/contacts/:id/avatar` | POST | | | | | | |
+| `/api/contacts/:id/enrich` | POST | | | | | | |
+| `/api/contacts/:id/timeline` | GET | | | | | | |
+| `/api/contacts/:id/interactions` | POST | | | | | | |
+| `/api/contacts/:id/briefing` | POST | | | | | | |
+| `/api/contacts/:id/promote` | POST | | | | | | |
+| `/api/contacts/:id/attachments` | POST | | | | | | |
+| `/api/contacts/:id/relationships` | GET | | | | | | |
+| `/api/interactions/:id` | PATCH | | | | | | |
+| `/api/interactions/:id` | DELETE | | | | | | |
+| `/api/search/` | GET | | | | | | |
+| `/api/search/semantic` | POST | | | | | | |
+| `/api/search/synthesize` | POST | | | | | | |
+| `/api/ai-search` | POST | | | | | | |
+| `/api/ai-search/status` | GET | | | | | | |
+| `/api/ai-search/stream` | GET (SSE) | | | | | | |
+| `/api/ai/diagnostics` | GET | | | | | | |
+| `/api/ai/grounding-capacity` | GET | | | | | | |
+| `/api/ai/stats/summary` | GET | | | | | | |
+| `/api/ai/stats/feed` | GET | | | | | | |
+| `/api/dashboard` | GET | | | | | | |
+| `/api/dashboard/insight` | GET | | | | | | |
+| `/api/command-palette/zero-state` | GET | | | | | | |
+| `/api/action-items` | GET | | | | | | |
+| `/api/action-items/completed` | GET | | | | | | |
+| `/api/action-items/count` | GET | | | | | | |
+| `/api/action-items/:id` | PATCH | | | | | | |
+| `/api/action-items/:id/complete` | PATCH | | | | | | |
+| `/api/action-items/:id` | DELETE | | | | | | |
+| `/api/contacts/:id/action-items` | GET | | | | | | |
+| `/api/contacts/:id/action-items` | POST | | | | | | |
+| `/api/lists/` | GET | | | | | | |
+| `/api/lists/` | POST | | | | | | |
+| `/api/lists/reorder` | PUT | | | | | | |
+| `/api/lists/:id` | PATCH | | | | | | |
+| `/api/lists/:id/contacts` | GET | | | | | | |
+| `/api/lists/:id` | DELETE | | | | | | |
+| `/api/lists/:id/members` | POST | | | | | | |
+| `/api/lists/:id/members/:contactId` | DELETE | | | | | | |
+| `/api/lists/:id/members/bulk` | POST | | | | | | |
+| `/api/link-preview/unfurl` | GET | | | | | | |
+| `/api/parse-contact` | POST | | | | | | |
+| `/api/dedupe/scan` | POST | | | | | | |
+| `/api/dedupe/stream` | GET (SSE) | | | | | | |
+| `/api/dedupe/active` | GET | | | | | | |
+| `/api/dedupe/status` | GET | | | | | | |
+| `/api/dedupe/suggestions` | GET | | | | | | |
+| `/api/dedupe/suggestions/count` | GET | | | | | | |
+| `/api/dedupe/suggestion-for/:contactId` | GET | | | | | | |
+| `/api/dedupe/suggestions/:id/dismiss` | POST | | | | | | |
+| `/api/dedupe/suggestions/:id/merge` | POST | | | | | | |
+| `/api/dedupe/merge-log` | GET | | | | | | |
+| `/api/dedupe/merge-log/:id/undo` | POST | | | | | | |
+| `/api/dedupe/backfill-embeddings` | POST | | | | | | |
+| `/api/dedupe/embedding-status` | GET | | | | | | |
+| `/api/contacts/merge` | POST | | | | | | |
+| `/api/contacts/merge-batch` | POST | | | | | | |
+| `/api/contacts/merge-cluster` | POST | | | | | | |
+| `/api/contacts/merge-clusters` | POST | | | | | | |
+| `/api/query/contacts` (MCP) | GET | | | | | | |
+| `/api/contacts/action-items` (MCP) | GET | | | | | | |
+| `/api/tags` (MCP) | GET | | | | | | |
+| `/api/industries` (MCP) | GET | | | | | | |
+| `/api/interactions/search` (MCP) | GET | | | | | | |
+| `/api/timeline` (MCP) | GET | | | | | | |
+| `/api/logos/:domain` | GET | | | | | | |
+
+---
+
+## Frontend Component State Matrix
+
+_Populated by the SDET during the Trap phase. Every interactive component must be tested across all visual states._
+
+| Component | Empty | Loading | Success | Error | Partial |
+|-----------|-------|---------|---------|-------|---------|
+| `CommandPalette` (cmdk) | | | | | |
+| `FacetAutocomplete` | | | | | |
+| `FacetPills` | | | | | |
+| `ResultPeek` | | | | | |
+| `SynthesisBar` | | | | | |
+| `ZeroStateView` | | | | | |
+| `ContactList` (contact-list view) | | | | | |
+| `ContactDetail` (contact-detail view) | | | | | |
+| `SearchView` | | | | | |
+| `DashboardView` | | | | | |
+| `MapView` | | | | | |
+| `SettingsView` | | | | | |
+| `ArchivedContactsView` | | | | | |
+| `AISearchView` (ai-search view) | | | | | |
+| `AIStatsView` (ai-stats view) | | | | | |
+| `DedupeView` (dedupe view) | | | | | |
+| `ListDetailView` (lists view) | | | | | |
+| `ImportModal` | | | | | |
+| `QuickInteractionModal` | | | | | |
+| `RichInteractionComposer` | | | | | |
+| `AvatarPickerModal` | | | | | |
+| `BulkEditFieldModal` | | | | | |
+| `KeyboardShortcutsModal` | | | | | |
+| `FloatingContactCard` | | | | | |
+| `HealthRingAvatar` | | | | | |
+| `LocalTimeWeather` | | | | | |
+| `Sidebar` | | | | | |
+| `EmptyState` | | | | | |
+| `ErrorBoundary` | | | | | |
+| `Modal` | | | | | |
+| `ContextMenu` | | | | | |
+| `Combobox` | | | | | |
+| `AnimatedSkeleton` | | | | | |
+
+---
+
+## ML / AI Evaluation Thresholds
+
+_Populated by the ML Engineer during the Build phase. Track AI feature quality metrics._
+
+| Metric | Target | Current | Method | Eval Set | Prompt Ver. | Last Run |
+|--------|--------|---------|--------|----------|-------------|----------|
+| Search Relevance (Reranker Precision) | ≥90% | — | Manual review of reranker output vs query intent | N/A | v1.0 (`aiService.ts:422`) | — |
+| Search Relevance (RRF Recall@10) | ≥80% | — | Measure how often correct contact appears in top-10 hybrid results | N/A | N/A (algorithmic) | — |
+| AI Dossier Accuracy (Two-Pass) | ≥85% field correctness | — | Compare AI Search output fields against known ground truth contacts | N/A | v1.0 (`promptTemplate.ts:31`) | — |
+| AI Dossier Hallucination Rate | ≤5% | — | Spot-check AI-generated fields (social links, education, experience) against source | N/A | v1.0 (`promptTemplate.ts:31`) | — |
+| Mention Extraction Precision | ≥95% | — | Compare extracted mentions against manually tagged interaction notes | N/A | v1.0 (`aiService.ts:280`) | — |
+| Catch-Me-Up Briefing Relevance | ≥85% | — | Human rating of briefing bullet point grounding in actual interaction data | N/A | v1.0 (`aiService.ts:213`) | — |
+| Contact Parse Accuracy | ≥90% | — | Compare parsed contact fields against original unstructured text | N/A | v1.0 (`aiService.ts:84`) | — |
+| Search Expansion Quality | ≥80% term relevance | — | Human review of Doc2Query expansion terms vs contact profile | N/A | v1.0 (`aiService.ts:680`) | — |
+| Synthesis Brief Quality | ≥85% | — | Human rating of executive brief accuracy and completeness | N/A | v1.0 (`aiService.ts:748`) | — |
+
+### Eval / Holdout Boundary
+- **eval_set**: No eval set configured yet
+- **holdout_set**: No holdout set configured yet — HUMAN-ONLY when created
+
 ## 5. Bugs Found (Fix Phase Queue)
 _List specific bugs discovered during testing._
 1. None


### PR DESCRIPTION
## Summary

Completes the Gemstack topology migration for **contrack** — the final repository (8/8) to be migrated. Adds topology-aware agent configuration for the full `[frontend, backend, ml-ai]` topology.

All changes are **purely additive** — no existing content was modified, deleted, or renumbered.

## Key Changes

### ARCHITECTURE.md
- **`§0 Project Topology`** — Topology declaration directing agents to read `frontend.md`, `backend.md`, and `ml-ai.md` Gemstack profiles
- **Model Ledger** — 7 models documented (6 Gemini variants + Xenova/all-MiniLM-L6-v2) with full pricing, per-tier rate limits, and circuit breaker cost caps

### TESTING.md
- **Backend Route Coverage Matrix** — 76 endpoints pre-populated from all 13 route files
- **Frontend Component State Matrix** — 32 components from command palette, views, modals, layout, and UI primitives
- **ML/AI Evaluation Thresholds** — 9 metrics (reranker precision, RRF recall, dossier accuracy, hallucination rate, mention extraction, briefing quality, contact parsing, search expansion, synthesis quality) linked to prompt versions

### STATUS.md
- **Stub Audit Tracker** — 10 `isMockMode()` graceful degradation paths catalogued
- **Prompt Versioning Changelog** — 10 v1.0 baseline entries for every LLM prompt location

## Testing
- All changes are documentation-only (Markdown files in `.agent/`)
- No code changes — no build/lint/test validation required