### PR TITLE
fix(ui): stabilize scrolling dialogs and edit feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@google/genai": "^2.2.0",
         "@huggingface/transformers": "^4.0.1",
+        "@radix-ui/react-dialog": "^1.1.23",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.14",
         "@tanstack/react-query": "^5.96.1",
@@ -4158,49 +4159,49 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.29.2.tgz",
-      "integrity": "sha512-oKUkiPUB7noilVYxI9lNzUD4rX17sHub+PYjMfHMWHG9A3nvIy+FdePIVIIhThKWF7ijhr3eIqHY51Bn+GAFtw==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.31.3.tgz",
+      "integrity": "sha512-Cz50pvciQrxdSxgTkHOVz0uD0Yl/8Xt0QatGD6ILm47jW8EzyHR9RkUGs/D5IqzXKuVPntfw1ttaT926vXfiRg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "3.29.2"
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.29.2.tgz",
-      "integrity": "sha512-ca4OzKDh0yaxg2+Z56bC2QnWsNsFp2YMRfVig1PDXyMVFMNJpLcnhxgq/9btn+xYAlYrj8RymOeCTYREOR6Zjg==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.31.3.tgz",
+      "integrity": "sha512-fyY2XMbyDDDfOTQ1Qdrnqa1qwC9DWE4n7AfE0EKQI0G8MfLV8RaDlLDcOZDJ9JbMPY7/Gx7EjyK4NKxSW9n2hQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-bold": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.29.2.tgz",
-      "integrity": "sha512-elYbGxJsYnBb4leqrcjdIJuiG380BcOgN+UUzvOv+qEjfGVzHodFOMBl3qnmD6urYHNu5/qQK2S0qSSRXKCLNQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.31.3.tgz",
+      "integrity": "sha512-dIuYhKk8TitKU/FeDpoTeWZhU42YgDN5npgWNjAmMmRktPdoxnH3/wGSiwXlqZgJWjehN7kPWDePWpJeAImGpQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.29.2.tgz",
-      "integrity": "sha512-kzcWarcpr031rZu+R3Hzut5uxb3Qj/xxMDEYZIQ3uiq1yb5vEMXj8/SIyWautk6Nu8Rr1leV3rGdR4NzhzyFAA==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.31.3.tgz",
+      "integrity": "sha512-EV6ZnwKc++2OM/OcD54n8s1B7C9LP7GKAtdEPwu0t3BYJf3sG8Ueoinf7SgGPO9oMPg96GneOkDNm1urMV167g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4211,80 +4212,80 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-bullet-list": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.29.2.tgz",
-      "integrity": "sha512-3bWcCUPbCHv0XttlMdnAtXLNYWx2pblByMgxmGsaP9FU0QnslGXty6A6gHCqI33ygRg1vrA6U5Wtpwbi5aKu5g==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.31.3.tgz",
+      "integrity": "sha512-qEyyoPapPef4LO8XKaN83bxtaNzkJ4kFn/IxLnEKd4BJ3Mvi4MH2yJYlyDqwFnMoev4pMA1zBHRAt/C0THRmZw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.29.2"
+        "@tiptap/extension-list": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-code": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.29.2.tgz",
-      "integrity": "sha512-c6W5UGuB7WNLpYocsgRzpO2OOTI4QjaI9jjHRMuty9z+s9DtaYM/HrRLNwVh6MopkHb+i/89Wkv8gCS34fftig==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.31.3.tgz",
+      "integrity": "sha512-SzxOqchrD2AcN3uT67PjKmRFEMOU3vNNiwNaamZJUbZrI6Hmy+bvdHJrc3jrIddyyCrAtsnAfRI0cmorW1jGfg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-code-block": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.29.2.tgz",
-      "integrity": "sha512-w153ct8g6dLiPTdXQ6SOIMxX4SEo5Q50AmjdEEEcJ7ZcYUcde/ScSskLHfOYmyt5ZFAiyEwr121+pux+p3/oAQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.31.3.tgz",
+      "integrity": "sha512-nvknt4FhyJQjYcvxptmeUlFsIAc8ibua3E5BN4Pim374/9RWepH4cdE9X0/qUTtguHElLx0iKtSIY3rW2qGTFA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-document": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.29.2.tgz",
-      "integrity": "sha512-YUamvefLnsqu6124GavVTI7nqcFlQJ12ROB0oSwG69eSBZYNjg1tIs05LFrBxkwf4Xgqd6YzfJ9+FeG428RvzQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.31.3.tgz",
+      "integrity": "sha512-EexgmqnyDNyGlISxo7SMrp5MygpJYmqD+0cY5jB6L1U6L4CpKKRWUt8OO1sWzEHDE1+TTvwt+WIFoIWAziOtEA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-dropcursor": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.29.2.tgz",
-      "integrity": "sha512-KKno7cU9r1HdR48CRrsDu69/1UjZdoslq/UcE+Kx+tdhAv/aljXMkRSNzGMrBNOBDmHRgS1+58zm21WQWdQzwA==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.31.3.tgz",
+      "integrity": "sha512-NWomSfu5CSC7VacnMSDzKT8qm66SzMfZwVPEtwY5bPpRTJgTiT1rNK0neDrrzfMN27MfylGyKWWf7Q5Qf8w/fg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "3.29.2"
+        "@tiptap/extensions": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.29.2.tgz",
-      "integrity": "sha512-CBTq4Xs5aGWr65uFCIkKBms796OhmirWf/ax//iJ4fl9IfwqjwFuc2vQs9PmuwpKn9ctDHo2sMTtvyeCvIt5LQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.31.3.tgz",
+      "integrity": "sha512-rd4VJ9PGSP9Eop8ZTEwaLZcMzMXLuJKe3hUNf58rq+zANpwM+9fI+vB7g9MAc3eXwUNDxNDVACFIL2oeBqpQ3A==",
       "license": "MIT",
       "optional": true,
       "funding": {
@@ -4293,80 +4294,80 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.29.2.tgz",
-      "integrity": "sha512-8Q39UR4/Tit759IeW9xZIe3NMwN11GsuA3FLheDyyGn7RrW02HD3HhUDlazE54Ki4HoosjFmChPlN4Ik2ubdRQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.31.3.tgz",
+      "integrity": "sha512-EBXKb1FrVStsNYCcRGtd9jmzveCvR+eqgg1rVqoONrqFK6U7bga6LN+1dMKroP1kliDVgveYkP3vRYxqw+rFqg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "3.29.2"
+        "@tiptap/extensions": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-hard-break": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.29.2.tgz",
-      "integrity": "sha512-eUW3LN3fq8rXnjEUeI3D2QONYdLsU3yYQm4jxlErs2h4cfwrFjgf19VSUFVmm6LrFbbQ0OnDVPeVLL6iOwDw2w==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.31.3.tgz",
+      "integrity": "sha512-QAdCvNO4+yW9ATwsrej11NTkDYFqPLIEQr3ARNrKOK1qaiS7A0fia2SEukb/hrkP3A6mbozhoQt2r2RGUf/DpQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-heading": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.29.2.tgz",
-      "integrity": "sha512-6W4aIy70Mh7BNlbG9zZ5FBLhJhU2UUEzgZJ/jwYSCcB30o8McLxJSEjhtoHiX8R78Ah2/JzBGvIe5olZlbeE4A==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.31.3.tgz",
+      "integrity": "sha512-rk5VHMAeQcg06SLauN6EGdD2jc0O2qY8QkZYPd0LxNvLblw2BxBx+lxUQSYwLAT9Ie5914gKIK2YbRyO2Ts3ig==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.29.2.tgz",
-      "integrity": "sha512-8/ZPzbB9X85Mc9/7xVLZupQKBr2UVcQTGr512xtqMW+XkCQRHCph46tRo828YE13IMWI5fWn/FaNCqXG9cULSw==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.31.3.tgz",
+      "integrity": "sha512-YnHGy2KShRwvCseAmmxl9VP7R0qaj8QMp3DA6DJWZqp7r5gLGvDkAqhedxqqefqsE4Y43hjkBdjtB9Ce78LkIw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-italic": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.29.2.tgz",
-      "integrity": "sha512-iH63V/5wsaMnY4Jz0+meaAGhaec4AiOzOduzl6ZZr5IyGhZ1kthyW84ELt0dyLI3hNceAUhaNWc+I7+vX0aoXA==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.31.3.tgz",
+      "integrity": "sha512-ibGvdvAPyfxBMUVNRI43eb9h2/Jka1MRG5GtnGqbcCX/2+Y/y0EOfFrPQPkuYphiWQYyu9+FzPKMB/pjuaLuKQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-link": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.29.2.tgz",
-      "integrity": "sha512-DcVer5SqrexKCEP6Ip1UPxJUMvcRCCItSv0wxoGytanrimBh2smvcg6X0DWnjlsi5H0updhyl+atYCmmQXUIXA==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.31.3.tgz",
+      "integrity": "sha512-986wOQzTL9Zr5lf84LCLpm+YOms8A0K39/8DVoqRfebqcOe0/eq4bnztmAlfabOd+kJY92g3AgZERFUx/w+dcw==",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^4.3.3"
@@ -4376,161 +4377,161 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-list": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.29.2.tgz",
-      "integrity": "sha512-WPZ9BHAPT6QeIm1vdVkuoOWvy9a8/EZeJwV2VhU8LXyTAttvzyj4rsbbHyJWvYWlUSTt/QF2AZ2zhKo7u1w3/A==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.31.3.tgz",
+      "integrity": "sha512-LoveGnC0FVdCV4jUNBaG1ZA+KWE07+adzV3kGy6uUYFcJEjbVUHTnPDrBOob3IwOSO3sCwIkvQb6EVYeXn/4yg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.29.2.tgz",
-      "integrity": "sha512-s8vBVHHFT0Qpu7CzAZ7S1kYmSiVaDvUNvMNcZUWnxj6VPfiwmx0eXd9FsjePrRCMoM5tFmPnhFTHDxY3D/eZeQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.31.3.tgz",
+      "integrity": "sha512-4QlKOriJJMvg95QJTEsy9BUYPBQ6UvJyb8WURRwdUtQUkkqb8h32lg/eyQUv2FzW9IT1AdUyNZfVaxH64kRfQA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.29.2"
+        "@tiptap/extension-list": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-list-keymap": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.29.2.tgz",
-      "integrity": "sha512-R+3k8OLnxdCH7Xy9ieOwUt5m2Je74u8mikothGmsYVO2Zyq48fIbmZ+X6RBPCu7DBOI2FIUhHEFbKQeDWvDNmA==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.31.3.tgz",
+      "integrity": "sha512-If8UOEdDZbPJU6iYTvLtH6DOp2KBy6BKxg9UELL1AevVetGHEF/7lW8hP50Gn1tHMVpPRqmhSzVrJRpEJJgb/Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.29.2"
+        "@tiptap/extension-list": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-mention": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.29.2.tgz",
-      "integrity": "sha512-WF8ugDa2IRbgyRW+PffPYg8ZI+Qp9azvIsNoyuf+VSg5Vp7ze2TuJXUTObSckyiN5Ann8bDNM9Hbu3TdoI0DFQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.31.3.tgz",
+      "integrity": "sha512-ygOPc3nQijSMUTbEdMeng12P1szk3znubA9xNi84f31VnR18VjmU0we8SIOSSVwDfm1GppSjRER2qHmX/wGIIw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2",
-        "@tiptap/suggestion": "3.29.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3",
+        "@tiptap/suggestion": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-ordered-list": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.29.2.tgz",
-      "integrity": "sha512-ndCunC+UsYOpkOtL7vGnDz21UNa45WUlcO9wMT1fbuYow2QnRhsuMlCWENXI52YPPARWuQ0RDgN7q6TaxPERBg==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.31.3.tgz",
+      "integrity": "sha512-mp3g11NgA/PYu8rj7J7Ez3l4qBy6WfTSmHIG4PZvEGG5w2oUAIkgb9DU7nPPzjmeme27oazFYZw+AtZA0+u4tw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.29.2"
+        "@tiptap/extension-list": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.29.2.tgz",
-      "integrity": "sha512-7qJj5YTr11vvjNgjDN1ypOfwTovc0QOCYcit/rskeuVgnmQZOZQzC/BbyKLLG7UGnpRLemU/mEGbW9pAqjAXkQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.31.3.tgz",
+      "integrity": "sha512-+iPku7wJfy5hbNDNLX8dveFtYVsZMmh7vztjuq8hT3mipSC4IByDehDbU8fzUCjfXiEzmI7mQn7c8LGmHULuzA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-placeholder": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.29.2.tgz",
-      "integrity": "sha512-/BlpPIq2JZk6zLaeYVOXazi6dmd0iRriTymNEnFn1doManN1y5HED9LsMeb/AhNhauL5AgmcHgpvAjbsN9k4SA==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.31.3.tgz",
+      "integrity": "sha512-9jYtR8ELEw7GVaruyrm4oFkPcjig9Q+crc+dpmarhBNXUmxagCdlhVzNwCJ2WJRzvBAtx59sEYqNTU38Wx8S3A==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "3.29.2"
+        "@tiptap/extensions": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-strike": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.29.2.tgz",
-      "integrity": "sha512-aEvLAbddUQZ+FukCreV3q4G2HfNI+odE7E9U+wbq6XsSWKyo8/pDu1muz+TFKNre4blSMOQ3JQmw5UeHDKy+fg==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.31.3.tgz",
+      "integrity": "sha512-G29bhKttYwcKHT+BI6emWVFol3RO/gUXxQVcmr/iT8LXXy7j8J6HFUnsKM+Kg5YlP1rxMRgsa65dbrQVahZi0A==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-text": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.29.2.tgz",
-      "integrity": "sha512-Ubko45JWWHe8glBt2PiGNF8hcbys/JNalFhiR7Y1X4iOOtAxAKJJxh3+eq+//NTlGuBPdWGp7zw8EEUp7anjKA==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.31.3.tgz",
+      "integrity": "sha512-gdsWtF+taeaCu6V+5Ct10fGo0ACUy1GnYtbb+mcathBt8OqbT+Ws60p/yEmKesBDz2Hn+B5IcWy6+2BBZl5ZTg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-underline": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.29.2.tgz",
-      "integrity": "sha512-K7XwH/xS/5AIREWQ00VTEf/W5U0olp7j6wwit7cdd/8nHv6h6AGr1+iEApHKoLXWQZLfGQKzJlT9W61LAl+fHA==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.31.3.tgz",
+      "integrity": "sha512-HghdJaOwRqYzsAxqSyNyb+IWyOMcdCl8IoiBETA9BZCJAqdXzFLcuWp7CqCqJPam9dgkWosSoHqTCAO4nTBfpw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extensions": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.29.2.tgz",
-      "integrity": "sha512-BCz+FCAChSYtUe4BFj97HEO+nSK+J7GxbJgZG4Hg7DT/gI+hRyeNndU8efiQAx3WGdzsFi3UxRpcF1tTQM7iMQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.31.3.tgz",
+      "integrity": "sha512-8sJNPGGUe8f3aDojcOW5cfVL7I5NrBbE0UWxG08qoi9Tea6qWbvQJsCR9tsrOapr/DaLr3kpbGZ9s1gEEfcNcA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.29.2.tgz",
-      "integrity": "sha512-GCOme7xHaS+DSoaA4CDcAD3l6JyBlvZhvCyfsy2Vp6j8tEoBkZWio7soYVosmlyn7zq8/64VeFZP5s47yfG7fQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.31.3.tgz",
+      "integrity": "sha512-sZime0SWsz/k62W2WvHx5Ig7G2h7kVhrrmnqy+wEgIHfDwEfOlelRjaWCiBCFlF7dxGUntJusCh9FxlLhni0Ag==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.4.1",
@@ -4545,7 +4546,7 @@
         "prosemirror-state": "^1.4.4",
         "prosemirror-tables": "^1.8.5",
         "prosemirror-transform": "^1.12.0",
-        "prosemirror-view": "^1.41.9"
+        "prosemirror-view": "^1.42.3"
       },
       "funding": {
         "type": "github",
@@ -4553,9 +4554,9 @@
       }
     },
     "node_modules/@tiptap/react": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.29.2.tgz",
-      "integrity": "sha512-ZMKgteYmZXnq7C22U9fbCTC6jAF8XlQM5n2K2FLWCdYAlP4FNV3XeQ9hY2a13KSQ0Q3yltWXZlcWBpt5ClxScg==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.31.3.tgz",
+      "integrity": "sha512-QiwQqvaLFLm5EMFu5tg7nAgXJxCUiUTLD8EsK+TqVV5P4bqOoMOCM39khbhXTJyahCuYpiFWx5YOSDtC/JiPtg==",
       "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
@@ -4567,12 +4568,12 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.29.2",
-        "@tiptap/extension-floating-menu": "^3.29.2"
+        "@tiptap/extension-bubble-menu": "^3.31.3",
+        "@tiptap/extension-floating-menu": "^3.31.3"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2",
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -4580,35 +4581,35 @@
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.29.2.tgz",
-      "integrity": "sha512-oTu0tysiqk4zgjEtxRHjAQgxUKaAevZwueOWwSWubHdokqp7SpcbE5n9USJv89HKuTUDm3GjnQH6q8HNn/2DsA==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.31.3.tgz",
+      "integrity": "sha512-WKof9RewdmGHvWJ1wn0/HVNG2mV+HOgVRyJkKekuM9fgr6BZAAH/xZsWE1eon+94JnQ+KtK2ThydXQM/qc6b2A==",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^3.29.2",
-        "@tiptap/extension-blockquote": "^3.29.2",
-        "@tiptap/extension-bold": "^3.29.2",
-        "@tiptap/extension-bullet-list": "^3.29.2",
-        "@tiptap/extension-code": "^3.29.2",
-        "@tiptap/extension-code-block": "^3.29.2",
-        "@tiptap/extension-document": "^3.29.2",
-        "@tiptap/extension-dropcursor": "^3.29.2",
-        "@tiptap/extension-gapcursor": "^3.29.2",
-        "@tiptap/extension-hard-break": "^3.29.2",
-        "@tiptap/extension-heading": "^3.29.2",
-        "@tiptap/extension-horizontal-rule": "^3.29.2",
-        "@tiptap/extension-italic": "^3.29.2",
-        "@tiptap/extension-link": "^3.29.2",
-        "@tiptap/extension-list": "^3.29.2",
-        "@tiptap/extension-list-item": "^3.29.2",
-        "@tiptap/extension-list-keymap": "^3.29.2",
-        "@tiptap/extension-ordered-list": "^3.29.2",
-        "@tiptap/extension-paragraph": "^3.29.2",
-        "@tiptap/extension-strike": "^3.29.2",
-        "@tiptap/extension-text": "^3.29.2",
-        "@tiptap/extension-underline": "^3.29.2",
-        "@tiptap/extensions": "^3.29.2",
-        "@tiptap/pm": "^3.29.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/extension-blockquote": "3.31.3",
+        "@tiptap/extension-bold": "3.31.3",
+        "@tiptap/extension-bullet-list": "3.31.3",
+        "@tiptap/extension-code": "3.31.3",
+        "@tiptap/extension-code-block": "3.31.3",
+        "@tiptap/extension-document": "3.31.3",
+        "@tiptap/extension-dropcursor": "3.31.3",
+        "@tiptap/extension-gapcursor": "3.31.3",
+        "@tiptap/extension-hard-break": "3.31.3",
+        "@tiptap/extension-heading": "3.31.3",
+        "@tiptap/extension-horizontal-rule": "3.31.3",
+        "@tiptap/extension-italic": "3.31.3",
+        "@tiptap/extension-link": "3.31.3",
+        "@tiptap/extension-list": "3.31.3",
+        "@tiptap/extension-list-item": "3.31.3",
+        "@tiptap/extension-list-keymap": "3.31.3",
+        "@tiptap/extension-ordered-list": "3.31.3",
+        "@tiptap/extension-paragraph": "3.31.3",
+        "@tiptap/extension-strike": "3.31.3",
+        "@tiptap/extension-text": "3.31.3",
+        "@tiptap/extension-underline": "3.31.3",
+        "@tiptap/extensions": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       },
       "funding": {
         "type": "github",
@@ -4616,9 +4617,9 @@
       }
     },
     "node_modules/@tiptap/suggestion": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.29.2.tgz",
-      "integrity": "sha512-ZEhRm0gnRCwCScR9IrnIBhm9sr6U8vpR9oeznYk3hiedZ48zsgohqvgoIYpWcwYWrT2Pb0NrfhCT8IuSzdJHzQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.31.3.tgz",
+      "integrity": "sha512-z1OQ/Yx6seMZehi1AcmNkyJ8qkHQzybArmCyRdmreS4YL9C4bPMBe5lbMfFsArYs+KD5JyHwps5j7J/YE5BIuw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4626,8 +4627,8 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@types/aria-query": {
@@ -12064,9 +12065,9 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.42.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
-      "integrity": "sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==",
+      "version": "1.42.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.3.tgz",
+      "integrity": "sha512-oTN7EtH+CpwxU9NrwEYWd0UZ4JUx7l048l5A2Xppm4p/60isZYLnth9QVQmC3VRIvdrIWCxwZSd+Uz791G31/w==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "^1.25.8",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@google/genai": "^2.2.0",
     "@huggingface/transformers": "^4.0.1",
+    "@radix-ui/react-dialog": "^1.1.23",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.14",
     "@tanstack/react-query": "^5.96.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -176,12 +176,12 @@ const ResponsiveLayout = () => {
   // Full-page views (cleanup, search, pulse, dev) take the full main area
   if (isCleanup || isSearch || isPulse || isDev) {
     return (
-      <div className="h-screen w-full flex overflow-hidden bg-surface text-on-surface font-body font-medium">
+      <div className="h-dvh w-full flex overflow-hidden bg-surface text-on-surface font-body font-medium">
         <div className="hidden md:flex shrink-0">
           <Sidebar />
         </div>
-        <main className="flex-1 h-full overflow-hidden relative flex">
-          <div className="flex-1 h-full overflow-hidden">
+        <main className="flex-1 min-w-0 h-full overflow-hidden relative flex">
+          <div className="flex-1 min-w-0 h-full overflow-hidden">
             <Routes>
               <Route
                 path="/settings/*"
@@ -238,7 +238,7 @@ const ResponsiveLayout = () => {
   }
 
   return (
-    <div className="h-screen w-full flex overflow-hidden bg-surface text-on-surface font-body font-medium">
+    <div className="h-dvh w-full flex overflow-hidden bg-surface text-on-surface font-body font-medium">
       {/*
         The sidebar used to be suppressed (`hidden lg:flex`) whenever a contact
         was open, which meant that between 768 and 1023 px — an iPad in
@@ -296,7 +296,7 @@ const ResponsiveLayout = () => {
         <main
           className={`
           ${isContactSelected ? "flex" : "hidden lg:flex"}
-          flex-1 bg-surface z-10 h-full overflow-hidden relative flex-col
+          flex-1 min-w-0 bg-surface z-10 h-full overflow-hidden relative flex-col
         `}
         >
           <Routes location={location}>

--- a/src/components/ui/CustomSelect.tsx
+++ b/src/components/ui/CustomSelect.tsx
@@ -1,75 +1,38 @@
-import React, { useState, useRef, useEffect } from "react";
-import { cn } from "../../lib/utils";
-import { DROPDOWN_MENU, DROPDOWN_ITEM } from "../../lib/styles";
 import { ChevronDown } from "lucide-react";
-import { activateOnKey } from "../../lib/a11y";
+import { cn } from "../../lib/utils";
 
-export const CustomSelect = ({
+/** Native selection supports touch, keyboard arrows, and Escape inside dialogs. */
+export function CustomSelect({
   value,
   onChange,
   options,
   className,
+  ariaLabel = "Label",
 }: {
   value: string;
-  onChange: (val: string) => void;
+  onChange: (value: string) => void;
   options: readonly string[];
   className?: string;
-}) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handleOutsideClick = (event: MouseEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleOutsideClick);
-    return () => document.removeEventListener("mousedown", handleOutsideClick);
-  }, []);
-
+  ariaLabel?: string;
+}) {
   return (
-    <div className="relative inline-block" ref={containerRef}>
-      <button
-        type="button"
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => setIsOpen(!isOpen)}
-        className={cn(className, "flex items-center justify-between gap-1")}
+    <span className="relative inline-flex items-center">
+      <select
+        aria-label={ariaLabel}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className={cn(className, "appearance-none cursor-pointer pr-5")}
       >
-        {value}
-        <ChevronDown className="w-2.5 h-2.5 opacity-60" />
-      </button>
-
-      {isOpen && (
-        <ul
-          role="listbox"
-          className={cn(DROPDOWN_MENU, "min-w-[100px]")}
-          onMouseDown={(e) => e.preventDefault()}
-        >
-          {options.map((opt) => (
-            <li
-              aria-selected={opt === value}
-              onKeyDown={activateOnKey(() => {
-                onChange(opt);
-                setIsOpen(false);
-              })}
-              tabIndex={0}
-              role="option"
-              key={opt}
-              className={DROPDOWN_ITEM}
-              onClick={() => {
-                onChange(opt);
-                setIsOpen(false);
-              }}
-            >
-              {opt}
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+      <ChevronDown
+        aria-hidden
+        className="absolute right-1 w-2.5 h-2.5 opacity-60 pointer-events-none"
+      />
+    </span>
   );
-};
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,37 +1,8 @@
-/**
- * Modal — Accessible, animated overlay dialog with responsive presentation.
- *
- * Accessibility:
- *  - Saves `document.activeElement` before opening; restores it on close
- *  - Auto-focuses the close button on open (acts as initial focus anchor)
- *  - Traps full Tab/Shift+Tab focus cycling within the dialog
- *  - Respects `prefers-reduced-motion` by falling back to opacity-only transitions
- *
- * Rendering:
- *  - Uses a React portal to escape parent stacking contexts
- *  - Two presentations driven by viewport width:
- *      • Desktop (≥ sm, 640px+): centered card with backdrop blur + scale entrance
- *      • Mobile  (< sm):         bottom sheet that slides up from the bottom edge
- *    The switch happens via Tailwind responsive classes alone — there is no
- *    JS media query, so the choice updates correctly on rotation/resize.
- *
- * Two content modes:
- *  1. **Standard** (`title` provided): renders a header bar with title + close
- *     button; body area scrolls within the dialog.
- *  2. **Headless** (`title` omitted): children fill the entire modal — useful
- *     for modals with custom headers (dashboard drilldowns, detail views).
- *
- * Sizes (desktop only — mobile bottom sheet always uses full width):
- *  sm (max-w-sm), md (max-w-lg, default), lg (max-w-2xl), xl (max-w-4xl),
- *  2xl (max-w-5xl), full (max-w-[min(95vw,1280px)])
- */
-import { motion, AnimatePresence } from "motion/react";
+import * as Dialog from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
-import { ReactNode, useEffect, useId, useRef } from "react";
-import { createPortal } from "react-dom";
-import { useFocusTrap } from "../../hooks/useFocusTrap";
+import { type ReactNode, useRef } from "react";
 
-const SIZE_MAP: Record<string, string> = {
+const SIZE_MAP = {
   sm: "sm:max-w-sm",
   md: "sm:max-w-lg",
   lg: "sm:max-w-2xl",
@@ -43,178 +14,84 @@ const SIZE_MAP: Record<string, string> = {
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
-  /** When provided, renders a standard header bar. Omit for headless mode. */
   title?: string;
+  /** Accessible name for dialogs that render their own header. */
+  ariaLabel?: string;
   children: ReactNode;
-  /** Controls desktop max-width. Default: `md` (max-w-lg). Mobile is always full width. */
   size?: keyof typeof SIZE_MAP;
-  /**
-   * Disable the responsive bottom-sheet on mobile. Use this only for very small
-   * modals (e.g. confirmations) where a centered dialog still works on phones.
-   */
   disableMobileSheet?: boolean;
 }
 
+/** Responsive dialog with nested focus, scroll locking, and keyboard dismissal. */
 export function Modal({
   isOpen,
   onClose,
   title,
+  ariaLabel = "Dialog",
   children,
   size = "md",
   disableMobileSheet = false,
 }: ModalProps) {
-  const previousFocusRef = useRef<HTMLElement | null>(null);
-  const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const modalContainerRef = useRef<HTMLDivElement>(null);
-  const titleId = useId();
-
-  // Trap Tab/Shift+Tab within the modal
-  useFocusTrap(modalContainerRef, isOpen);
-
-  // Capture previous focus on open; restore it on close
-  useEffect(() => {
-    if (isOpen) {
-      previousFocusRef.current = document.activeElement as HTMLElement;
-      // Move initial focus to the close button after animation frame
-      requestAnimationFrame(() => closeButtonRef.current?.focus());
-    } else {
-      // Restore focus to the element that triggered the modal
-      requestAnimationFrame(() => previousFocusRef.current?.focus());
-    }
-  }, [isOpen]);
-
-  // Lock body scroll while modal is open
-  useEffect(() => {
-    if (!isOpen) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, [isOpen]);
-
-  // Escape key closes
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (isOpen && e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose]);
-
-  const widthClass = SIZE_MAP[size] || SIZE_MAP.md;
-
-  // Layout classes for the dialog container.
-  //
-  // Desktop (sm:): centered card, capped width, rounded on all sides, modest
-  // top offset (sm:top-1/2 + transform centers it vertically).
-  //
-  // Mobile (default, < sm): full-width sheet anchored to the bottom edge,
-  // rounded only on top. We use `inset-x-0 bottom-0` to pin the sheet, then
-  // `sm:inset-auto sm:left-1/2 sm:top-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2`
-  // to re-center on desktop. Without `disableMobileSheet`, this is the
-  // recommended pattern for every modal that contains substantial content.
-  const positionClasses = disableMobileSheet
-    ? "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full mx-4"
-    : "fixed inset-x-0 bottom-0 sm:inset-auto sm:left-1/2 sm:top-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2 sm:w-full";
-
-  const radiusClasses = disableMobileSheet
-    ? "rounded-2xl"
-    : "rounded-t-2xl sm:rounded-2xl";
-
-  // Mobile sheet slides up; desktop scales in. Both share an opacity fade.
-  // Reduced-motion users get an instant opacity-only transition.
-  const reducedMotion =
-    typeof window !== "undefined" &&
-    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-  const enterAnim = reducedMotion
-    ? { initial: { opacity: 0 }, animate: { opacity: 1 }, exit: { opacity: 0 } }
-    : disableMobileSheet
-      ? {
-          initial: { opacity: 0, scale: 0.95, y: 20 },
-          animate: { opacity: 1, scale: 1, y: 0 },
-          exit: { opacity: 0, scale: 0.95, y: 20 },
-        }
-      : {
-          // On mobile this reads as "slide up from bottom"; on desktop the
-          // y: 20 + scale: 0.95 still produces a tasteful settle-in. The
-          // CSS transforms in `positionClasses` keep the dialog centered on
-          // desktop regardless of the animation's residual `y`.
-          initial: { opacity: 0, y: 60 },
-          animate: { opacity: 1, y: 0 },
-          exit: { opacity: 0, y: 60 },
-        };
-
-  const content = (
-    <AnimatePresence>
-      {isOpen && (
-        <>
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={onClose}
-            className="fixed inset-0 bg-on-surface/20 backdrop-blur-sm z-[200]"
-          />
-          <motion.div
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby={title ? titleId : undefined}
-            {...enterAnim}
-            transition={{ type: "spring", bounce: 0, duration: 0.28 }}
-            className={`${positionClasses} ${widthClass} glass-panel ${radiusClasses} shadow-2xl z-[201] overflow-hidden`}
-            ref={modalContainerRef}
+  const previousFocus = useRef<HTMLElement | null>(null);
+  const closeButton = useRef<HTMLButtonElement>(null);
+  const position = disableMobileSheet
+    ? "left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[calc(100%-2rem)] rounded-2xl"
+    : "inset-x-0 bottom-0 rounded-t-2xl sm:rounded-2xl sm:inset-auto sm:left-1/2 sm:top-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2 sm:w-[calc(100%-2rem)]";
+  return (
+    <Dialog.Root
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-on-surface/20 backdrop-blur-sm z-[200] modal-fade" />
+        <Dialog.Content
+          aria-describedby={undefined}
+          className={`fixed ${position} ${SIZE_MAP[size]} glass-panel shadow-2xl z-[201] flex flex-col max-h-[calc(100dvh-2rem)] overflow-hidden modal-fade`}
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            previousFocus.current = document.activeElement as HTMLElement;
+            closeButton.current?.focus({ preventScroll: true });
+          }}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            if (previousFocus.current?.isConnected)
+              previousFocus.current.focus({ preventScroll: true });
+          }}
+        >
+          {title ? (
+            <div className="shrink-0 flex justify-between items-center px-5 py-4 sm:p-6 bg-surface-container-low">
+              <Dialog.Title className="text-lg sm:text-xl font-bold font-headline">
+                {title}
+              </Dialog.Title>
+              <Dialog.Close
+                ref={closeButton}
+                className="-mr-2 inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-full hover:bg-surface-container-high transition-colors"
+                aria-label="Close dialog"
+              >
+                <X className="w-5 h-5" />
+              </Dialog.Close>
+            </div>
+          ) : (
+            <>
+              <Dialog.Title className="sr-only">{ariaLabel}</Dialog.Title>
+              <Dialog.Close
+                ref={closeButton}
+                aria-label="Close dialog"
+                className="sr-only focus:not-sr-only focus:absolute focus:right-3 focus:top-3 focus:z-10 focus:p-3 focus:bg-surface"
+              >
+                Close
+              </Dialog.Close>
+            </>
+          )}
+          <div
+            className={`min-h-0 overflow-y-auto overscroll-contain pb-[max(1.25rem,env(safe-area-inset-bottom))] ${title ? "p-5 sm:p-6" : "flex flex-col"}`}
           >
-            {/* Drag indicator — visual cue that the sheet is dismissible by
-                swipe-down (purely visual; swipe gesture isn't wired up yet). */}
-            {!disableMobileSheet && (
-              <div className="sm:hidden flex justify-center pt-2 pb-1">
-                <div className="w-9 h-1 rounded-full bg-on-surface/15" />
-              </div>
-            )}
-
-            {/* Standard header — only rendered when `title` is provided */}
-            {title ? (
-              <>
-                <div className="flex justify-between items-center px-5 py-4 sm:p-6 bg-surface-container-low">
-                  <h2
-                    id={titleId}
-                    className="text-lg sm:text-xl font-bold font-headline"
-                  >
-                    {title}
-                  </h2>
-                  <button
-                    ref={closeButtonRef}
-                    onClick={onClose}
-                    className="-mr-2 inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-full hover:bg-surface-container-high active:bg-surface-container-highest transition-colors"
-                    aria-label="Close dialog"
-                  >
-                    <X className="w-5 h-5" />
-                  </button>
-                </div>
-                <div className="p-5 sm:p-6 max-h-[70vh] sm:max-h-[75vh] overflow-y-auto pb-[env(safe-area-inset-bottom)]">
-                  {children}
-                </div>
-              </>
-            ) : (
-              /* Headless mode — children fill entire modal */
-              <>
-                <button
-                  ref={closeButtonRef}
-                  onClick={onClose}
-                  className="sr-only"
-                  aria-label="Close dialog"
-                />
-                <div className="max-h-[85vh] overflow-y-auto flex flex-col pb-[env(safe-area-inset-bottom)]">
-                  {children}
-                </div>
-              </>
-            )}
-          </motion.div>
-        </>
-      )}
-    </AnimatePresence>
+            {children}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
-
-  return createPortal(content, document.body);
 }

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -18,13 +18,13 @@ export function useClickOutside(
   useEffect(() => {
     if (!enabled) return;
 
-    const handler = (e: MouseEvent) => {
+    const handler = (e: PointerEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         onOutsideClick();
       }
     };
 
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
+    document.addEventListener("pointerdown", handler);
+    return () => document.removeEventListener("pointerdown", handler);
   }, [ref, onOutsideClick, enabled]);
 }

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -30,6 +30,7 @@ export const useLongPress = (
   delay: number = DEFAULT_DELAY_MS,
 ) => {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const consumed = useRef(false);
   const startCoordsRef = useRef<LongPressCoords | null>(null);
 
   // Clean up on unmount
@@ -49,6 +50,9 @@ export const useLongPress = (
 
   const onTouchStart = useCallback(
     (e: React.TouchEvent) => {
+      cancel();
+      consumed.current = false;
+      if (e.touches.length !== 1) return;
       const touch = e.touches[0];
       startCoordsRef.current = {
         clientX: touch.clientX,
@@ -60,18 +64,25 @@ export const useLongPress = (
         if (navigator.vibrate) navigator.vibrate(50);
 
         const coords = startCoordsRef.current;
-        if (coords) callback(coords);
+        if (coords) {
+          consumed.current = true;
+          callback(coords);
+        }
 
         timerRef.current = null;
         startCoordsRef.current = null;
       }, delay);
     },
-    [callback, delay],
+    [callback, delay, cancel],
   );
 
   const onTouchMove = useCallback(
     (e: React.TouchEvent) => {
       if (!startCoordsRef.current || !timerRef.current) return;
+      if (e.touches.length !== 1) {
+        cancel();
+        return;
+      }
       const touch = e.touches[0];
       const dx = Math.abs(touch.clientX - startCoordsRef.current.clientX);
       const dy = Math.abs(touch.clientY - startCoordsRef.current.clientY);
@@ -84,6 +95,13 @@ export const useLongPress = (
   );
 
   return {
+    onClickCapture: (event: React.MouseEvent) => {
+      if (consumed.current) {
+        consumed.current = false;
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    },
     onTouchStart,
     onTouchMove,
     onTouchEnd: cancel,

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,94 +1,93 @@
-/**
- * usePullToRefresh — Mobile pull-to-refresh gesture handler.
- *
- * Attaches touch listeners to a scroll container. When the user pulls down
- * beyond a threshold while at the top of the scroll, calls `onRefresh`.
- *
- * Design:
- * - Only activates when scrollTop === 0
- * - Uses resistance factor so the pull gets harder near the threshold
- * - Does NOT interfere with normal vertical scrolling
- * - `disabled` flag lets callers opt out on desktop (where pull-to-refresh is irrelevant)
- *
- * @example
- *   const { containerRef, isPulling, pullProgress, isRefreshing, pullDistance } = usePullToRefresh(refetch);
- *   <div ref={containerRef}>
- *     <PullIndicator isPulling={isPulling} isRefreshing={isRefreshing} progress={pullProgress} pullDistance={pullDistance} />
- *     ...content...
- *   </div>
- */
-import { useRef, useState, useCallback, useEffect } from "react";
+import { useRef, useState, useEffect } from "react";
 
-const PULL_THRESHOLD = 80; // px to trigger refresh
-const MAX_PULL = 120; // max visual pull distance
+const THRESHOLD = 80;
 
-interface UsePullToRefreshOptions {
-  disabled?: boolean;
-}
-
-export const usePullToRefresh = (
+/** Read one touch gesture and refresh once. Cancelled gestures preserve normal scrolling. */
+export function usePullToRefresh(
   onRefresh: () => Promise<void> | void,
-  options: UsePullToRefreshOptions = {},
-) => {
-  const { disabled = false } = options;
+  { disabled = false }: { disabled?: boolean } = {},
+) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const startYRef = useRef<number | null>(null);
+  const refreshRef = useRef(onRefresh);
+  const refreshingRef = useRef(false);
   const [pullDistance, setPullDistance] = useState(0);
   const [isRefreshing, setIsRefreshing] = useState(false);
-
-  const isPulling = pullDistance > 0;
-  const pullProgress = Math.min(pullDistance / PULL_THRESHOLD, 1);
-
-  const triggerRefresh = useCallback(async () => {
-    setIsRefreshing(true);
-    setPullDistance(0);
-    try {
-      await onRefresh();
-    } finally {
-      setIsRefreshing(false);
-    }
-  }, [onRefresh]);
-
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el || disabled) return;
-
-    const onTouchStart = (e: TouchEvent) => {
-      if (el.scrollTop === 0) {
-        startYRef.current = e.touches[0].clientY;
-      }
+    refreshRef.current = onRefresh;
+  }, [onRefresh]);
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element || disabled) return;
+    let startY: number | null = null;
+    let distance = 0;
+    let frame: number | undefined;
+    let mounted = true;
+    const update = (next: number) => {
+      distance = next;
+      if (frame !== undefined) cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        frame = undefined;
+        setPullDistance(distance);
+      });
     };
-
-    const onTouchMove = (e: TouchEvent) => {
-      if (startYRef.current === null || isRefreshing) return;
-      const dy = e.touches[0].clientY - startYRef.current;
-      if (dy > 0 && el.scrollTop === 0) {
-        // Apply resistance so pulling far requires more force
-        const clamped = Math.min(dy * 0.5, MAX_PULL);
-        setPullDistance(clamped);
-      }
+    const cancel = () => {
+      startY = null;
+      update(0);
     };
-
-    const onTouchEnd = () => {
-      if (startYRef.current === null) return;
-      startYRef.current = null;
-      if (pullDistance >= PULL_THRESHOLD) {
-        triggerRefresh();
-      } else {
-        setPullDistance(0);
-      }
+    const start = (event: TouchEvent) => {
+      cancel();
+      if (
+        event.touches.length === 1 &&
+        element.scrollTop <= 0 &&
+        !refreshingRef.current
+      )
+        startY = event.touches[0].clientY;
     };
-
-    el.addEventListener("touchstart", onTouchStart, { passive: true });
-    el.addEventListener("touchmove", onTouchMove, { passive: true });
-    el.addEventListener("touchend", onTouchEnd, { passive: true });
-
+    const move = (event: TouchEvent) => {
+      if (startY === null) return;
+      if (event.touches.length !== 1 || element.scrollTop > 0) {
+        cancel();
+        return;
+      }
+      update(
+        Math.min(Math.max(0, (event.touches[0].clientY - startY) * 0.5), 120),
+      );
+    };
+    const end = () => {
+      const shouldRefresh =
+        startY !== null && distance >= THRESHOLD && !refreshingRef.current;
+      cancel();
+      if (!shouldRefresh) return;
+      refreshingRef.current = true;
+      setIsRefreshing(true);
+      void Promise.resolve()
+        .then(() => refreshRef.current())
+        .catch(() => {
+          // The query retains its error for the view's retry control.
+        })
+        .finally(() => {
+          refreshingRef.current = false;
+          if (mounted) setIsRefreshing(false);
+        });
+    };
+    element.addEventListener("touchstart", start, { passive: true });
+    element.addEventListener("touchmove", move, { passive: true });
+    element.addEventListener("touchend", end, { passive: true });
+    element.addEventListener("touchcancel", cancel, { passive: true });
     return () => {
-      el.removeEventListener("touchstart", onTouchStart);
-      el.removeEventListener("touchmove", onTouchMove);
-      el.removeEventListener("touchend", onTouchEnd);
+      mounted = false;
+      if (frame !== undefined) cancelAnimationFrame(frame);
+      element.removeEventListener("touchstart", start);
+      element.removeEventListener("touchmove", move);
+      element.removeEventListener("touchend", end);
+      element.removeEventListener("touchcancel", cancel);
     };
-  }, [disabled, isRefreshing, pullDistance, triggerRefresh]);
-
-  return { containerRef, isPulling, pullProgress, isRefreshing, pullDistance };
-};
+  }, [disabled]);
+  return {
+    containerRef,
+    isPulling: pullDistance > 0,
+    pullProgress: Math.min(pullDistance / THRESHOLD, 1),
+    isRefreshing,
+    pullDistance,
+  };
+}

--- a/src/hooks/useScrollRestoration.ts
+++ b/src/hooks/useScrollRestoration.ts
@@ -1,64 +1,41 @@
-/**
- * useScrollRestoration — Persists the scroll position of a scrollable container
- * across navigations using sessionStorage.
- *
- * Usage:
- *   const scrollRef = useScrollRestoration('contact-list');
- *   <div ref={scrollRef} className="overflow-y-auto">...</div>
- *
- * The key should be unique per scroll container (e.g. the route name).
- * Position is saved on scroll (debounced) and on unmount for safety.
- * Restored after a single animation frame to allow layout to settle.
- */
-import { useRef, useEffect } from "react";
+import { useRef, useLayoutEffect } from "react";
 
-const STORAGE_PREFIX = "contrack_scroll_";
-const DEBOUNCE_MS = 150;
-
-export const useScrollRestoration = <T extends HTMLElement = HTMLDivElement>(
+/** Restore a container after its data loads. Storage failures never interrupt navigation. */
+export function useScrollRestoration<T extends HTMLElement = HTMLDivElement>(
   key: string,
-) => {
+  ready = true,
+) {
   const ref = useRef<T>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-
-    // Restore position after layout paint
-    const saved = sessionStorage.getItem(`${STORAGE_PREFIX}${key}`);
-    if (saved !== null) {
-      const pos = parseInt(saved, 10);
-      requestAnimationFrame(() => {
-        if (ref.current) ref.current.scrollTop = pos;
-      });
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element || !ready) return;
+    const storageKey = `contrack_scroll_${key}`;
+    let position = 0;
+    try {
+      const saved = Number(sessionStorage.getItem(storageKey));
+      if (Number.isFinite(saved) && saved > 0) position = saved;
+    } catch {
+      /* Storage can be disabled. */
     }
-
-    // Save on scroll (debounced)
+    element.scrollTop = position;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const save = () => {
+      try {
+        sessionStorage.setItem(storageKey, String(element.scrollTop));
+      } catch {
+        /* Scrolling also works without storage. */
+      }
+    };
     const onScroll = () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => {
-        if (ref.current) {
-          sessionStorage.setItem(
-            `${STORAGE_PREFIX}${key}`,
-            String(ref.current.scrollTop),
-          );
-        }
-      }, DEBOUNCE_MS);
+      clearTimeout(timer);
+      timer = setTimeout(save, 150);
     };
-
-    el.addEventListener("scroll", onScroll, { passive: true });
-
+    element.addEventListener("scroll", onScroll, { passive: true });
     return () => {
-      el.removeEventListener("scroll", onScroll);
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      // Also save on unmount (catch cases where scroll didn't fire).
-      // `el` is captured from effect setup — by cleanup time `ref.current`
-      // may already be null (React detaches refs before running cleanups),
-      // which silently skipped this save.
-      sessionStorage.setItem(`${STORAGE_PREFIX}${key}`, String(el.scrollTop));
+      element.removeEventListener("scroll", onScroll);
+      clearTimeout(timer);
+      save();
     };
-  }, [key]);
-
+  }, [key, ready]);
   return ref;
-};
+}

--- a/src/index.css
+++ b/src/index.css
@@ -422,3 +422,16 @@
   pointer-events: none;
   opacity: 0.5;
 }
+
+/* Keep dialog transitions on opacity so positioning remains stable. */
+@keyframes modal-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.modal-fade[data-state="open"] {
+  animation: modal-fade-in 120ms ease-out;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import { MotionConfig } from "motion/react";
 /**
  * main.tsx — React DOM entry point.
  *
@@ -69,7 +70,9 @@ createRoot(document.getElementById("root")!).render(
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <AuthGate>
-          <App />
+          <MotionConfig reducedMotion="user">
+            <App />
+          </MotionConfig>
         </AuthGate>
       </QueryClientProvider>
     </ErrorBoundary>

--- a/src/views/contact-detail/ContactDetail.tsx
+++ b/src/views/contact-detail/ContactDetail.tsx
@@ -33,7 +33,7 @@ export const ContactDetail = () => {
       )}
 
       {id ? (
-        <ContactProfile contactId={id} onClose={handleClose} />
+        <ContactProfile key={id} contactId={id} onClose={handleClose} />
       ) : (
         <div className="p-12 text-center text-on-surface-variant">
           No Contact Selected

--- a/src/views/contact-detail/components/ContactProfile.tsx
+++ b/src/views/contact-detail/components/ContactProfile.tsx
@@ -160,9 +160,13 @@ export const ContactProfile = ({
   });
 
   // ── Event handlers ────────────────────────────────────────────────────
-  const handleUpdate = (field: string, val: string) => {
-    if (!id) return;
-    updateContact.mutate({ id, data: { [field]: val } });
+  const handleUpdate = async (field: string, val: string) => {
+    try {
+      await updateContact.mutateAsync({ id, data: { [field]: val } });
+      return true;
+    } catch {
+      return false;
+    }
   };
 
   // Delete confirmation — uses <Modal> instead of native confirm()

--- a/src/views/contact-detail/components/DetailsCard.tsx
+++ b/src/views/contact-detail/components/DetailsCard.tsx
@@ -240,6 +240,7 @@ const DetailsCardInner: React.FC<DetailsCardProps> = ({
                       {pref}
                     </span>
                     <button
+                      aria-label={`Remove preference ${pref}`}
                       onClick={() => {
                         const newPrefs = contact
                           .preferences!.split(",")
@@ -314,6 +315,7 @@ const DetailsCardInner: React.FC<DetailsCardProps> = ({
                       {interest.interest}
                     </span>
                     <button
+                      aria-label={`Remove interest ${interest.interest}`}
                       onClick={() => handleRemoveInterest(interest.id)}
                       className="w-6 h-6 -my-1 -mr-1.5 rounded-full text-on-surface-variant hover:text-error hover:bg-red-500/10 flex items-center justify-center transition-colors shrink-0"
                     >

--- a/src/views/contact-detail/components/EditableField.tsx
+++ b/src/views/contact-detail/components/EditableField.tsx
@@ -1,100 +1,129 @@
-/**
- * EditableField — Inline editable text with save feedback.
- *
- * On blur (or Enter), if the value changed, fires onSave() and plays a brief
- * ✓ confirmation animation so users know the change was persisted.
- * Escape reverts to the original value without saving.
- */
-import React, { useState, useEffect } from "react";
-import { Check } from "lucide-react";
+import React, { useState, useRef, useEffect } from "react";
+import { Check, Loader2 } from "lucide-react";
 import { cn } from "../../../lib/utils";
 import { EDITABLE_INPUT } from "../../../lib/styles";
-import { activateOnKey } from "../../../lib/a11y";
 
-export const EditableField = ({
+/** Inline editor that retains rejected drafts and confirms completed asynchronous saves. */
+export function EditableField({
   value,
   onSave,
   placeholder,
   className = "",
 }: {
   value: string | null;
-  onSave: (val: string) => void;
+  onSave: (value: string) => unknown;
   placeholder: string;
   className?: string;
-}) => {
-  const [isEditing, setIsEditing] = useState(false);
-  const [currentVal, setCurrentVal] = useState(value || "");
-  const [showSaved, setShowSaved] = useState(false);
-
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value ?? "");
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState(false);
+  const cancelled = useRef(false);
+  const pending = useRef(false);
+  const mounted = useRef(true);
   useEffect(() => {
-    setCurrentVal(value || "");
-  }, [value]);
-
-  const handleBlur = () => {
-    setIsEditing(false);
-    if (currentVal.trim() !== (value || "")) {
-      onSave(currentVal.trim());
-      // Show brief ✓ confirmation
-      setShowSaved(true);
-      const t = setTimeout(() => setShowSaved(false), 1500);
-      return () => clearTimeout(t);
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+  useEffect(() => {
+    if (!saved) return;
+    const timer = setTimeout(() => setSaved(false), 1500);
+    return () => clearTimeout(timer);
+  }, [saved]);
+  const begin = () => {
+    cancelled.current = false;
+    setDraft(value ?? "");
+    setSaved(false);
+    setError(false);
+    setEditing(true);
+  };
+  const commit = async () => {
+    if (cancelled.current || pending.current) return;
+    const next = draft.trim();
+    if (next === (value ?? "")) {
+      setEditing(false);
+      return;
+    }
+    pending.current = true;
+    setSaving(true);
+    setError(false);
+    try {
+      const result = onSave(next);
+      const completed = await result;
+      if (completed === false) throw new Error("Save failed");
+      if (mounted.current) {
+        setEditing(false);
+        setSaved(result instanceof Promise);
+      }
+    } catch {
+      if (mounted.current) setError(true);
+    } finally {
+      pending.current = false;
+      if (mounted.current) setSaving(false);
     }
   };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      e.currentTarget.blur();
-    }
-    if (e.key === "Escape") {
-      setCurrentVal(value || "");
-      setIsEditing(false);
-    }
-  };
-
-  if (isEditing) {
+  if (editing)
     return (
-      <input
-        aria-label={placeholder}
-        // Inline editor, opened by clicking the value it replaces.
-        // eslint-disable-next-line jsx-a11y/no-autofocus
-        autoFocus
-        value={currentVal}
-        onChange={(e) => setCurrentVal(e.target.value)}
-        onBlur={handleBlur}
-        onKeyDown={handleKeyDown}
-        className={cn(EDITABLE_INPUT, className)}
-        placeholder={placeholder}
-      />
+      <span className="inline-flex flex-col min-w-0">
+        <span className="inline-flex items-center gap-1">
+          <input
+            aria-label={placeholder}
+            aria-invalid={error || undefined}
+            aria-busy={saving}
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            value={draft}
+            readOnly={saving}
+            onChange={(event) => setDraft(event.target.value)}
+            onBlur={() => {
+              void commit();
+            }}
+            onKeyDown={(event) => {
+              if (event.nativeEvent.isComposing) return;
+              if (event.key === "Enter") {
+                event.preventDefault();
+                void commit();
+              }
+              if (event.key === "Escape" && !pending.current) {
+                event.preventDefault();
+                event.stopPropagation();
+                cancelled.current = true;
+                setEditing(false);
+                setError(false);
+              }
+            }}
+            className={cn(EDITABLE_INPUT, className)}
+            placeholder={placeholder}
+          />
+          {saving && (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" aria-label="Saving" />
+          )}
+        </span>
+        {error && (
+          <span role="alert" className="text-xs text-error">
+            Save failed. Press Enter to retry or Escape to cancel.
+          </span>
+        )}
+      </span>
     );
-  }
-
   return (
-    <span
-      onKeyDown={activateOnKey(() => setIsEditing(true))}
-      tabIndex={0}
-      role="button"
-      onClick={() => setIsEditing(true)}
+    <button
+      type="button"
+      onClick={begin}
       className={cn(
-        "relative cursor-text group inline-flex items-center gap-1.5",
+        "relative cursor-text text-left inline-flex items-center gap-1.5 rounded hover:bg-surface-container-high transition-colors",
         !value && "text-on-surface-variant italic",
         className,
       )}
     >
-      {/* Absolute hover background layer completely decoupled from flex flow */}
-      <span className="absolute -inset-x-2 -top-1 -bottom-1.5 rounded bg-transparent group-hover:bg-surface-container-high transition-colors -z-10 pointer-events-none" />
-      <span className="relative pointer-events-none">
-        {value || placeholder}
-      </span>
-      {/* Save confirmation ✓ — fades in/out */}
-      {showSaved && (
-        <span
-          className="inline-flex items-center shrink-0 text-success animate-fade-in pointer-events-none"
-          aria-label="Saved"
-        >
-          <Check className="w-3.5 h-3.5" strokeWidth={3} />
-        </span>
+      <span>{value || placeholder}</span>
+      {saved && (
+        <Check className="w-3.5 h-3.5 text-success" aria-label="Saved" />
       )}
-    </span>
+    </button>
   );
-};
+}

--- a/src/views/contact-detail/components/TimelineTab.tsx
+++ b/src/views/contact-detail/components/TimelineTab.tsx
@@ -66,6 +66,7 @@ export interface TimelineTabProps {
 
   // Mutations passed from parent
   deleteInteraction: {
+    isPending: boolean;
     mutate: (
       args: { id: string; contactId: string },
       opts?: { onSuccess?: () => void; onError?: (err: Error) => void },
@@ -261,7 +262,7 @@ const TimelineTabInner: React.FC<TimelineTabProps> = ({
             <div
               key={item.id}
               className="relative flex items-center justify-between md:justify-normal md:odd:flex-row-reverse group is-active timeline-entry"
-              style={{ animationDelay: `${index * 40}ms` }}
+              style={{ animationDelay: `${Math.min(index, 6) * 25}ms` }}
             >
               {/* Icon marker */}
               <div
@@ -271,16 +272,16 @@ const TimelineTabInner: React.FC<TimelineTabProps> = ({
               </div>
 
               {/* Content Box */}
-              <div
-                onKeyDown={activateOnKey(() => setSelectedInteraction(item))}
-                tabIndex={0}
-                role="button"
-                className="w-[calc(100%-3rem)] md:w-[calc(50%-2.5rem)] ml-auto md:ml-0 p-5 rounded-2xl bg-surface-container-lowest shadow-sm hover:shadow-md transition-shadow relative group/card cursor-pointer"
-                onClick={() => setSelectedInteraction(item)}
-              >
+              <div className="w-[calc(100%-3rem)] md:w-[calc(50%-2.5rem)] ml-auto md:ml-0 p-5 rounded-2xl bg-surface-container-lowest shadow-sm hover:shadow-md transition-shadow relative group/card cursor-pointer">
                 <div className="flex justify-between items-center mb-2">
                   <h4 className="font-extrabold text-on-surface">
-                    {item.title}
+                    <button
+                      type="button"
+                      className="text-left hover:underline"
+                      onClick={() => setSelectedInteraction(item)}
+                    >
+                      {item.title}
+                    </button>
                   </h4>
                   <div className="flex items-center gap-2 shrink-0">
                     <time className="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">
@@ -291,7 +292,8 @@ const TimelineTabInner: React.FC<TimelineTabProps> = ({
                         e.stopPropagation();
                         handleDeleteInteraction(item.id);
                       }}
-                      className="opacity-0 group-hover/card:opacity-60 hover:!opacity-100 text-error p-1 rounded transition-opacity"
+                      className="opacity-70 hover:opacity-100 text-error min-w-9 min-h-9 flex items-center justify-center rounded transition-opacity"
+                      disabled={deleteInteraction.isPending}
                       title="Delete interaction"
                       aria-label="Delete interaction"
                     >

--- a/src/views/contact-list/ContactList.tsx
+++ b/src/views/contact-list/ContactList.tsx
@@ -47,11 +47,7 @@ import {
   useBulkUpdateContacts,
 } from "../../api";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import {
-  DENSITY_METRICS,
-  useListDensity,
-  type ListDensity,
-} from "../../hooks/useListDensity";
+import { useListDensity, type ListDensity } from "../../hooks/useListDensity";
 import { AlphabetJumpButtons, AlphabetRail, bucketFor } from "./AlphabetRail";
 import type { Contact, ContactUpdateData } from "../../types";
 import { ContextMenu, useContextMenu } from "../../components/ui/ContextMenu";
@@ -200,12 +196,6 @@ const ContactRowWrapper = React.memo(
           isFlashing &&
             "ring-2 ring-primary/40 shadow-[0_0_12px_rgba(0,113,156,0.2)]",
         )}
-        style={{
-          contentVisibility: "auto",
-          // Must track the real row height, or `content-visibility` reserves
-          // the wrong space for off-screen rows and the scrollbar lurches.
-          containIntrinsicSize: `1px ${DENSITY_METRICS[density].rowHeight}px`,
-        }}
       >
         <ContactListItem
           contact={contact}
@@ -239,7 +229,10 @@ export const ContactList = () => {
 
   // ── UX hooks ────────────────────────────────────────────────────────
   usePageTitle("Network");
-  const scrollRef = useScrollRestoration<HTMLDivElement>("contact-list");
+  const scrollRef = useScrollRestoration<HTMLDivElement>(
+    `contact-list:${filters.filterMode}:${filters.searchQuery}`,
+    !isLoading,
+  );
   const {
     containerRef: pullRef,
     isPulling,
@@ -421,6 +414,10 @@ export const ContactList = () => {
 
   const rowVirtualizer = useVirtualizer({
     count: filteredContacts.length,
+    getItemKey: React.useCallback(
+      (index) => filteredContacts[index].id,
+      [filteredContacts],
+    ),
     getScrollElement: () => scrollRef.current,
     scrollMargin,
     // Only an estimate — rows are measured for real by `measureElement`
@@ -444,7 +441,16 @@ export const ContactList = () => {
     // Recomputed whenever the block above the list can change height: the
     // Recent row count, its preference, the density of those rows, and
     // whether a search collapses the section entirely.
-  }, [recentContacts.length, recentLimit, density, searchQuery, scrollRef]);
+  }, [
+    recentContacts.length,
+    recentLimit,
+    density,
+    searchQuery,
+    filterMode,
+    isLoading,
+    pullDistance,
+    scrollRef,
+  ]);
 
   // ── Alphabet rail ───────────────────────────────────────────────────
   // Only meaningful when the list is actually alphabetical, and only worth
@@ -472,7 +478,9 @@ export const ContactList = () => {
   const virtualItems = rowVirtualizer.getVirtualItems();
   const activeBucket = showAlphabetRail
     ? (() => {
-        const first = virtualItems[0];
+        const first = virtualItems.find(
+          (item) => item.end > (rowVirtualizer.scrollOffset ?? 0),
+        );
         const contact = first ? filteredContacts[first.index] : undefined;
         return contact ? bucketFor(contact.name) : null;
       })()
@@ -711,7 +719,7 @@ export const ContactList = () => {
       <div className="relative flex-1 min-h-0">
         <div
           ref={listScrollRef}
-          className="h-full overflow-y-auto p-4 space-y-2 pb-24 md:pb-4 scrollbar-hide"
+          className="h-full overflow-y-auto p-4 space-y-2 pb-24 md:pb-4 overscroll-contain"
         >
           {/* Pull-to-refresh indicator — mobile only */}
           <PullIndicator
@@ -851,6 +859,7 @@ export const ContactList = () => {
                   {recentContacts.map((contact) => (
                     <ContactListItem
                       key={`recent-${contact.id}`}
+                      idPrefix="recent-contact"
                       contact={contact}
                       density={density}
                       active={id === contact.id}
@@ -886,7 +895,7 @@ export const ContactList = () => {
                     position: "absolute",
                     top: 0,
                     left: 0,
-                    width: "100%",
+                    width: showAlphabetRail ? "calc(100% - 1.5rem)" : "100%",
                     transform: `translateY(${virtualItem.start - scrollMargin}px)`,
                     paddingBottom: "8px", // Replaces space-y-2
                   }}

--- a/src/views/contact-list/ContactListItem.tsx
+++ b/src/views/contact-list/ContactListItem.tsx
@@ -7,7 +7,7 @@
  * - Prefetches the contact detail query on pointer enter (100ms debounce) so
  *   by the time the user clicks, the detail pane loads instantly from cache.
  */
-import React, { useState, useRef, useCallback } from "react";
+import React, { useState, useRef, useCallback, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import {
   CheckCheck,
@@ -53,7 +53,7 @@ function shortRecency(iso: string | null | undefined): string {
   return `${value}${abbrev[unit] ?? ""}`;
 }
 
-const API_BASE = "/api";
+import { apiFetch } from "../../api/client";
 
 // ---------------------------------------------------------------------------
 // ContactListItem — memoized row component
@@ -61,6 +61,7 @@ const API_BASE = "/api";
 
 interface ContactListItemProps {
   contact: Contact;
+  idPrefix?: string;
   /** Comfortable keeps the roomy default; compact roughly doubles rows/screen. */
   density: ListDensity;
   active: boolean;
@@ -72,6 +73,7 @@ interface ContactListItemProps {
 
 const ContactListItemInner = ({
   contact,
+  idPrefix = "contact-row",
   density,
   active,
   isSelectMode,
@@ -85,6 +87,13 @@ const ContactListItemInner = ({
   const queryClient = useQueryClient();
   const location = useLocation();
   const prefetchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (prefetchTimer.current) clearTimeout(prefetchTimer.current);
+    },
+    [contact.id],
+  );
 
   // ── Computed values ────────────────────────────────────────────────────────
 
@@ -103,11 +112,12 @@ const ContactListItemInner = ({
 
   const handlePointerEnter = useCallback(() => {
     if (isSelectMode || active) return; // already loaded or irrelevant in select mode
+    if (prefetchTimer.current) clearTimeout(prefetchTimer.current);
     prefetchTimer.current = setTimeout(() => {
       queryClient.prefetchQuery({
         queryKey: ["contacts", contact.id],
-        queryFn: () =>
-          fetch(`${API_BASE}/contacts/${contact.id}`).then((r) => {
+        queryFn: ({ signal }) =>
+          apiFetch(`/contacts/${contact.id}`, { signal }).then((r) => {
             if (!r.ok) throw new Error("Failed to prefetch contact");
             return r.json();
           }),
@@ -139,7 +149,8 @@ const ContactListItemInner = ({
 
   return (
     <Link
-      id={`contact-row-${contact.id}`}
+      id={`${idPrefix}-${contact.id}`}
+      aria-current={active && !isSelectMode ? "page" : undefined}
       to={isSelectMode ? "#" : `/contact/${contact.id}${location.search}`}
       onClick={handleClick}
       onPointerEnter={handlePointerEnter}
@@ -268,34 +279,5 @@ const ContactListItemInner = ({
   );
 };
 
-/**
- * Custom memo comparator — only re-render when props that affect display change.
- * This prevents cascade rerenders when ContactList state (flashId, contextMenu,
- * drag state, etc.) changes without touching this contact's data.
- */
-const areEqual = (
-  prev: ContactListItemProps,
-  next: ContactListItemProps,
-): boolean => {
-  return (
-    prev.contact.id === next.contact.id &&
-    prev.contact.updatedAt === next.contact.updatedAt &&
-    prev.contact.name === next.contact.name &&
-    prev.contact.company === next.contact.company &&
-    prev.contact.avatarUrl === next.contact.avatarUrl &&
-    prev.contact.nextFollowUpAt === next.contact.nextFollowUpAt &&
-    prev.contact.relationshipScore === next.contact.relationshipScore &&
-    // Rendered by the tablet-band metadata column.
-    prev.contact.location === next.contact.location &&
-    prev.contact.lastContactedAt === next.contact.lastContactedAt &&
-    prev.contact.themeColor === next.contact.themeColor &&
-    prev.contact.role === next.contact.role &&
-    prev.contact.isGhost === next.contact.isGhost &&
-    prev.density === next.density &&
-    prev.active === next.active &&
-    prev.isSelectMode === next.isSelectMode &&
-    prev.isSelected === next.isSelected
-  );
-};
-
-export const ContactListItem = React.memo(ContactListItemInner, areEqual);
+// Query structural sharing keeps unchanged contact objects stable.
+export const ContactListItem = React.memo(ContactListItemInner);

--- a/src/views/contact-list/hooks/useContactListFilters.ts
+++ b/src/views/contact-list/hooks/useContactListFilters.ts
@@ -63,12 +63,20 @@ export function useContactListFilters(contacts: Contact[]) {
   // during the debounce window, causing the "character deletion" bug.
   const isInternalUpdateRef = useRef(false);
 
+  useEffect(
+    () => () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    },
+    [],
+  );
+
   // Sync URL → local state ONLY for external navigation events
   useEffect(() => {
     if (isInternalUpdateRef.current) {
       isInternalUpdateRef.current = false;
       return;
     }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
     const urlQ = searchParams.get("q") ?? "";
     setInputValue((prev) => (prev === urlQ ? prev : urlQ));
   }, [searchParams]);
@@ -125,7 +133,9 @@ export function useContactListFilters(contacts: Contact[]) {
 
   // ── Filtered + sorted contacts ────────────────────────────────────────
   const filteredContacts = useMemo(() => {
-    let result = contacts.filter((contact) => !contact.isArchived);
+    let result = contacts.filter(
+      (contact) => !contact.isArchived && !contact.isGhost,
+    );
 
     // 1. Apply List Filter
     if (filterMode !== "all") {
@@ -181,8 +191,9 @@ export function useContactListFilters(contacts: Contact[]) {
           const phoneMatch = contact.phones.some((p) => {
             const normalized = normalizePhone(p.phone);
             return (
-              normalized.includes(cleanPhoneQuery) ||
-              cleanPhoneQuery.includes(normalized)
+              normalized.length > 0 &&
+              (normalized.includes(cleanPhoneQuery) ||
+                cleanPhoneQuery.includes(normalized))
             );
           });
           if (phoneMatch) score += 10;

--- a/tests/unit/frontend.ui.test.tsx
+++ b/tests/unit/frontend.ui.test.tsx
@@ -1,0 +1,265 @@
+// @vitest-environment jsdom
+import { usePullToRefresh } from "../../src/hooks/usePullToRefresh";
+import React, { useState, StrictMode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { Modal } from "../../src/components/ui/Modal";
+import { EditableField } from "../../src/views/contact-detail/components/EditableField";
+import { useLongPress } from "../../src/hooks/useLongPress";
+import { useScrollRestoration } from "../../src/hooks/useScrollRestoration";
+import { useClickOutside } from "../../src/hooks/useClickOutside";
+import { MemoryRouter } from "react-router-dom";
+import { useContactListFilters } from "../../src/views/contact-list/hooks/useContactListFilters";
+import type { Contact } from "../../src/types";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  sessionStorage.clear();
+});
+
+describe("dialog interaction", () => {
+  function Nested() {
+    const [outer, setOuter] = useState(false);
+    const [inner, setInner] = useState(false);
+    return (
+      <>
+        <button onClick={() => setOuter(true)}>Open parent</button>
+        <Modal isOpen={outer} onClose={() => setOuter(false)} title="Parent">
+          <button onClick={() => setInner(true)}>Open child</button>
+          <Modal isOpen={inner} onClose={() => setInner(false)} title="Child">
+            <input aria-label="Child input" />
+          </Modal>
+        </Modal>
+      </>
+    );
+  }
+  it("closes only the top dialog and restores focus without unlocking its parent", async () => {
+    render(
+      <StrictMode>
+        <Nested />
+      </StrictMode>,
+    );
+    screen.getByText("Open parent").focus();
+    fireEvent.click(screen.getByText("Open parent"));
+    screen.getByText("Open child").focus();
+    fireEvent.click(screen.getByText("Open child"));
+    expect(screen.getByRole("dialog").textContent).toContain("Child");
+    expect(document.body.style.pointerEvents).toBe("none");
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    await waitFor(() =>
+      expect(screen.getByRole("dialog").textContent).toContain("Parent"),
+    );
+    expect(document.body.style.pointerEvents).toBe("none");
+    await waitFor(() =>
+      expect(document.activeElement).toBe(screen.getByText("Open child")),
+    );
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    await waitFor(() => expect(document.body.style.pointerEvents).toBe(""));
+    expect(document.activeElement).toBe(screen.getByText("Open parent"));
+  });
+  it("contains Tab and Shift+Tab and gives headless dialogs a name", () => {
+    render(
+      <Modal isOpen onClose={() => {}} ariaLabel="Contact details">
+        <input aria-label="Last input" />
+      </Modal>,
+    );
+    expect(
+      screen.getByRole("dialog", { name: "Contact details" }),
+    ).toBeTruthy();
+    const first = screen.getByRole("button", { name: "Close dialog" });
+    const last = screen.getByLabelText("Last input");
+    last.focus();
+    fireEvent.keyDown(last, { key: "Tab" });
+    expect(document.activeElement).toBe(first);
+    fireEvent.keyDown(first, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+});
+
+describe("inline edits", () => {
+  it("does not save after Escape or during text composition", () => {
+    const save = vi.fn();
+    render(<EditableField value="Saved" onSave={save} placeholder="Name" />);
+    fireEvent.click(screen.getByText("Saved"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Draft" } });
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+    expect(save).not.toHaveBeenCalled();
+    fireEvent.keyDown(input, { key: "Escape" });
+    fireEvent.blur(input);
+    expect(save).not.toHaveBeenCalled();
+    expect(screen.getByText("Saved")).toBeTruthy();
+  });
+  it("retains a failed draft and confirms only a completed save", async () => {
+    let resolve!: (result: boolean) => void;
+    const save = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((r) => {
+            resolve = r;
+          }),
+      )
+      .mockResolvedValueOnce(true);
+    render(<EditableField value="Saved" onSave={save} placeholder="Name" />);
+    fireEvent.click(screen.getByText("Saved"));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Draft" },
+    });
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+    fireEvent.blur(screen.getByRole("textbox"));
+    expect(save).toHaveBeenCalledOnce();
+    expect(screen.queryByLabelText("Saved")).toBeNull();
+    await act(async () => resolve(false));
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe(
+      "Draft",
+    );
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+    await waitFor(() => expect(screen.getByLabelText("Saved")).toBeTruthy());
+  });
+});
+
+describe("scroll and touch", () => {
+  function Scroller({
+    ready = true,
+    id = "test",
+  }: {
+    ready?: boolean;
+    id?: string;
+  }) {
+    const ref = useScrollRestoration(id, ready);
+    return <div data-testid="scroller" ref={ref} />;
+  }
+  it("waits for data before restoring and separates scroll positions by view", () => {
+    sessionStorage.setItem("contrack_scroll_test", "400");
+    const { rerender } = render(<Scroller ready={false} />);
+    const el = screen.getByTestId("scroller");
+    expect(el.scrollTop).toBe(0);
+    rerender(<Scroller />);
+    expect(el.scrollTop).toBe(400);
+    rerender(<Scroller id="filtered" />);
+    expect(el.scrollTop).toBe(0);
+    expect(sessionStorage.getItem("contrack_scroll_test")).toBe("400");
+  });
+  it("works when browser storage throws", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    const { unmount } = render(<Scroller />);
+    fireEvent.scroll(screen.getByTestId("scroller"));
+    expect(() => unmount()).not.toThrow();
+  });
+  it("suppresses the click after a long press but preserves normal taps", () => {
+    vi.useFakeTimers();
+    const press = vi.fn();
+    const click = vi.fn();
+    function Row() {
+      const gesture = useLongPress(press);
+      return (
+        <div {...gesture}>
+          <button onClick={click}>Row</button>
+        </div>
+      );
+    }
+    render(<Row />);
+    const button = screen.getByText("Row");
+    fireEvent.touchStart(button, { touches: [{ clientX: 1, clientY: 1 }] });
+    act(() => vi.advanceTimersByTime(600));
+    fireEvent.touchEnd(button);
+    fireEvent.click(button);
+    expect(press).toHaveBeenCalledOnce();
+    expect(click).not.toHaveBeenCalled();
+    fireEvent.touchStart(button, { touches: [{ clientX: 1, clientY: 1 }] });
+    fireEvent.touchEnd(button);
+    fireEvent.click(button);
+    expect(click).toHaveBeenCalledOnce();
+  });
+  it("cancels long presses during scrolling or multiple touches", () => {
+    vi.useFakeTimers();
+    const press = vi.fn();
+    const { result } = renderHook(() => useLongPress(press));
+    act(() => {
+      result.current.onTouchStart({
+        touches: [{ clientX: 0, clientY: 0 }],
+      } as unknown as React.TouchEvent);
+      result.current.onTouchMove({
+        touches: [{ clientX: 0, clientY: 30 }],
+      } as unknown as React.TouchEvent);
+      vi.advanceTimersByTime(600);
+    });
+    expect(press).not.toHaveBeenCalled();
+  });
+  it("dismisses outside touch pointers", () => {
+    const dismiss = vi.fn();
+    function Menu() {
+      const ref = React.useRef<HTMLDivElement>(null);
+      useClickOutside(ref, dismiss);
+      return <div ref={ref}>Menu</div>;
+    }
+    render(<Menu />);
+    fireEvent.pointerDown(screen.getByText("Menu"));
+    expect(dismiss).not.toHaveBeenCalled();
+    fireEvent.pointerDown(document.body, { pointerType: "touch" });
+    expect(dismiss).toHaveBeenCalledOnce();
+  });
+});
+
+it("does not match empty phone values against every numeric query", () => {
+  const contacts = [
+    { id: "a", name: "Alice", phones: [{ phone: "" }] },
+  ] as Contact[];
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter initialEntries={["/?q=555"]}>{children}</MemoryRouter>
+  );
+  const { result } = renderHook(() => useContactListFilters(contacts), {
+    wrapper,
+  });
+  expect(result.current.filteredContacts).toEqual([]);
+});
+
+it("cancels a pull gesture and never overlaps refreshes", async () => {
+  let resolve!: () => void;
+  const refresh = vi.fn().mockImplementation(
+    () =>
+      new Promise<void>((r) => {
+        resolve = r;
+      }),
+  );
+  function Pull() {
+    const { containerRef } = usePullToRefresh(refresh);
+    return <div data-testid="pull" ref={containerRef} />;
+  }
+  render(<Pull />);
+  const el = screen.getByTestId("pull");
+  const pull = () => {
+    fireEvent.touchStart(el, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(el, { touches: [{ clientY: 200 }] });
+  };
+  pull();
+  fireEvent.touchCancel(el);
+  fireEvent.touchEnd(el);
+  await act(async () => {});
+  expect(refresh).not.toHaveBeenCalled();
+  pull();
+  fireEvent.touchEnd(el);
+  await waitFor(() => expect(refresh).toHaveBeenCalledOnce());
+  pull();
+  fireEvent.touchEnd(el);
+  expect(refresh).toHaveBeenCalledOnce();
+  await act(async () => resolve());
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
           name: "unit",
           environment: "node",
           globals: true,
-          include: ["tests/unit/**/*.test.ts"],
+          include: ["tests/unit/**/*.test.{ts,tsx}"],
           setupFiles: ["./tests/setup.ts"],
         },
       },


### PR DESCRIPTION
This PR stabilizes list navigation, dialogs, and inline edits so the UI stays usable during scrolling and saves.

- Give virtual rows stable contact keys and remove competing content measurements.
- Restore scroll after data loads, keep filtered views separate, and tolerate blocked browser storage.
- Use Radix Dialog for nested focus, Escape, and scroll locking. Keep dialogs inside short phone viewports.
- Keep failed inline drafts available for retry. Show save confirmation only after an asynchronous save completes.
- Prevent long presses from opening contacts. Cancel pull gestures correctly and prevent overlapping refreshes.
- Add accessible labels, native keyboard and touch selection, visible timeline actions, and reduced-motion support.
- Update the rich-text and avatar dependencies within supported version ranges.

**Stack:** Part 3 of 5. Base: #19. Merge after #19.

## Testing

- `npm test`: 619 tests passed across 45 files.
- `npm run lint`: passed.
- `npm run format:check`: passed.
- `npm run build`: passed.
- Browser: 390×844, 390×480, and 1440×900 viewports.
- The avatar dialog fits the short viewport and scrolls to its final controls. Escape restores focus and pointer access.
- Alphabet navigation followed by filtering shows the correct contacts with no duplicate DOM IDs or horizontal page overflow.
