### PR TITLE
🧪 [Add tests for error message helper]

### DIFF
--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { getErrorMessage } from "../../server/utils/helpers";
+
+describe("getErrorMessage", () => {
+  it("extracts message from a standard Error instance", () => {
+    const message = "Something went wrong";
+    const error = new Error(message);
+    expect(getErrorMessage(error)).toBe(message);
+  });
+
+  it("extracts message from a custom Error subclass", () => {
+    class CustomError extends Error {
+      constructor(msg: string) {
+        super(msg);
+        this.name = "CustomError";
+      }
+    }
+    const message = "Custom error message";
+    const error = new CustomError(message);
+    expect(getErrorMessage(error)).toBe(message);
+  });
+
+  it("returns the string representation of a string thrown value", () => {
+    const message = "Simple string error";
+    expect(getErrorMessage(message)).toBe(message);
+  });
+
+  it("returns the string representation of a numeric thrown value", () => {
+    expect(getErrorMessage(404)).toBe("404");
+  });
+
+  it("returns the string representation of a boolean thrown value", () => {
+    expect(getErrorMessage(true)).toBe("true");
+    expect(getErrorMessage(false)).toBe("false");
+  });
+
+  it("returns the string representation of null", () => {
+    expect(getErrorMessage(null)).toBe("null");
+  });
+
+  it("returns the string representation of undefined", () => {
+    expect(getErrorMessage(undefined)).toBe("undefined");
+  });
+
+  it("returns '[object Object]' for a plain object", () => {
+    expect(getErrorMessage({})).toBe("[object Object]");
+  });
+
+  it("returns string representation of an object with toString", () => {
+    const obj = {
+      toString: () => "Custom Object Error",
+    };
+    expect(getErrorMessage(obj)).toBe("Custom Object Error");
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for the `getErrorMessage` utility function.
📊 **Coverage:** 
- Standard `Error` instances (extracts `.message`)
- Custom `Error` subclasses
- String values (returns as-is)
- Numeric values (returns string representation)
- Boolean values (returns string representation)
- `null` and `undefined` (returns "null" and "undefined")
- Plain objects (returns "[object Object]")
- Objects with custom `toString()` (returns the result of `toString()`)
✨ **Result:** Increased reliability of a core utility used throughout the server for error reporting. Verified with 100% pass rate in the new test suite.

---
*PR created automatically by Jules for task [321854343890725033](https://jules.google.com/task/321854343890725033) started by @arvarik*