### PR TITLE
fix(search): harden indexing and retrieval freshness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: ["main"]
     tags: ["v*"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "arvind/harden-*"]
   # Manual re-run, and an escape hatch when GitHub's hosted pool is congested
   # or degraded — pick the hppc self-hosted runner instead of waiting in queue.
   workflow_dispatch:

--- a/docs/search-hardening.md
+++ b/docs/search-hardening.md
@@ -1,0 +1,34 @@
+# Search reliability
+
+Keyword search treats input as literal Unicode tokens. It matches token prefixes across contact fields.
+Every search channel excludes ghost, archived, merged, and trashed contacts.
+The retrieval query applies contact filters before the result limit.
+
+The FTS migration uses each contact's SQLite rowid for its index row.
+An edit deletes one index row through that rowid. It does not scan every contact ID.
+The migration installs triggers and rebuilds the index in one transaction.
+Child inserts, edits, moves, and deletes refresh both affected contacts.
+
+Contact edits remove obsolete vectors in the same transaction.
+An asynchronous embedding write compares its source text and model with the current values before saving.
+Search cache keys include the database revision and a five-minute time window.
+An older request cannot repopulate the current search cache after a contact change.
+
+Automatic contact refreshes use local embeddings of saved fields.
+Contact edits no longer request AI keyword expansion. The migration clears older inferred expansion terms.
+This reduces AI work and prevents inferred keywords from becoming search evidence.
+Pinned provider embeddings remain available through the embedding-store backfill path.
+Automatic local refreshes skip provider embeddings. Until a backfill runs, keyword search covers those edited contacts.
+
+## Verification
+
+Run `npm test` for keyword syntax, visibility, child updates, migration, filtered retrieval, and asynchronous write regressions.
+Run `npx tsx scripts/benchmark-search.ts` for a temporary database with 10,000 synthetic contacts.
+The benchmark measures 100 contact edits and 100 keyword searches. It never opens the user's database.
+
+On the development machine, the edit p95 decreased from 3.094 ms to 0.113 ms.
+Keyword search p95 decreased from 0.464 ms to 0.235 ms.
+These measurements describe this benchmark, not a production latency guarantee.
+
+The implementation follows [SQLite FTS5](https://www.sqlite.org/fts5.html) and [sqlite-vec KNN guidance](https://alexgarcia.xyz/sqlite-vec/features/knn.html).
+The regression suite also checks the installed sqlite-vec version with a text-primary-key filter.

--- a/scripts/benchmark-search.ts
+++ b/scripts/benchmark-search.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Each run uses synthetic data in a temporary database, including when comparing branches.
+const dataDir = mkdtempSync(path.join(tmpdir(), "contrack-search-bench-"));
+process.env.DATA_DIR = dataDir;
+process.env.DISABLE_BACKGROUND_JOBS = "true";
+process.env.GEMINI_API_KEY = "";
+process.env.OPENAI_API_KEY = "";
+process.env.ANTHROPIC_API_KEY = "";
+const { sqlite } = await import(
+  pathToFileURL(path.resolve("server/db.ts")).href
+);
+
+try {
+  const count = 10_000;
+  const insert = sqlite.prepare(
+    "INSERT INTO contacts(id, name, company, role) VALUES (?, ?, ?, ?)",
+  );
+  sqlite.transaction(() => {
+    for (let i = 0; i < count; i++)
+      insert.run(
+        `bench-${i}`,
+        `Contact ${i}`,
+        `Company ${i % 100}`,
+        "Engineer",
+      );
+  })();
+  const update = sqlite.prepare("UPDATE contacts SET role = ? WHERE id = ?");
+  const query = sqlite.prepare(
+    "SELECT contactId FROM contacts_fts WHERE contacts_fts MATCH ? ORDER BY rank LIMIT 20",
+  );
+  const edits: number[] = [],
+    searches: number[] = [];
+  for (let i = 0; i < 100; i++) {
+    let start = performance.now();
+    update.run(i % 2 ? "Engineer" : "Designer", `bench-${i}`);
+    edits.push(performance.now() - start);
+    start = performance.now();
+    query.all(`"Company ${i % 100}"`);
+    searches.push(performance.now() - start);
+  }
+  const summarize = (values: number[]) => {
+    values.sort((a, b) => a - b);
+    return { p50Ms: +values[50].toFixed(3), p95Ms: +values[95].toFixed(3) };
+  };
+  console.log(
+    JSON.stringify({
+      contacts: count,
+      samples: 100,
+      edit: summarize(edits),
+      search: summarize(searches),
+    }),
+  );
+} finally {
+  sqlite.close();
+  rmSync(dataDir, { recursive: true, force: true });
+}

--- a/server/db.ts
+++ b/server/db.ts
@@ -10,6 +10,10 @@
  * @module server/db
  */
 import Database from "better-sqlite3";
+import {
+  installSearchIndex,
+  installSearchVectorTriggers,
+} from "./services/search/ftsIndex.ts";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import * as schema from "../src/db/schema.ts";
@@ -361,198 +365,14 @@ sqlite.exec(
   `CREATE INDEX IF NOT EXISTS idx_contacts_deleted ON contacts(deletedAt)`,
 );
 
-// ── Versioned rebuild gate ──────────────────────────────────────────────
-// Dropping the FTS table forces a full reindex of every contact on boot.
-// That's only needed when the FTS schema or trigger payloads change — bump
-// FTS_SCHEMA_VERSION when they do. Otherwise the triggers below keep the
-// index in sync and the incremental backfill catches any missed rows.
-const FTS_SCHEMA_VERSION = 1;
-const storedFtsVersion = sqlite.pragma("user_version", {
-  simple: true,
-}) as number;
-const ftsTableExists = !!sqlite
-  .prepare(
-    "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'contacts_fts'",
-  )
-  .get();
-const ftsNeedsRebuild =
-  !ftsTableExists || storedFtsVersion !== FTS_SCHEMA_VERSION;
-
-if (ftsNeedsRebuild) {
-  try {
-    sqlite.exec(`DROP TABLE IF EXISTS contacts_fts`);
-  } catch {
-    /* may not exist */
-  }
+// These columns must exist before the search migration on older installations.
+for (const column of ["canonicalId TEXT", "isArchived INTEGER DEFAULT 0"]) {
+  const name = column.split(" ")[0];
+  const columns = sqlite.pragma("table_info(contacts)") as { name: string }[];
+  if (!columns.some((c) => c.name === name))
+    sqlite.exec(`ALTER TABLE contacts ADD COLUMN ${column}`);
 }
-
-sqlite.exec(`
-  CREATE VIRTUAL TABLE IF NOT EXISTS contacts_fts USING fts5(
-    contactId UNINDEXED, name, company, role, headline, location, about, industry, extras, searchExpansion
-  );
-
-  DROP TRIGGER IF EXISTS contacts_ai;
-  CREATE TRIGGER contacts_ai AFTER INSERT ON contacts BEGIN
-    INSERT INTO contacts_fts(contactId, name, company, role, headline, location, about, industry, extras, searchExpansion)
-    VALUES (
-      new.id, new.name, new.company, new.role, new.headline, new.location, new.about, new.industry,
-      COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = new.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(interest, ' ') FROM contact_interests WHERE contactId = new.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contactId = new.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contactId = new.id), ''),
-      COALESCE(new.searchExpansion, '')
-    );
-  END;
-
-  DROP TRIGGER IF EXISTS contacts_ad;
-  CREATE TRIGGER contacts_ad AFTER DELETE ON contacts BEGIN
-    DELETE FROM contacts_fts WHERE contactId = old.id;
-  END;
-
-  DROP TRIGGER IF EXISTS contacts_au;
-  CREATE TRIGGER contacts_au AFTER UPDATE ON contacts BEGIN
-    DELETE FROM contacts_fts WHERE contactId = old.id;
-    -- Trash-aware: soft-deleted contacts are removed from the index and
-    -- not reinserted until restored (deletedAt cleared).
-    INSERT INTO contacts_fts(contactId, name, company, role, headline, location, about, industry, extras, searchExpansion)
-    SELECT
-      new.id, new.name, new.company, new.role, new.headline, new.location, new.about, new.industry,
-      COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = new.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(interest, ' ') FROM contact_interests WHERE contactId = new.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contactId = new.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contactId = new.id), ''),
-      COALESCE(new.searchExpansion, '')
-    WHERE new.deletedAt IS NULL;
-  END;
-
-  -- Child-table triggers: refresh FTS when tags, interests, emails, or phones change
-  DROP TRIGGER IF EXISTS fts_tags_ai;
-  CREATE TRIGGER fts_tags_ai AFTER INSERT ON contact_tags BEGIN
-    DELETE FROM contacts_fts WHERE contactId = new.contactId;
-    INSERT INTO contacts_fts(contactId, name, company, role, headline, location, about, industry, extras, searchExpansion)
-    SELECT c.id, c.name, c.company, c.role, c.headline, c.location, c.about, c.industry,
-      COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(interest, ' ') FROM contact_interests WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contactId = c.id), ''),
-      COALESCE(c.searchExpansion, '')
-    FROM contacts c WHERE c.id = new.contactId AND c.deletedAt IS NULL;
-  END;
-
-  DROP TRIGGER IF EXISTS fts_tags_ad;
-  CREATE TRIGGER fts_tags_ad AFTER DELETE ON contact_tags BEGIN
-    DELETE FROM contacts_fts WHERE contactId = old.contactId;
-    INSERT INTO contacts_fts(contactId, name, company, role, headline, location, about, industry, extras, searchExpansion)
-    SELECT c.id, c.name, c.company, c.role, c.headline, c.location, c.about, c.industry,
-      COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(interest, ' ') FROM contact_interests WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contactId = c.id), ''),
-      COALESCE(c.searchExpansion, '')
-    FROM contacts c WHERE c.id = old.contactId AND c.deletedAt IS NULL;
-  END;
-
-  DROP TRIGGER IF EXISTS fts_interests_ai;
-  CREATE TRIGGER fts_interests_ai AFTER INSERT ON contact_interests BEGIN
-    DELETE FROM contacts_fts WHERE contactId = new.contactId;
-    INSERT INTO contacts_fts(contactId, name, company, role, headline, location, about, industry, extras, searchExpansion)
-    SELECT c.id, c.name, c.company, c.role, c.headline, c.location, c.about, c.industry,
-      COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(interest, ' ') FROM contact_interests WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contactId = c.id), ''),
-      COALESCE(c.searchExpansion, '')
-    FROM contacts c WHERE c.id = new.contactId AND c.deletedAt IS NULL;
-  END;
-
-  DROP TRIGGER IF EXISTS fts_interests_ad;
-  CREATE TRIGGER fts_interests_ad AFTER DELETE ON contact_interests BEGIN
-    DELETE FROM contacts_fts WHERE contactId = old.contactId;
-    INSERT INTO contacts_fts(contactId, name, company, role, headline, location, about, industry, extras, searchExpansion)
-    SELECT c.id, c.name, c.company, c.role, c.headline, c.location, c.about, c.industry,
-      COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(interest, ' ') FROM contact_interests WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contactId = c.id), ''),
-      COALESCE(c.searchExpansion, '')
-    FROM contacts c WHERE c.id = old.contactId AND c.deletedAt IS NULL;
-  END;
-
-  DROP TRIGGER IF EXISTS fts_emails_ai;
-  CREATE TRIGGER fts_emails_ai AFTER INSERT ON contact_emails BEGIN
-    DELETE FROM contacts_fts WHERE contactId = new.contactId;
-    INSERT INTO contacts_fts(contactId, name, company, role, headline, location, about, industry, extras, searchExpansion)
-    SELECT c.id, c.name, c.company, c.role, c.headline, c.location, c.about, c.industry,
-      COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(interest, ' ') FROM contact_interests WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contactId = c.id), ''),
-      COALESCE(c.searchExpansion, '')
-    FROM contacts c WHERE c.id = new.contactId AND c.deletedAt IS NULL;
-  END;
-
-  DROP TRIGGER IF EXISTS fts_emails_ad;
-  CREATE TRIGGER fts_emails_ad AFTER DELETE ON contact_emails BEGIN
-    DELETE FROM contacts_fts WHERE contactId = old.contactId;
-    INSERT INTO contacts_fts(contactId, name, company, role, headline, location, about, industry, extras, searchExpansion)
-    SELECT c.id, c.name, c.company, c.role, c.headline, c.location, c.about, c.industry,
-      COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(interest, ' ') FROM contact_interests WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contactId = c.id), ''),
-      COALESCE(c.searchExpansion, '')
-    FROM contacts c WHERE c.id = old.contactId AND c.deletedAt IS NULL;
-  END;
-
-  -- Phone number triggers: refresh FTS when phones are added or removed
-  DROP TRIGGER IF EXISTS fts_phones_ai;
-  CREATE TRIGGER fts_phones_ai AFTER INSERT ON contact_phones BEGIN
-    DELETE FROM contacts_fts WHERE contactId = new.contactId;
-    INSERT INTO contacts_fts(contactId, name, company, role, headline, location, about, industry, extras, searchExpansion)
-    SELECT c.id, c.name, c.company, c.role, c.headline, c.location, c.about, c.industry,
-      COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(interest, ' ') FROM contact_interests WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contactId = c.id), ''),
-      COALESCE(c.searchExpansion, '')
-    FROM contacts c WHERE c.id = new.contactId AND c.deletedAt IS NULL;
-  END;
-
-  DROP TRIGGER IF EXISTS fts_phones_ad;
-  CREATE TRIGGER fts_phones_ad AFTER DELETE ON contact_phones BEGIN
-    DELETE FROM contacts_fts WHERE contactId = old.contactId;
-    INSERT INTO contacts_fts(contactId, name, company, role, headline, location, about, industry, extras, searchExpansion)
-    SELECT c.id, c.name, c.company, c.role, c.headline, c.location, c.about, c.industry,
-      COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(interest, ' ') FROM contact_interests WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contactId = c.id), '') || ' ' ||
-      COALESCE((SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contactId = c.id), ''),
-      COALESCE(c.searchExpansion, '')
-    FROM contacts c WHERE c.id = old.contactId AND c.deletedAt IS NULL;
-  END;
-
-  -- Backfill FTS for any contacts not yet indexed (including phones in extras)
-  INSERT INTO contacts_fts(contactId, name, company, role, headline, location, about, industry, extras, searchExpansion)
-  SELECT c.id, c.name, c.company, c.role, c.headline, c.location, c.about, c.industry,
-    COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = c.id), '') || ' ' ||
-    COALESCE((SELECT GROUP_CONCAT(interest, ' ') FROM contact_interests WHERE contactId = c.id), '') || ' ' ||
-    COALESCE((SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contactId = c.id), '') || ' ' ||
-    COALESCE((SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contactId = c.id), ''),
-    COALESCE(c.searchExpansion, '')
-  FROM contacts c
-  WHERE c.id NOT IN (SELECT contactId FROM contacts_fts)
-    AND c.deletedAt IS NULL;
-`);
-
-if (ftsNeedsRebuild) {
-  sqlite.pragma(`user_version = ${FTS_SCHEMA_VERSION}`);
-  log.info(
-    "Database",
-    `FTS5 search index rebuilt (schema v${FTS_SCHEMA_VERSION})`,
-  );
-} else {
-  log.info("Database", "FTS5 search index up-to-date (full rebuild skipped)");
-}
+installSearchIndex(sqlite);
 
 // =============================================================================
 // 4. Auto-stamp updatedAt on every contacts mutation
@@ -964,3 +784,5 @@ if (contactsMissingHash.length > 0) {
     `Backfilled phoneticHash for ${contactsMissingHash.length} contacts`,
   );
 }
+
+installSearchVectorTriggers(sqlite);

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -12,7 +12,9 @@ router.get(
   "/",
   asyncHandler(async (req, res) => {
     const rid = req.requestId;
-    const q = req.query.q as string;
+    const q = req.query.q;
+    if (q !== undefined && typeof q !== "string")
+      throw new AppError("q must be a string", 400);
 
     if (!q) return res.json([]);
     if (q.length > 500) throw new AppError("q must be ≤ 500 characters", 400);

--- a/server/services/aiSearch/mergeEngine.ts
+++ b/server/services/aiSearch/mergeEngine.ts
@@ -20,6 +20,7 @@
 import { sqlite } from "../../db.ts";
 import { sanitizeAiOutputValue } from "../../ai/promptSafety.ts";
 import { contactRepo } from "../../repositories/contactRepository.ts";
+import { scheduleSearchIndex } from "../search/indexQueue.ts";
 import { invalidateSearchCache } from "../../utils/aiCache.ts";
 import type {
   HydratedContact,
@@ -296,6 +297,7 @@ export function mergeSearchResult(
 
   // Invalidate the semantic search cache so updated data is searchable
   invalidateSearchCache();
+  scheduleSearchIndex(contactId);
 
   log.info(
     "MergeEngine",

--- a/server/services/contactService.ts
+++ b/server/services/contactService.ts
@@ -23,8 +23,7 @@ import { aiCache } from "../utils/aiCache.ts";
 import { buildContactUpdate } from "../utils/helpers.ts";
 import { buildAvatarUrl } from "./avatarService.ts";
 import { generateAndStoreEmbedding } from "./dedupe/embeddings.ts";
-import { embedContact } from "./search/localEmbeddings.ts";
-import { generateSearchExpansion } from "../ai/aiService.ts";
+import { scheduleSearchIndex } from "./search/indexQueue.ts";
 import { doubleMetaphone } from "../utils/nlp/index.ts";
 import { log } from "../utils/logger.ts";
 import { dedupeService } from "./dedupe/index.ts";
@@ -232,37 +231,7 @@ export const contactService = {
       ),
     );
 
-    // Fire-and-forget: Doc2Query search expansion → then embed with complete data
-    // NOTE: We intentionally don't embed before expansion completes — the single
-    // embedContact call after expansion captures the enriched text, avoiding a
-    // double-embed race condition.
-    generateSearchExpansion({
-      name: body.name,
-      role: body.role,
-      company: body.company,
-      industry: body.industry,
-      about: body.about,
-      preferences: body.preferences,
-      tags: body.tags?.map((t) => (typeof t === "string" ? t : t.tag)),
-      interests: body.interests?.map((i) =>
-        typeof i === "string" ? i : i.interest,
-      ),
-    })
-      .then((expansion) => {
-        if (expansion) {
-          sqlite
-            .prepare("UPDATE contacts SET searchExpansion = ? WHERE id = ?")
-            .run(expansion, id);
-        }
-        // Embed with or without expansion — this is the definitive embedding
-        return embedContact(id);
-      })
-      .catch((err) =>
-        log.debug(
-          "ContactService",
-          `Doc2Query/embed for ${id} skipped: ${err?.message}`,
-        ),
-      );
+    scheduleSearchIndex(id);
 
     // Fire-and-forget: incremental dedupe check (debounced)
     scheduleIncrementalDedupe(id);
@@ -436,50 +405,12 @@ export const contactService = {
       );
     }
 
-    // Fire-and-forget: recompute search embedding + Doc2Query
-    if (SEARCH_TRIGGER_FIELDS.some((f) => body[f] !== undefined)) {
-      // Regenerate Doc2Query expansion → then embed once with complete data
-      const row = sqlite
-        .prepare(
-          "SELECT name, role, company, industry, about, preferences FROM contacts WHERE id = ?",
-        )
-        .get(id) as
-        | Pick<
-            ContactRow,
-            "name" | "role" | "company" | "industry" | "about" | "preferences"
-          >
-        | undefined;
-      if (row) {
-        const tags = (
-          sqlite
-            .prepare("SELECT tag FROM contact_tags WHERE contactId = ?")
-            .all(id) as { tag: string }[]
-        ).map((t) => t.tag);
-        const interests = (
-          sqlite
-            .prepare(
-              "SELECT interest FROM contact_interests WHERE contactId = ?",
-            )
-            .all(id) as { interest: string }[]
-        ).map((t) => t.interest);
-        generateSearchExpansion({ ...row, tags, interests })
-          .then((expansion) => {
-            if (expansion) {
-              sqlite
-                .prepare("UPDATE contacts SET searchExpansion = ? WHERE id = ?")
-                .run(expansion, id);
-            }
-            return embedContact(id);
-          })
-          .catch((err) =>
-            log.debug(
-              "ContactService",
-              `Doc2Query/embed update for ${id} skipped: ${err?.message}`,
-            ),
-          );
-      } else {
-        embedContact(id).catch(() => {});
-      }
+    if (
+      SEARCH_TRIGGER_FIELDS.some((f) => body[f] !== undefined) ||
+      body.tags !== undefined ||
+      body.interests !== undefined
+    ) {
+      scheduleSearchIndex(id);
     }
 
     // Fire-and-forget: incremental dedupe if identity fields changed
@@ -514,7 +445,7 @@ export const contactService = {
     // NOTE: FTS5 is already updated by the contacts_au trigger, but the
     // vector embedding + Doc2Query expansion must be refreshed explicitly.
     if (SEARCH_TRIGGER_FIELDS.some((f) => body[f] !== undefined)) {
-      embedContact(id).catch(() => {});
+      scheduleSearchIndex(id);
     }
 
     const updated = contactRepo.hydrate(
@@ -568,7 +499,7 @@ export const contactService = {
       .run();
 
     // Fire-and-forget: regenerate the purged embeddings.
-    embedContact(id).catch(() => {});
+    scheduleSearchIndex(id);
     generateAndStoreEmbedding(id).catch(() => {});
 
     invalidateAllCaches();

--- a/server/services/dedupe/merging.ts
+++ b/server/services/dedupe/merging.ts
@@ -1,3 +1,4 @@
+import { scheduleSearchIndex } from "../search/indexQueue.ts";
 import { sqlite, db } from "../../db.ts";
 import * as schema from "../../../src/db/schema.ts";
 import { eq } from "drizzle-orm";
@@ -347,6 +348,7 @@ export function mergeContacts(
   });
 
   mergeTxn();
+  scheduleSearchIndex(primaryId);
   return contactRepo.hydrate(
     sqlite.prepare("SELECT * FROM contacts WHERE id = ?").get(primaryId),
   );

--- a/server/services/search/ftsIndex.ts
+++ b/server/services/search/ftsIndex.ts
@@ -1,0 +1,97 @@
+import type Database from "better-sqlite3";
+
+/** The active contact predicate shared by every search channel. */
+export const ACTIVE_CONTACT_SQL = `c.isGhost = 0 AND COALESCE(c.isArchived, 0) = 0
+  AND c.canonicalId IS NULL AND c.deletedAt IS NULL`;
+
+const VERSION = 2;
+const COLUMNS =
+  "contactId, name, company, role, headline, location, about, industry, extras, searchExpansion";
+const VALUES = `c.id, c.name, c.company, c.role, c.headline, c.location, c.about, c.industry,
+  COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = c.id), '') || ' ' ||
+  COALESCE((SELECT GROUP_CONCAT(interest, ' ') FROM contact_interests WHERE contactId = c.id), '') || ' ' ||
+  COALESCE((SELECT GROUP_CONCAT(email, ' ') FROM contact_emails WHERE contactId = c.id), '') || ' ' ||
+  COALESCE((SELECT GROUP_CONCAT(phone, ' ') FROM contact_phones WHERE contactId = c.id), ''),
+  COALESCE(c.searchExpansion, '')`;
+
+/** Columns which change search text or contact visibility. */
+export const SEARCH_COLUMNS =
+  "id, name, company, role, headline, location, about, industry, preferences, searchExpansion, isGhost, isArchived, canonicalId, deletedAt";
+
+/** Install or migrate FTS atomically. FTS rowids match contact rowids for indexed deletes. */
+export function installSearchIndex(sqlite: Database.Database): void {
+  sqlite.transaction(() => {
+    const version = sqlite.pragma("user_version", { simple: true });
+    if (version !== VERSION) sqlite.exec("DROP TABLE IF EXISTS contacts_fts");
+    sqlite.exec(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS contacts_fts USING fts5(
+        contactId UNINDEXED, name, company, role, headline, location, about, industry, extras, searchExpansion,
+        prefix='2 3 4'
+      );
+      CREATE TABLE IF NOT EXISTS search_revision (id INTEGER PRIMARY KEY CHECK(id = 1), revision INTEGER NOT NULL);
+      INSERT OR IGNORE INTO search_revision VALUES (1, 0);
+      DROP TRIGGER IF EXISTS contacts_ai;
+      DROP TRIGGER IF EXISTS contacts_ad;
+      DROP TRIGGER IF EXISTS contacts_au;
+      CREATE TRIGGER contacts_ai AFTER INSERT ON contacts BEGIN
+        INSERT INTO contacts_fts(rowid, ${COLUMNS}) SELECT c.rowid, ${VALUES}
+        FROM contacts c WHERE c.id = new.id AND ${ACTIVE_CONTACT_SQL};
+      END;
+      CREATE TRIGGER contacts_ad AFTER DELETE ON contacts BEGIN
+        DELETE FROM contacts_fts WHERE rowid = old.rowid;
+      END;
+      CREATE TRIGGER contacts_au AFTER UPDATE OF ${SEARCH_COLUMNS} ON contacts BEGIN
+        DELETE FROM contacts_fts WHERE rowid = old.rowid;
+        INSERT INTO contacts_fts(rowid, ${COLUMNS}) SELECT c.rowid, ${VALUES}
+        FROM contacts c WHERE c.id = new.id AND ${ACTIVE_CONTACT_SQL};
+      END;
+    `);
+    for (const event of ["INSERT", "UPDATE", "DELETE"]) {
+      sqlite.exec(`
+        DROP TRIGGER IF EXISTS search_revision_${event};
+        CREATE TRIGGER search_revision_${event} AFTER ${event} ON contacts BEGIN
+          UPDATE search_revision SET revision = revision + 1 WHERE id = 1;
+        END;
+      `);
+    }
+    for (const table of ["tags", "interests", "emails", "phones"]) {
+      for (const [suffix, event, ids] of [
+        ["ai", "INSERT", "new.contactId"],
+        ["ad", "DELETE", "old.contactId"],
+        ["au", "UPDATE", "old.contactId, new.contactId"],
+      ]) {
+        sqlite.exec(`
+          DROP TRIGGER IF EXISTS fts_${table}_${suffix};
+          CREATE TRIGGER fts_${table}_${suffix} AFTER ${event} ON contact_${table} BEGIN
+            UPDATE contacts SET searchExpansion = NULL WHERE id IN (${ids});
+          END;
+        `);
+      }
+    }
+    if (version !== VERSION) {
+      sqlite.exec(
+        "UPDATE contacts SET searchExpansion = NULL WHERE searchExpansion IS NOT NULL",
+      );
+    }
+    sqlite.exec(`
+      INSERT INTO contacts_fts(rowid, ${COLUMNS}) SELECT c.rowid, ${VALUES}
+      FROM contacts c WHERE ${ACTIVE_CONTACT_SQL}
+      AND NOT EXISTS (SELECT 1 FROM contacts_fts f WHERE f.rowid = c.rowid);
+    `);
+    sqlite.pragma(`user_version = ${VERSION}`);
+  })();
+}
+
+/** Remove outdated vectors in the same transaction as the contact change. */
+export function installSearchVectorTriggers(sqlite: Database.Database): void {
+  sqlite.exec(`
+    DROP TRIGGER IF EXISTS search_vector_update;
+    CREATE TRIGGER search_vector_update AFTER UPDATE OF ${SEARCH_COLUMNS} ON contacts BEGIN
+      DELETE FROM search_embeddings WHERE contactId = old.id;
+    END;
+    DROP TRIGGER IF EXISTS search_vector_delete;
+    CREATE TRIGGER search_vector_delete AFTER DELETE ON contacts BEGIN
+      DELETE FROM search_embeddings WHERE contactId = old.id;
+    END;
+  `);
+}

--- a/server/services/search/hybridRetrieval.ts
+++ b/server/services/search/hybridRetrieval.ts
@@ -41,9 +41,11 @@
 // =============================================================================
 
 import { sqlite } from "../../db.ts";
+import { lexicalSearch } from "./lexical.ts";
+import { ACTIVE_CONTACT_SQL } from "./ftsIndex.ts";
 import { log } from "../../utils/logger.ts";
 import {
-  isLocalEmbeddingReady,
+  isSearchEmbeddingReady,
   embedText,
   findSearchNeighbors,
   getSearchEmbeddingCount,
@@ -106,13 +108,6 @@ const FTS_LIMIT = 100;
 const VECTOR_LIMIT = 100;
 
 /**
- * BM25 column weights for FTS5.
- * Column order: name, company, role, headline, location, about, industry, extras, searchExpansion
- * A match in "name" (10x) is far more informative than "extras" (1x).
- */
-const BM25_WEIGHTS = "10.0, 5.0, 3.0, 2.0, 2.0, 1.0, 1.0, 1.0, 1.0";
-
-/**
  * High-confidence threshold: if ≥ this fraction of candidates came from
  * the FTS5 channel, the query is likely a keyword/exact match
  * and we can skip the LLM reranker.
@@ -145,11 +140,11 @@ interface HardFilterResult {
  * Active contacts only — ghosts, archived contacts, and soft-merged
  * (canonical replaced) contacts are excluded from all search results.
  */
-const ACTIVE_GATE_SQL = `isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL) AND canonicalId IS NULL`;
+const ACTIVE_GATE_SQL = ACTIVE_CONTACT_SQL;
 
 /**
  * Compile a list of matchers into a single case-insensitive word-boundary
- * regex. Word boundary uses `(?:^|[^a-zA-Z0-9])` and `(?=[^a-zA-Z0-9]|$)`
+ * regex. Word boundary uses `(?:^|[^\\p{L}\\p{N}])` and `(?=[^\\p{L}\\p{N}]|$)`
  * (not \b) so that hyphenated/punctuated text matches correctly without
  * Unicode surprises.
  */
@@ -163,8 +158,8 @@ function buildMatcherRegex(matchers: string[]): RegExp | null {
   // Sort longest-first so the alternation prefers the most specific match
   parts.sort((a, b) => b.length - a.length);
   return new RegExp(
-    `(?:^|[^a-zA-Z0-9])(?:${parts.join("|")})(?=[^a-zA-Z0-9]|$)`,
-    "i",
+    `(?:^|[^\\p{L}\\p{N}])(?:${parts.join("|")})(?=[^\\p{L}\\p{N}]|$)`,
+    "iu",
   );
 }
 
@@ -216,13 +211,10 @@ function applyHardFilters(plan: QueryPlan): HardFilterResult {
         c.role,
         c.headline,
         c.industry,
-        COALESCE(GROUP_CONCAT(DISTINCT t.tag), '')      AS tagsText,
-        COALESCE(GROUP_CONCAT(DISTINCT i.interest), '') AS interestsText
+        COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = c.id), '') AS tagsText,
+        COALESCE((SELECT GROUP_CONCAT(interest, ' ') FROM contact_interests WHERE contactId = c.id), '') AS interestsText
       FROM contacts c
-      LEFT JOIN contact_tags t      ON t.contactId = c.id
-      LEFT JOIN contact_interests i ON i.contactId = c.id
       WHERE ${ACTIVE_GATE_SQL}${temporalSql}
-      GROUP BY c.id
     `,
     )
     .all(...temporalParams) as {
@@ -277,49 +269,11 @@ function ftsRetrieval(
   query: string,
   preFilterIds: Set<string> | null,
 ): RankedItem[] {
-  const sanitized = query.replace(/['\"]/g, "").trim();
-  if (!sanitized) return [];
-
-  const tokens = sanitized.split(/\s+/).filter((t) => t.length > 0);
-  if (tokens.length === 0) return [];
-
-  const strategies = [
-    `"${sanitized}"`,
-    tokens.map((t) => `"${t}"*`).join(" "),
-    tokens.map((t) => `"${t}"*`).join(" OR "),
-  ];
-
-  for (const ftsQuery of strategies) {
-    try {
-      const rows = sqlite
-        .prepare(
-          `
-        SELECT contactId, bm25(contacts_fts, ${BM25_WEIGHTS}) as score
-        FROM contacts_fts
-        WHERE contacts_fts MATCH ?
-        ORDER BY score
-        LIMIT ?
-      `,
-        )
-        .all(ftsQuery, FTS_LIMIT) as { contactId: string; score: number }[];
-
-      const filtered = preFilterIds
-        ? rows.filter((r) => preFilterIds.has(r.contactId))
-        : rows;
-
-      if (filtered.length > 0) {
-        return filtered.map((r, i) => ({
-          contactId: r.contactId,
-          rank: i + 1,
-          channel: "fts" as const,
-        }));
-      }
-    } catch {
-      // FTS5 syntax errors — continue to next strategy
-    }
-  }
-
-  return [];
+  return lexicalSearch(query, FTS_LIMIT, preFilterIds, true).map((row, i) => ({
+    contactId: row.contactId,
+    rank: i + 1,
+    channel: "fts" as const,
+  }));
 }
 
 // =============================================================================
@@ -330,7 +284,7 @@ async function vectorRetrieval(
   embedInputText: string,
   preFilterIds: Set<string> | null,
 ): Promise<RankedItem[]> {
-  if (!isLocalEmbeddingReady() || getSearchEmbeddingCount() === 0) {
+  if (!isSearchEmbeddingReady() || getSearchEmbeddingCount() === 0) {
     return [];
   }
 
@@ -386,22 +340,24 @@ function buildTraitBoosts(
           LEFT JOIN contact_interests i ON i.contactId = c.id
           WHERE c.isGhost = 0
             AND (c.isArchived = 0 OR c.isArchived IS NULL)
-            AND c.canonicalId IS NULL
+            AND c.canonicalId IS NULL AND c.deletedAt IS NULL
+            AND (${allowedIds ? "c.id IN (SELECT value FROM json_each(?))" : "1"})
             AND (
-              c.about LIKE ? OR c.preferences LIKE ? OR c.headline LIKE ?
-              OR c.searchExpansion LIKE ?
-              OR t.tag LIKE ? OR i.interest LIKE ?
+              c.about LIKE ? ESCAPE '\\' OR c.preferences LIKE ? ESCAPE '\\' OR c.headline LIKE ? ESCAPE '\\'
+              OR c.searchExpansion LIKE ? ESCAPE '\\'
+              OR t.tag LIKE ? ESCAPE '\\' OR i.interest LIKE ? ESCAPE '\\'
             )
           LIMIT ?
         `,
         )
         .all(
-          `%${trait}%`,
-          `%${trait}%`,
-          `%${trait}%`,
-          `%${trait}%`,
-          `%${trait}%`,
-          `%${trait}%`,
+          ...(allowedIds ? [JSON.stringify([...allowedIds])] : []),
+          `%${trait.replace(/[\\%_]/g, "\\$&")}%`,
+          `%${trait.replace(/[\\%_]/g, "\\$&")}%`,
+          `%${trait.replace(/[\\%_]/g, "\\$&")}%`,
+          `%${trait.replace(/[\\%_]/g, "\\$&")}%`,
+          `%${trait.replace(/[\\%_]/g, "\\$&")}%`,
+          `%${trait.replace(/[\\%_]/g, "\\$&")}%`,
           BOOST_LIMIT,
         ) as { id: string }[];
 

--- a/server/services/search/indexQueue.ts
+++ b/server/services/search/indexQueue.ts
@@ -1,0 +1,48 @@
+import { sqlite } from "../../db.ts";
+import { resolveEmbeddings } from "../../ai/embeddings.ts";
+import { embedContact } from "./localEmbeddings.ts";
+import { log } from "../../utils/logger.ts";
+import { getErrorMessage } from "../../utils/helpers.ts";
+
+const pending = new Set<string>();
+let running = false;
+let timer: ReturnType<typeof setTimeout> | undefined;
+
+async function drain(): Promise<void> {
+  timer = undefined;
+  if (running) return;
+  running = true;
+  try {
+    while (pending.size) {
+      const id = pending.values().next().value!;
+      pending.delete(id);
+      // Automatic refreshes run locally. Provider embeddings use the explicit backfill path.
+      if (resolveEmbeddings().kind !== "builtin") continue;
+      try {
+        await embedContact(id);
+      } catch (error) {
+        log.warn(
+          "SearchIndex",
+          `Local refresh failed for ${id}: ${getErrorMessage(error)}`,
+        );
+      }
+    }
+  } finally {
+    running = false;
+  }
+}
+
+/** Coalesce local indexing after edits. FTS updates in the contact transaction. */
+export function scheduleSearchIndex(id: string): void {
+  sqlite
+    .prepare(
+      "UPDATE contacts SET searchExpansion = NULL WHERE id = ? AND searchExpansion IS NOT NULL",
+    )
+    .run(id);
+  if (process.env.DISABLE_BACKGROUND_JOBS === "true") return;
+  pending.add(id);
+  if (!timer && !running) {
+    timer = setTimeout(() => void drain(), 250);
+    timer.unref();
+  }
+}

--- a/server/services/search/lexical.ts
+++ b/server/services/search/lexical.ts
@@ -1,0 +1,44 @@
+import { sqlite } from "../../db.ts";
+import { ACTIVE_CONTACT_SQL } from "./ftsIndex.ts";
+
+// The first FTS column is the unindexed contactId. It still consumes a weight.
+const WEIGHTS = "0, 10, 5, 3, 2, 2, 1, 1, 1, 0.5";
+
+/** Treat user text as literal Unicode tokens, never as FTS operators. */
+export function searchTokens(query: string): string[] {
+  return (query.normalize("NFKC").match(/[\p{L}\p{N}\p{M}]+/gu) ?? []).slice(
+    0,
+    32,
+  );
+}
+
+/** Retrieve active keyword matches. Apply allowed IDs before ranking and limiting. */
+export function lexicalSearch(
+  query: string,
+  limit = 20,
+  allowedIds?: Set<string> | null,
+  broad = false,
+): { contactId: string }[] {
+  const tokens = searchTokens(query);
+  if (!tokens.length || allowedIds?.size === 0) return [];
+  const clauses = tokens.map((token) => `"${token}"*`);
+  const strategies = [clauses.join(" AND ")];
+  if (broad && tokens.length > 1) strategies.push(clauses.join(" OR "));
+  const scope = allowedIds
+    ? "AND c.id IN (SELECT value FROM json_each(?))"
+    : "";
+  const stmt = sqlite.prepare(`
+    SELECT c.id AS contactId FROM contacts_fts f
+    JOIN contacts c ON c.rowid = f.rowid
+    WHERE contacts_fts MATCH ? AND ${ACTIVE_CONTACT_SQL} ${scope}
+    ORDER BY bm25(contacts_fts, ${WEIGHTS}), c.id LIMIT ?
+  `);
+  for (const strategy of strategies) {
+    const params = allowedIds
+      ? [strategy, JSON.stringify([...allowedIds]), limit]
+      : [strategy, limit];
+    const rows = stmt.all(...params) as { contactId: string }[];
+    if (rows.length) return rows;
+  }
+  return [];
+}

--- a/server/services/search/localEmbeddings.ts
+++ b/server/services/search/localEmbeddings.ts
@@ -17,6 +17,8 @@
 
 import path from "path";
 import { sqlite } from "../../db.ts";
+import { ACTIVE_CONTACT_SQL } from "./ftsIndex.ts";
+import { AppError } from "../../utils/AppError.ts";
 import { log } from "../../utils/logger.ts";
 import { getErrorMessage } from "../../utils/helpers.ts";
 import {
@@ -94,7 +96,11 @@ export async function initLocalEmbeddings(): Promise<void> {
     }
   })();
 
-  return initPromise;
+  try {
+    await initPromise;
+  } finally {
+    initPromise = null;
+  }
 }
 
 /** Check if the local embedding model is ready. */
@@ -143,7 +149,7 @@ async function embedTexts(texts: string[]): Promise<Float32Array[]> {
     const vec = new Float32Array(values);
     // Guards against a silent local-model swap by a contributor.
     if (vec.length !== BUILTIN_DIMENSION) {
-      throw new Error(
+      throw new AppError(
         `Expected ${BUILTIN_DIMENSION}-dim vector from the built-in model, got ${vec.length}`,
       );
     }
@@ -217,7 +223,7 @@ export function upsertSearchEmbedding(
 ): void {
   // Defensive copy — Buffer.from(arrayBuffer) is zero-copy, which risks
   // corruption if Transformers.js reclaims the underlying ArrayBuffer.
-  const buf = Buffer.from(embedding.buffer.slice(0));
+  const buf = Buffer.from(new Float32Array(embedding).buffer);
   _upsertTxn(contactId, buf);
 }
 
@@ -229,29 +235,24 @@ export function findSearchNeighbors(
   k: number,
   preFilterIds?: Set<string>,
 ): { contactId: string; distance: number }[] {
-  const buf = Buffer.from(queryVec.buffer.slice(0));
-
-  // Brute-force KNN via sqlite-vec — perfect for ~960 rows (<0.5ms).
-  // NOTE: If the dataset exceeds ~10K contacts, consider switching to an
-  // approximate nearest neighbor index (e.g., HNSW) or pre-filtering in SQL.
-  const rows = sqlite
+  if (preFilterIds?.size === 0 || !Number.isFinite(k) || k < 1) return [];
+  const buf = Buffer.from(new Float32Array(queryVec).buffer);
+  const scope = preFilterIds
+    ? "AND c.id IN (SELECT value FROM json_each(?))"
+    : "";
+  const params = preFilterIds
+    ? [buf, JSON.stringify([...preFilterIds]), Math.min(Math.floor(k), 500)]
+    : [buf, Math.min(Math.floor(k), 500)];
+  return sqlite
     .prepare(
       `
-    SELECT contactId, distance
-    FROM search_embeddings
+    SELECT contactId, distance FROM search_embeddings
     WHERE embedding MATCH ?
-    ORDER BY distance
-    LIMIT ?
+      AND contactId IN (SELECT c.id FROM contacts c WHERE ${ACTIVE_CONTACT_SQL} ${scope})
+      AND k = ? ORDER BY distance
   `,
     )
-    .all(buf, Math.min(k, 500)) as { contactId: string; distance: number }[];
-
-  // Apply pre-filter if provided
-  if (preFilterIds) {
-    return rows.filter((r) => preFilterIds.has(r.contactId));
-  }
-
-  return rows;
+    .all(...params) as { contactId: string; distance: number }[];
 }
 
 /** Count of contacts with search embeddings. */
@@ -299,10 +300,10 @@ export async function ensureEmbeddingStore(): Promise<number> {
     state.dimension !== dimension;
   if (!changed) return 0;
 
-  if (state) {
+  if (state || dimension !== BUILTIN_DIMENSION) {
     log.info(
       "LocalEmbeddings",
-      `Embeddings changed (${state.signature} → ${resolved.signature}); rebuilding vector store`,
+      `Embeddings changed (${state?.signature ?? "unversioned"} → ${resolved.signature}); rebuilding vector store`,
     );
     rebuildSearchEmbeddingTable(dimension);
   }
@@ -334,8 +335,7 @@ export async function backfillSearchEmbeddings(): Promise<number> {
     SELECT c.id, c.name, c.company, c.role, c.location, c.industry,
            c.headline, c.about, c.preferences, c.searchExpansion
     FROM contacts c
-    WHERE c.isGhost = 0 AND (c.isArchived = 0 OR c.isArchived IS NULL)
-      AND c.canonicalId IS NULL
+    WHERE ${ACTIVE_CONTACT_SQL}
       AND c.id NOT IN (SELECT contactId FROM search_embeddings)
   `,
     )
@@ -375,11 +375,13 @@ export async function backfillSearchEmbeddings(): Promise<number> {
       return contactToSearchText(c, tags, interests);
     });
 
+    const signature = resolveEmbeddings().signature;
     const vectors = await embedBatch(texts);
+    if (signature !== resolveEmbeddings().signature) return embedded;
 
     // Store in transaction for speed
     if (vectors.length !== batch.length) {
-      throw new Error(
+      throw new AppError(
         `Embedding backend returned ${vectors.length} vectors for ${batch.length} contacts — refusing to write a partial index`,
       );
     }
@@ -387,7 +389,7 @@ export async function backfillSearchEmbeddings(): Promise<number> {
     const txn = sqlite.transaction(() => {
       for (let j = 0; j < batch.length; j++) {
         const vec = vectors[j];
-        if (!vec) continue;
+        if (!vec || currentSearchText(batch[j].id) !== texts[j]) continue;
         const buf = Buffer.from(vec.buffer.slice(0));
         deleteStmt.run(batch[j].id);
         insertStmt.run(batch[j].id, buf);
@@ -409,13 +411,13 @@ export async function backfillSearchEmbeddings(): Promise<number> {
  * Called on contact create/update.
  */
 export async function embedContact(contactId: string): Promise<void> {
-  if (!modelReady) return;
+  if (!isSearchEmbeddingReady()) return;
 
   const row = sqlite
     .prepare(
       `
     SELECT id, name, company, role, location, industry, headline, about, preferences, searchExpansion
-    FROM contacts WHERE id = ?
+    FROM contacts c WHERE c.id = ? AND ${ACTIVE_CONTACT_SQL}
   `,
     )
     .get(contactId) as SearchTextRow | undefined;
@@ -434,9 +436,15 @@ export async function embedContact(contactId: string): Promise<void> {
   ).map((t) => t.interest);
 
   const text = contactToSearchText(row, tags, interests);
+  const signature = resolveEmbeddings().signature;
   const vec = await embedText(text);
   if (!vec) return;
 
+  if (
+    signature !== resolveEmbeddings().signature ||
+    text !== currentSearchText(contactId)
+  )
+    return;
   upsertSearchEmbedding(contactId, vec);
 }
 
@@ -480,4 +488,25 @@ function contactToSearchText(
   if (interests.length) parts.push(interests.join(", "));
   if (row.searchExpansion) parts.push(row.searchExpansion);
   return parts.join(" | ");
+}
+
+/** Read current source text after an asynchronous embedding call. */
+function currentSearchText(contactId: string): string | null {
+  const row = sqlite
+    .prepare(
+      `SELECT c.* FROM contacts c WHERE c.id = ? AND ${ACTIVE_CONTACT_SQL}`,
+    )
+    .get(contactId) as SearchTextRow | undefined;
+  if (!row) return null;
+  const tags = (
+    sqlite
+      .prepare("SELECT tag FROM contact_tags WHERE contactId = ?")
+      .all(contactId) as { tag: string }[]
+  ).map((t) => t.tag);
+  const interests = (
+    sqlite
+      .prepare("SELECT interest FROM contact_interests WHERE contactId = ?")
+      .all(contactId) as { interest: string }[]
+  ).map((t) => t.interest);
+  return contactToSearchText(row, tags, interests);
 }

--- a/server/services/searchService.ts
+++ b/server/services/searchService.ts
@@ -20,6 +20,8 @@
 // =============================================================================
 
 import { sqlite } from "../db.ts";
+import { lexicalSearch } from "./search/lexical.ts";
+import { ACTIVE_CONTACT_SQL } from "./search/ftsIndex.ts";
 import { log } from "../utils/logger.ts";
 import { contactRepo } from "../repositories/contactRepository.ts";
 import { rerankCandidates, type CompressedContact } from "../ai/aiService.ts";
@@ -86,7 +88,9 @@ function hydrateCandidates(
   // per-id hydrate() here previously cost ~13 queries per candidate.
   const placeholders = topIds.map(() => "?").join(",");
   const rows = sqlite
-    .prepare(`SELECT * FROM contacts WHERE id IN (${placeholders})`)
+    .prepare(
+      `SELECT c.* FROM contacts c WHERE c.id IN (${placeholders}) AND ${ACTIVE_CONTACT_SQL}`,
+    )
     .all(topIds);
   const hydratedRows = contactRepo.hydrateMany(rows);
   const byId = new Map(hydratedRows.map((r) => [r.id, r]));
@@ -168,7 +172,9 @@ function hydrateAiMatches(
   const placeholders = ids.map(() => "?").join(",");
 
   const rows = sqlite
-    .prepare(`SELECT * FROM contacts WHERE id IN (${placeholders})`)
+    .prepare(
+      `SELECT c.* FROM contacts c WHERE c.id IN (${placeholders}) AND ${ACTIVE_CONTACT_SQL}`,
+    )
     .all(ids);
   const hydratedRows = contactRepo.hydrateMany(rows);
 
@@ -193,18 +199,8 @@ export const searchService = {
    * Simple, fast, exact-match search.
    */
   searchFts(q: string) {
-    const safeQ = q.replace(/['"]/g, "");
-    const results = sqlite
-      .prepare(
-        `
-      SELECT c.* FROM contacts c
-      JOIN contacts_fts fts ON c.id = fts.contactId
-      WHERE contacts_fts MATCH ?
-      ORDER BY rank LIMIT 20
-    `,
-      )
-      .all(`"${safeQ}"*`);
-    return contactRepo.hydrateMany(results);
+    const ids = lexicalSearch(q).map((row) => row.contactId);
+    return [...hydrateCandidates(ids, 20).values()];
   },
 
   // ===========================================================================
@@ -229,9 +225,15 @@ export const searchService = {
     signal?: AbortSignal,
   ) {
     const startTime = Date.now();
+    const revision = (
+      sqlite
+        .prepare("SELECT revision FROM search_revision WHERE id = 1")
+        .get() as { revision: number }
+    ).revision;
+    const cacheKey = `${revision}:${Math.floor(startTime / 300_000)}:${query.trim().toLowerCase()}`;
 
     // ── 1. Cache check ─────────────────────────────────────────────────
-    const cached = getCachedSearch(query);
+    const cached = getCachedSearch(cacheKey);
     if (cached) {
       log.info(
         "SemanticSearch",
@@ -330,7 +332,7 @@ export const searchService = {
     // ── 5. Short-circuit: high-confidence → skip LLM ──────────────────
     if (retrieval.highConfidence) {
       // Cache the high-confidence result (no need for LLM enrichment)
-      setCachedSearch(query, { matches: phase1Matches, fallback: false });
+      setCachedSearch(cacheKey, { matches: phase1Matches, fallback: false });
       recordInvocation({
         operation: "rerank",
         latencyMs: Date.now() - startTime,
@@ -375,7 +377,7 @@ export const searchService = {
         );
 
         const result = { matches: enrichedMatches, fallback: false };
-        setCachedSearch(query, result);
+        setCachedSearch(cacheKey, result);
 
         res.write(
           JSON.stringify({
@@ -388,7 +390,7 @@ export const searchService = {
         );
       } else {
         // LLM returned 0 matches — keep Phase 1 results
-        setCachedSearch(query, { matches: phase1Matches, fallback: false });
+        setCachedSearch(cacheKey, { matches: phase1Matches, fallback: false });
       }
     } catch (aiErr: unknown) {
       log.warn(
@@ -412,9 +414,15 @@ export const searchService = {
    */
   async semanticSearch(query: string, rid: string) {
     const startTime = Date.now();
+    const revision = (
+      sqlite
+        .prepare("SELECT revision FROM search_revision WHERE id = 1")
+        .get() as { revision: number }
+    ).revision;
+    const cacheKey = `${revision}:${Math.floor(startTime / 300_000)}:${query.trim().toLowerCase()}`;
 
     // 1. Cache check
-    const cached = getCachedSearch(query);
+    const cached = getCachedSearch(cacheKey);
     if (cached) {
       log.info(
         "SemanticSearch",
@@ -456,7 +464,7 @@ export const searchService = {
         "SemanticSearch",
         `[${rid}] v3 "${query}" → ${hydratedPhase1.length} results (high confidence, skipped LLM) in ${elapsed}ms`,
       );
-      setCachedSearch(query, { matches: hydratedPhase1, fallback: false });
+      setCachedSearch(cacheKey, { matches: hydratedPhase1, fallback: false });
       recordInvocation({
         operation: "rerank",
         latencyMs: elapsed,
@@ -490,7 +498,7 @@ export const searchService = {
         );
 
         const result = { matches: enriched, fallback: false };
-        setCachedSearch(query, result);
+        setCachedSearch(cacheKey, result);
         return { ...result, cached: false };
       }
     } catch {

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -22,12 +22,14 @@ const API_BASE = "/api";
 export const useSearchContacts = (q: string) => {
   return useQuery({
     queryKey: ["contacts", "search", q],
-    queryFn: async (): Promise<Contact[]> => {
-      const res = await fetch(`${API_BASE}/search?q=${encodeURIComponent(q)}`);
+    queryFn: async ({ signal }): Promise<Contact[]> => {
+      const res = await fetch(`${API_BASE}/search?q=${encodeURIComponent(q)}`, {
+        signal,
+      });
       if (!res.ok) throw new Error("Failed to search contacts");
       return res.json();
     },
-    enabled: q.length > 0,
+    enabled: q.trim().length > 0,
     // CRITICAL: keepPreviousData prevents the result list from emptying and
     // re-filling on every debounced keystroke. Without this, each new query key
     // starts with data=undefined → layout shift → results reappear. With it,

--- a/src/hooks/useInstantSearch.ts
+++ b/src/hooks/useInstantSearch.ts
@@ -92,8 +92,12 @@ export function useInstantSearch(
     return debouncedQuery;
   }, [debouncedQuery, enabled]);
 
-  const { data: ftsResults = [], isLoading: ftsLoading } =
-    useSearchContacts(serverQuery);
+  const {
+    data: ftsResults = [],
+    isFetching: ftsLoading,
+    isPlaceholderData,
+    isSuccess,
+  } = useSearchContacts(serverQuery);
 
   // ── 3. Apply facet post-filter on FTS results ───────────────────────────
   // FTS results are server-side; we still need to filter by any active facets
@@ -107,11 +111,15 @@ export function useInstantSearch(
   // ── 4. Handover logic ───────────────────────────────────────────────────
   // FTS results replace client results when available
   const hasActiveFts =
-    filteredFtsResults.length > 0 && debouncedQuery.trim().length > 0;
+    enabled &&
+    serverQuery.length > 0 &&
+    serverQuery === query &&
+    isSuccess &&
+    !isPlaceholderData;
   const hasClientResults = clientResults.length > 0;
 
   return {
-    results: hasActiveFts ? filteredFtsResults : clientResults,
+    results: !enabled ? [] : hasActiveFts ? filteredFtsResults : clientResults,
     isInstant: !hasActiveFts && hasClientResults,
     isFtsLoading: ftsLoading && !!debouncedQuery.trim(),
   };

--- a/tests/integration/search.index.test.ts
+++ b/tests/integration/search.index.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+import { makeTestApp } from "./helpers.ts";
+import { sqlite } from "../../server/db.ts";
+import { lexicalSearch } from "../../server/services/search/lexical.ts";
+import { installSearchIndex } from "../../server/services/search/ftsIndex.ts";
+import {
+  embedContact,
+  findSearchNeighbors,
+  upsertSearchEmbedding,
+} from "../../server/services/search/localEmbeddings.ts";
+import * as embeddings from "../../server/ai/embeddings.ts";
+
+const app = makeTestApp();
+const insert = (id: string, name = "Alice", role = "Designer") =>
+  sqlite
+    .prepare("INSERT INTO contacts(id, name, role) VALUES (?, ?, ?)")
+    .run(id, name, role);
+const vector = (n = 0) => {
+  const v = new Float32Array(384);
+  v[0] = n;
+  return v;
+};
+
+beforeEach(() => sqlite.prepare("DELETE FROM contacts").run());
+afterEach(() => vi.restoreAllMocks());
+
+describe("search index lifecycle", () => {
+  it("matches words across fields and treats punctuation as literal input", async () => {
+    insert("alice");
+    expect(lexicalSearch("alice des").map((r) => r.contactId)).toEqual([
+      "alice",
+    ]);
+    for (const q of ['"', "* () :", "   ", '" OR * -']) {
+      expect((await request(app).get("/api/search").query({ q })).status).toBe(
+        200,
+      );
+    }
+    expect((await request(app).get("/api/search?q=a&q=b")).status).toBe(400);
+  });
+
+  it("excludes inactive contacts on insert, update, and index rebuild", () => {
+    insert("active");
+    for (const [id, update] of [
+      ["archived", "isArchived = 1"],
+      ["ghost", "isGhost = 1"],
+      ["merged", "canonicalId = 'active'"],
+      ["trash", "deletedAt = datetime('now')"],
+    ]) {
+      insert(id);
+      sqlite.prepare(`UPDATE contacts SET ${update} WHERE id = ?`).run(id);
+    }
+    expect(lexicalSearch("Alice").map((r) => r.contactId)).toEqual(["active"]);
+    sqlite.pragma("user_version = 1");
+    installSearchIndex(sqlite);
+    expect(lexicalSearch("Alice").map((r) => r.contactId)).toEqual(["active"]);
+    sqlite
+      .prepare("UPDATE contacts SET isArchived = 0 WHERE id = 'archived'")
+      .run();
+    expect(lexicalSearch("Alice")).toHaveLength(2);
+  });
+
+  it("refreshes edited and reparented child values without duplicate index entries", () => {
+    insert("one");
+    insert("two", "Bob");
+    sqlite
+      .prepare(
+        "INSERT INTO contact_emails(id,contactId,email) VALUES ('email','one','first@example.com')",
+      )
+      .run();
+    expect(lexicalSearch("first")[0].contactId).toBe("one");
+    sqlite
+      .prepare(
+        "UPDATE contact_emails SET email='second@example.com', contactId='two' WHERE id='email'",
+      )
+      .run();
+    expect(lexicalSearch("first")).toEqual([]);
+    expect(lexicalSearch("second")[0].contactId).toBe("two");
+    expect(
+      sqlite.prepare("SELECT count(*) AS n FROM contacts_fts").get(),
+    ).toEqual({ n: 2 });
+  });
+
+  it("keeps keyword and vector changes inside a rolled back contact transaction", () => {
+    insert("one");
+    upsertSearchEmbedding("one", vector());
+    expect(() =>
+      sqlite.transaction(() => {
+        sqlite
+          .prepare("UPDATE contacts SET name='Changed' WHERE id='one'")
+          .run();
+        throw new Error("rollback");
+      })(),
+    ).toThrow("rollback");
+    expect(lexicalSearch("Alice")).toHaveLength(1);
+    expect(lexicalSearch("Changed")).toEqual([]);
+    expect(findSearchNeighbors(vector(), 1)).toHaveLength(1);
+  });
+
+  it("applies FTS filters before the top-k limit", () => {
+    sqlite.transaction(() => {
+      for (let i = 0; i < 130; i++) insert(`other-${i}`, "Needle");
+      insert("wanted", "Long Profile With A Needle");
+    })();
+    expect(lexicalSearch("Needle", 1, new Set(["wanted"]))).toEqual([
+      { contactId: "wanted" },
+    ]);
+  });
+
+  it("weights contact names above the same keyword in a company", () => {
+    insert("name", "Needle");
+    insert("company", "Someone");
+    sqlite
+      .prepare("UPDATE contacts SET company='Needle' WHERE id='company'")
+      .run();
+    expect(lexicalSearch("Needle")[0].contactId).toBe("name");
+  });
+
+  it("uses stable contact rowids after migration and repeated installation", () => {
+    insert("one");
+    insert("two");
+    sqlite.pragma("user_version = 1");
+    installSearchIndex(sqlite);
+    installSearchIndex(sqlite);
+    const rows = sqlite
+      .prepare(
+        "SELECT f.rowid = c.rowid AS same FROM contacts_fts f JOIN contacts c ON c.id=f.contactId",
+      )
+      .all();
+    expect(rows).toEqual([{ same: 1 }, { same: 1 }]);
+    sqlite.prepare("DELETE FROM contacts WHERE id='one'").run();
+    expect(lexicalSearch("Alice").map((r) => r.contactId)).toEqual(["two"]);
+  });
+});
+
+describe("vector retrieval and asynchronous writes", () => {
+  it("filters before KNN and honors typed-array slice boundaries", () => {
+    insert("nearest");
+    insert("wanted");
+    upsertSearchEmbedding("nearest", vector());
+    const backing = new Float32Array(386);
+    backing[1] = 10;
+    upsertSearchEmbedding("wanted", backing.subarray(1, 385));
+    expect(
+      findSearchNeighbors(vector(), 1, new Set(["wanted"]))[0].contactId,
+    ).toBe("wanted");
+    expect(findSearchNeighbors(vector(), 10, new Set())).toEqual([]);
+    sqlite.prepare("UPDATE contacts SET isArchived=1 WHERE id='nearest'").run();
+    expect(findSearchNeighbors(vector(), 1)[0].contactId).toBe("wanted");
+  });
+
+  it("deletes stale vectors when searchable fields or tags change", () => {
+    insert("one");
+    upsertSearchEmbedding("one", vector());
+    sqlite.prepare("UPDATE contacts SET role='Engineer' WHERE id='one'").run();
+    expect(findSearchNeighbors(vector(), 1)).toEqual([]);
+    upsertSearchEmbedding("one", vector());
+    sqlite
+      .prepare(
+        "INSERT INTO contact_tags(id,contactId,tag) VALUES ('tag','one','New')",
+      )
+      .run();
+    expect(findSearchNeighbors(vector(), 1)).toEqual([]);
+  });
+
+  it.each(["edit", "delete", "model"])(
+    "rejects a late embedding after a %s",
+    async (change) => {
+      insert("one");
+      const resolve = vi
+        .spyOn(embeddings, "resolveEmbeddings")
+        .mockReturnValue({
+          kind: "provider",
+          providerId: "test",
+          model: "test",
+          dimension: 384,
+          signature: "test/test",
+        });
+      let finish!: (value: number[][]) => void;
+      vi.spyOn(embeddings, "embedWithProvider").mockImplementation(
+        () =>
+          new Promise((r) => {
+            finish = r;
+          }),
+      );
+      const pending = embedContact("one");
+      if (change === "edit")
+        sqlite.prepare("UPDATE contacts SET name='New' WHERE id='one'").run();
+      if (change === "delete")
+        sqlite.prepare("DELETE FROM contacts WHERE id='one'").run();
+      if (change === "model")
+        resolve.mockReturnValue({
+          kind: "builtin",
+          dimension: 384,
+          signature: "builtin/new",
+        });
+      finish([Array.from(vector())]);
+      await pending;
+      expect(findSearchNeighbors(vector(), 1)).toEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
This PR makes search results current and reduces index update time after contact edits.

- Apply active-contact and structured filters before keyword and vector limits.
- Migrate FTS atomically to stable contact rowids and correct ranking weights.
- Refresh indexes after child edits and moves. Reject late vectors after edits, deletion, or a model change.
- Include the database revision in search cache keys. Prevent previous-query results from replacing current results.
- Replace automatic AI keyword expansion with local source-text indexing.
  - **Provider embedding pins require the existing backfill path after edits.** Local automatic refreshes skip provider calls.
- Run CI for the five hardening branches so each stacked PR receives checks.

Validation:
- `npm test`: **587 passed**.
- `npm run lint`: passed.
- `npm run format:check`: passed.
- `npm run build`: passed.
- `npx tsx scripts/benchmark-search.ts`: 10,000 synthetic contacts, 100 samples. Edit p95 decreased from **3.094 ms to 0.113 ms**.
- Browser: opened the command palette, searched synthetic contacts, then entered a query with no matches. Previous results cleared correctly.

Stack: 1 of 5. Base: `main`. The API, UI, Ask Contrack, and AI enrichment PRs follow this branch.
