### PR TITLE
fix(ai-search): dynamically resolve strategy per request and respect SearXNG

### DIFF
--- a/server/routes/aiSearch.ts
+++ b/server/routes/aiSearch.ts
@@ -16,7 +16,11 @@ import { ai } from "../ai/index.ts";
 import { log } from "../utils/logger.ts";
 import type { AISearchBatch } from "../services/aiSearch/types.ts";
 import { getErrorMessage } from "../utils/helpers.ts";
-import { getDefaultStrategyForProvider } from "../services/aiSearch/strategies/index.ts";
+import {
+  getDefaultStrategyForProvider,
+  getStrategy,
+} from "../services/aiSearch/strategies/index.ts";
+import { providerIdFor } from "../ai/gateway.ts";
 
 export const aiSearchRouter = Router();
 
@@ -29,13 +33,9 @@ export const aiSearchRouter = Router();
 // (max 5/hr). Omitted intentionally — this is a single-user local app and
 // the in-memory 5-minute cooldown in jobQueue.canStartBatch() provides
 // equivalent protection. Add express-rate-limit if deploying multi-tenant.
-const providerName = (process.env.AI_PROVIDER ?? "gemini").toLowerCase();
 const aiSearchBodySchema = z.object({
   contactIds: z.array(z.string()).min(1).max(100),
-  strategy: z
-    .string()
-    .optional()
-    .default(getDefaultStrategyForProvider(providerName)),
+  strategy: z.string().optional(),
 });
 
 // =============================================================================
@@ -46,7 +46,17 @@ aiSearchRouter.post(
   "/ai-search",
   validateBody(aiSearchBodySchema),
   asyncHandler(async (req, res) => {
-    const { contactIds, strategy } = req.body;
+    const { contactIds, strategy: requestedStrategy } = req.body;
+
+    const researchProvider = providerIdFor("research");
+    const strategy =
+      requestedStrategy ?? getDefaultStrategyForProvider(researchProvider);
+
+    try {
+      getStrategy(strategy);
+    } catch (err) {
+      return res.status(400).json({ error: getErrorMessage(err) });
+    }
 
     // Check AI provider is configured
     if (!ai.isConfigured) {
@@ -55,7 +65,7 @@ aiSearchRouter.post(
         openai: "OPENAI_API_KEY",
         anthropic: "ANTHROPIC_API_KEY",
       };
-      const keyVar = KEY_MAP[providerName] ?? "GEMINI_API_KEY";
+      const keyVar = KEY_MAP[researchProvider ?? "gemini"] ?? "GEMINI_API_KEY";
       return res.status(503).json({
         error: `AI provider is not configured. Set ${keyVar} in your .env file.`,
       });

--- a/server/services/aiSearch/jobQueue.ts
+++ b/server/services/aiSearch/jobQueue.ts
@@ -355,6 +355,13 @@ class AISearchJobQueue extends EventEmitter {
       log.debug("AISearchQueue", `GC: cleaned ${cleaned} stale batch(es)`);
     }
   }
+
+  /** Reset queue state for tests. */
+  __resetForTests(): void {
+    this.batches.clear();
+    this.processing = false;
+    this.lastBatchCompletedAt = null;
+  }
 }
 
 // Singleton instance

--- a/tests/integration/api.aiSearch.test.ts
+++ b/tests/integration/api.aiSearch.test.ts
@@ -1,0 +1,168 @@
+// =============================================================================
+// Integration: AI Search API routes and strategy resolution
+// =============================================================================
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import request from "supertest";
+import { makeTestApp } from "./helpers.ts";
+import { sqlite } from "../../server/db.ts";
+import { jobQueue } from "../../server/services/aiSearch/jobQueue.ts";
+import {
+  setSetting,
+  clearSettingsCache,
+  SETTING_KEYS,
+} from "../../server/services/settingsService.ts";
+import { invalidateProviderCache } from "../../server/ai/providerRegistry.ts";
+
+const app = makeTestApp();
+
+describe("POST /api/ai-search", () => {
+  let contactId: string;
+
+  beforeEach(async () => {
+    jobQueue.__resetForTests();
+    sqlite.prepare("DELETE FROM app_settings").run();
+    clearSettingsCache();
+    invalidateProviderCache();
+
+    // Prevent background queue execution during endpoint tests
+    vi.spyOn(jobQueue, "processBatch").mockResolvedValue();
+
+    // Create a test contact
+    const res = await request(app)
+      .post("/api/contacts")
+      .send({ name: "Ada Lovelace", emails: ["ada@example.com"] });
+    contactId = res.body.id;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    jobQueue.__resetForTests();
+    sqlite.prepare("DELETE FROM app_settings").run();
+    clearSettingsCache();
+    invalidateProviderCache();
+  });
+
+  it("returns 503 when no AI provider is configured", async () => {
+    const res = await request(app)
+      .post("/api/ai-search")
+      .send({ contactIds: [contactId] });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toContain("AI provider is not configured");
+  });
+
+  it("dynamically resolves to 'searxng' on self-hosted setups with SearXNG configured", async () => {
+    // Configure a self-hosted custom endpoint (e.g. Ollama/LM Studio)
+    setSetting(SETTING_KEYS.aiCustomEndpoints, [
+      {
+        id: "local-ollama",
+        label: "Local Ollama",
+        baseUrl: "http://127.0.0.1:11434/v1",
+      },
+    ]);
+    // Configure SearXNG for research
+    setSetting(SETTING_KEYS.aiSearxng, { url: "http://127.0.0.1:8888" });
+    invalidateProviderCache();
+
+    const res = await request(app)
+      .post("/api/ai-search")
+      .send({ contactIds: [contactId] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.batchId).toBeDefined();
+    expect(res.body.jobCount).toBe(1);
+
+    const batch = jobQueue.getBatch(res.body.batchId);
+    expect(batch).not.toBeNull();
+    // Must resolve dynamically to searxng instead of baking 'two-pass'
+    expect(batch?.strategy).toBe("searxng");
+  });
+
+  it("defaults to 'two-pass' when no research provider or SearXNG is configured", async () => {
+    // Configure custom endpoint without SearXNG
+    setSetting(SETTING_KEYS.aiCustomEndpoints, [
+      {
+        id: "local-ollama",
+        label: "Local Ollama",
+        baseUrl: "http://127.0.0.1:11434/v1",
+      },
+    ]);
+    invalidateProviderCache();
+
+    const res = await request(app)
+      .post("/api/ai-search")
+      .send({ contactIds: [contactId] });
+
+    expect(res.status).toBe(200);
+    const batch = jobQueue.getBatch(res.body.batchId);
+    expect(batch?.strategy).toBe("two-pass");
+  });
+
+  it("honors explicit valid strategy requested in payload", async () => {
+    setSetting(SETTING_KEYS.aiCustomEndpoints, [
+      {
+        id: "local-ollama",
+        label: "Local Ollama",
+        baseUrl: "http://127.0.0.1:11434/v1",
+      },
+    ]);
+    setSetting(SETTING_KEYS.aiSearxng, { url: "http://127.0.0.1:8888" });
+    invalidateProviderCache();
+
+    const res = await request(app)
+      .post("/api/ai-search")
+      .send({ contactIds: [contactId], strategy: "single-pass" });
+
+    expect(res.status).toBe(200);
+    const batch = jobQueue.getBatch(res.body.batchId);
+    expect(batch?.strategy).toBe("single-pass");
+  });
+
+  it("rejects unknown strategy with 400 Bad Request", async () => {
+    setSetting(SETTING_KEYS.aiCustomEndpoints, [
+      {
+        id: "local-ollama",
+        label: "Local Ollama",
+        baseUrl: "http://127.0.0.1:11434/v1",
+      },
+    ]);
+    invalidateProviderCache();
+
+    const res = await request(app)
+      .post("/api/ai-search")
+      .send({ contactIds: [contactId], strategy: "invalid-strat" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Unknown AI Search strategy");
+  });
+
+  it("rejects empty contactIds array with 400 Validation Error", async () => {
+    const res = await request(app)
+      .post("/api/ai-search")
+      .send({ contactIds: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when none of the contacts exist", async () => {
+    setSetting(SETTING_KEYS.aiCustomEndpoints, [
+      {
+        id: "local-ollama",
+        label: "Local Ollama",
+        baseUrl: "http://127.0.0.1:11434/v1",
+      },
+    ]);
+    invalidateProviderCache();
+
+    const res = await request(app)
+      .post("/api/ai-search")
+      .send({ contactIds: ["00000000-0000-0000-0000-000000000000"] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain(
+      "None of the selected contacts were found",
+    );
+  });
+});

--- a/tests/unit/multi-provider.test.ts
+++ b/tests/unit/multi-provider.test.ts
@@ -418,6 +418,16 @@ describe("AI Search Strategy Selection", () => {
     const strategy = getStrategy();
     expect(strategy.name).toBe("two-pass");
   });
+
+  it("getDefaultStrategyForProvider resolves appropriate strategy per provider", async () => {
+    const { getDefaultStrategyForProvider } =
+      await import("../../server/services/aiSearch/strategies/index.ts");
+    expect(getDefaultStrategyForProvider("openai")).toBe("single-pass");
+    expect(getDefaultStrategyForProvider("anthropic")).toBe("single-pass");
+    expect(getDefaultStrategyForProvider("gemini")).toBe("two-pass");
+    // When provider is null and no SearXNG is configured, fallback is two-pass
+    expect(getDefaultStrategyForProvider(null)).toBe("two-pass");
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
Closes #12

## Overview
Resolves the AI Search strategy dynamically per-request in `POST /api/ai-search` using the active research capability provider (`providerIdFor("research")`) instead of evaluating a static default at module load time from `process.env.AI_PROVIDER`.

## Root Cause
1. `getDefaultStrategyForProvider(providerName)` was evaluated once at module import time and baked into Zod schema defaults.
2. `providerName` was sourced from `process.env.AI_PROVIDER` (defaulting to `"gemini"` via `docker-compose.yml`), rather than the actual provider assigned to the `"research"` capability.
3. Because `providerName` was always truthy (`"gemini"`), `getDefaultStrategyForProvider` never checked for a configured SearXNG instance, unconditionally returning `"two-pass"`.
4. In self-hosted setups (e.g. Ollama / LM Studio + SearXNG), `TwoPassStrategy` attempted `generateFor("research")`, which failed with `No AI provider is configured for the "research" capability` because OpenAI-compatible endpoints do not support native search grounding. Single-contact enrichment (`/api/contacts/:id/enrich`) already handled this dynamically and worked as expected.

## Solution
- Removed static module-level `providerName` and import-time strategy evaluation from `server/routes/aiSearch.ts`.
- Made `strategy` optional in `aiSearchBodySchema` without baking a static Zod default.
- In `aiSearchRouter.post("/ai-search")`, dynamically resolved `strategy = req.body.strategy ?? getDefaultStrategyForProvider(researchProvider)`.
- Added early validation for requested strategy via `getStrategy(strategy)` returning 400 Bad Request on unknown strategy names.
- Added `__resetForTests()` to `AISearchJobQueue` for clean test isolation.
- Added comprehensive integration tests in `tests/integration/api.aiSearch.test.ts` verifying SearXNG fallback, explicit strategy overrides, and invalid inputs.
- Added unit tests in `tests/unit/multi-provider.test.ts` for `getDefaultStrategyForProvider`.

## Verification
- `npm run lint`: Pass (clean, 0 warnings)
- `npm run format:check`: Pass
- `npm test`: All 41 test files (575 tests) pass
- `npm run build`: Pass