### PR TITLE
fix(ask): bound AI search and validate streamed evidence

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -468,14 +468,19 @@ curl -X POST http://localhost:3210/api/search/semantic \
   -d '{"query":"fintech contacts"}'
 ```
 
-Phase 1 (instant retrieval <15ms): returns matches with `aiReason: null`.
-Phase 2 (~500ms later): returns matches with AI-generated reasons.
+The `instant` event returns local keyword candidates before AI refinement.
+The `complete` event returns verified matches or explicit keyword fallback results.
+A valid empty result ends the search. AI refinement has a 12-second deadline.
+Both JSON and streaming callers use the same pipeline.
 
 ---
 
 ### `POST /api/search/synthesize`
 
 Synthesize search results into an executive brief. Streams via NDJSON.
+The body contains a query and 1 to 30 contact IDs. The server reads current, active contacts.
+It rejects missing contacts with `409` and rejects malformed input with `400`.
+It checks for concurrent edits before it returns the summary.
 
 ```bash
 curl -X POST http://localhost:3210/api/search/synthesize \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -254,28 +254,23 @@ Frontend caching via React Query v5 with:
 
 ## Search Pipeline
 
-Ask Contrack v3 uses a hybrid retrieval-augmented generation (RAG) pipeline:
+Ask Contrack sends local keyword candidates before it calls AI.
+A short name lookup uses only the local index.
 
-```
-User Query
-    │
-    ├──→ FTS5 Keyword Search (SQLite)     ──→ Top-N results
-    │                                          │
-    ├──→ Vector KNN Search (sqlite-vec)   ──→ Top-N results
-    │    (384-dim MiniLM local embeddings)     │
-    │                                          │
-    └──→ Reciprocal Rank Fusion (RRF)    ←────┘
-              │
-              ▼
-         Fused Results (Phase 1 — <15ms)
-              │
-              ▼
-         AI Re-ranking + Reason Generation (Phase 2 — ~500ms)
-              │
-              ▼
-         Streamed via NDJSON to client
-```
+1. The query planner produces bounded hard filters and optional traits.
+2. The retrieval engine applies those filters before keyword and vector limits.
+3. It combines local keyword rankings and local vector rankings.
+4. The reranker checks at most 30 compact profiles.
+5. The server verifies claimed field values and hard constraints.
+6. The response ends with verified matches, an empty result, or keyword fallback.
 
-### Write-Time Enrichment (Doc2Query)
+A shared 12-second deadline bounds refinement. Client disconnects cancel active work.
+Search caches include the data revision, model, and a five-minute time bucket.
+Concurrent edits prevent old evidence from entering the result cache.
 
-When contacts are created or updated, an async background job generates synthetic search terms using Gemini Lite. For example, a "Stripe Engineer" gets expansion terms like `fintech, payments, developer`. Stored in a `searchExpansion` column indexed by FTS5.
+### Index Refreshes
+
+SQLite triggers maintain the keyword index during contact and child-record changes.
+A coalesced local queue refreshes built-in embeddings after edits.
+Automatic index refreshes do not generate AI search terms.
+Explicit backfill commands remain available for configured provider embeddings.

--- a/server/ai/adapters/anthropic.ts
+++ b/server/ai/adapters/anthropic.ts
@@ -264,7 +264,7 @@ export class AnthropicAdapter implements AIProvider {
     const requestParams: Record<string, unknown> = {
       model,
       messages,
-      max_tokens: maxTokens,
+      max_tokens: options.maxOutputTokens ?? maxTokens,
     };
     let systemPrompt = options.systemPrompt ?? "";
     // Without a schema to constrain it, the model needs the shape in words.

--- a/server/ai/adapters/gemini.ts
+++ b/server/ai/adapters/gemini.ts
@@ -443,6 +443,8 @@ export class GeminiAdapter implements AIProvider {
     startMs: number,
   ): Promise<AIGenerateResult> {
     const config: Record<string, unknown> = {};
+    if (options.maxOutputTokens)
+      config.maxOutputTokens = options.maxOutputTokens;
 
     if (options.enableSearchGrounding) {
       // ⚠️ Gemini API constraint: googleSearch tool is incompatible with
@@ -466,18 +468,14 @@ export class GeminiAdapter implements AIProvider {
       config.systemInstruction = options.systemPrompt;
     }
 
-    // The Gemini SDK's `generateContent` does not accept an AbortSignal
-    // option, so we wrap it in `withTimeout` (Promise.race-based). When the
-    // timer fires the SDK call is left running in the background, but
-    // `withTimeout` will throw an `UpstreamTimeoutError` which the SmartMesh
-    // retry loop (or the caller) treats as a transient failure.
+    // Forward cancellation to the SDK and bound callers even if the transport stalls.
     const timeoutMs = options.timeoutMs ?? AI_DEFAULTS.perAttemptTimeoutMs;
     const response = await withTimeout(
-      async () =>
+      async (abortSignal) =>
         this.client.models.generateContent({
           model,
           contents: options.prompt,
-          config,
+          config: { ...config, abortSignal },
         }),
       timeoutMs,
       options.signal,

--- a/server/ai/adapters/openai.ts
+++ b/server/ai/adapters/openai.ts
@@ -245,6 +245,8 @@ export class OpenAIAdapter implements AIProvider {
     messages.push({ role: "user", content: options.prompt });
 
     const requestParams: Record<string, unknown> = { model, messages };
+    if (options.maxOutputTokens)
+      requestParams.max_completion_tokens = options.maxOutputTokens;
     if (options.responseFormat === "json" && options.jsonSchema) {
       requestParams.response_format = this.translateSchema(options.jsonSchema);
     } else if (options.responseFormat === "json") {
@@ -307,6 +309,8 @@ export class OpenAIAdapter implements AIProvider {
       }>;
       usage?: { total_tokens?: number };
     }
+    if (options.maxOutputTokens)
+      requestParams.max_output_tokens = options.maxOutputTokens;
     const response = (await this.client.responses.create(
       requestParams as unknown as Parameters<
         typeof this.client.responses.create

--- a/server/ai/resilience.ts
+++ b/server/ai/resilience.ts
@@ -131,33 +131,37 @@ export async function withTimeout<T>(
   timeoutMs: number,
   parentSignal?: AbortSignal,
 ): Promise<T> {
+  parentSignal?.throwIfAborted();
   const controller = new AbortController();
-  let timedOut = false;
-
-  const timer = setTimeout(() => {
-    timedOut = true;
-    controller.abort();
-  }, timeoutMs);
-
-  const onParentAbort = () => controller.abort();
-  if (parentSignal) {
-    if (parentSignal.aborted) controller.abort();
-    else parentSignal.addEventListener("abort", onParentAbort, { once: true });
-  }
-
+  let rejectAbort!: (reason: unknown) => void;
+  const aborted = new Promise<never>((_, reject) => {
+    rejectAbort = reject;
+  });
+  const abort = (reason: unknown) => {
+    rejectAbort(reason);
+    controller.abort(reason);
+  };
+  const timer = setTimeout(
+    () =>
+      abort(
+        new UpstreamTimeoutError(`AI call exceeded ${timeoutMs}ms timeout`),
+      ),
+    timeoutMs,
+  );
+  const onParentAbort = () =>
+    abort(parentSignal?.reason ?? new DOMException("Aborted", "AbortError"));
+  parentSignal?.addEventListener("abort", onParentAbort, { once: true });
   try {
-    return await op(controller.signal);
-  } catch (err) {
-    if (timedOut) {
-      throw new UpstreamTimeoutError(
-        `AI call exceeded ${timeoutMs}ms timeout`,
-        { cause: (err as Error)?.message },
-      );
-    }
-    throw err;
+    return await Promise.race([
+      Promise.resolve().then(() => {
+        controller.signal.throwIfAborted();
+        return op(controller.signal);
+      }),
+      aborted,
+    ]);
   } finally {
     clearTimeout(timer);
-    if (parentSignal) parentSignal.removeEventListener("abort", onParentAbort);
+    parentSignal?.removeEventListener("abort", onParentAbort);
   }
 }
 

--- a/server/ai/services/searchIntel.ts
+++ b/server/ai/services/searchIntel.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+import { AppError } from "../../utils/AppError.ts";
 // =============================================================================
 // AI Services — Search Intelligence (Ask Contrack pipeline)
 // =============================================================================
@@ -19,6 +21,7 @@ import { getErrorMessage } from "../../utils/helpers.ts";
 import { recordInvocation } from "../../services/aiStatsService.ts";
 import { aiCache, contentHash } from "../../utils/aiCache.ts";
 import { wrapUntrusted, UNTRUSTED_DATA_RULE } from "../promptSafety.ts";
+import { resolveCapability } from "../capabilities.ts";
 import { generateFor } from "../gateway.ts";
 import { isMockMode, safeParseJson } from "./shared.ts";
 
@@ -42,22 +45,12 @@ export async function rerankCandidates(
   plan?: QueryPlan | null,
   signal?: AbortSignal,
 ): Promise<SemanticMatchResult[]> {
-  if (isMockMode()) {
-    log.warn(
-      "AIService",
-      "Using mock rerank response due to unconfigured AI provider",
+  signal?.throwIfAborted();
+  if (isMockMode())
+    throw new AppError(
+      "AI search is unavailable. Showing keyword results.",
+      503,
     );
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    if (candidates.length > 0) {
-      return [
-        {
-          contact_id: candidates[0].id,
-          reason: "Mock result: AI provider not configured.",
-        },
-      ];
-    }
-    return [];
-  }
 
   if (candidates.length === 0) return [];
 
@@ -140,6 +133,8 @@ Return a JSON array of VERIFIED matches with field-level evidence. If no candida
     prompt,
     responseFormat: "json",
     signal,
+    timeoutMs: 8_000,
+    maxOutputTokens: 3_000,
     jsonSchema: {
       type: "array",
       items: {
@@ -155,16 +150,31 @@ Return a JSON array of VERIFIED matches with field-level evidence. If no candida
     },
   });
 
-  interface VerifiedMatch extends SemanticMatchResult {
-    verified_field?: string;
-    verified_value?: string;
-  }
-
-  const parsed = safeParseJson<VerifiedMatch[]>(
-    result.text,
-    "rerankCandidates",
-  );
-  if (!parsed) return [];
+  signal?.throwIfAborted();
+  const parsedResult = z
+    .array(
+      z.object({
+        contact_id: z.string().min(1).max(100),
+        reason: z.string().trim().min(1).max(600),
+        verified_field: z.enum([
+          "name",
+          "role",
+          "headline",
+          "company",
+          "location",
+          "about",
+          "industry",
+          "preferences",
+          "interests",
+        ]),
+        verified_value: z.string().trim().min(1).max(600),
+      }),
+    )
+    .max(30)
+    .safeParse(safeParseJson<unknown>(result.text, "rerankCandidates"));
+  if (!parsedResult.success)
+    throw new AppError("AI returned invalid search evidence", 502);
+  const parsed = parsedResult.data;
 
   // ── Server-side evidence verification ───────────────────────────────────
   // We re-check the LLM's claimed evidence against the actual candidate
@@ -179,8 +189,8 @@ Return a JSON array of VERIFIED matches with field-level evidence. If no candida
     if (!haystack || !needle) return false;
     const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     return new RegExp(
-      `(?:^|[^a-zA-Z0-9])${escaped}(?=[^a-zA-Z0-9]|$)`,
-      "i",
+      `(?:^|[^\\p{L}\\p{N}])${escaped}(?=[^\\p{L}\\p{N}]|$)`,
+      "iu",
     ).test(haystack);
   };
 
@@ -245,7 +255,7 @@ Return a JSON array of VERIFIED matches with field-level evidence. If no candida
       droppedHardConstraint++;
       continue;
     }
-    if (plan?.must.companyMatchers?.length && cand.company) {
+    if (plan?.must.companyMatchers?.length) {
       const ok = plan.must.companyMatchers.some((mat) =>
         wordBoundaryMatch(cand.company ?? "", mat),
       );
@@ -266,6 +276,16 @@ Return a JSON array of VERIFIED matches with field-level evidence. If no candida
       }
     }
 
+    if (
+      plan?.must.industryMatchers?.length &&
+      !plan.must.industryMatchers.some(
+        (matcher) =>
+          wordBoundaryMatch(cand.industry ?? "", matcher) ||
+          wordBoundaryMatch(cand.interests ?? "", matcher),
+      )
+    )
+      continue;
+    if (filtered.some((item) => item.contact_id === m.contact_id)) continue;
     filtered.push({ contact_id: m.contact_id, reason: m.reason });
   }
 
@@ -381,27 +401,20 @@ export async function synthesizeSearchResults(
     aiReason?: string;
   }[],
   plan?: QueryPlan | null,
+  signal?: AbortSignal,
 ): Promise<string> {
-  if (isMockMode()) {
-    log.warn(
-      "AIService",
-      "Using mock synthesis due to unconfigured AI provider",
-    );
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    if (contacts.length === 0) {
-      return `No contacts matched "${query}". Try rephrasing or broadening the search.`;
-    }
-    return (
-      `You have ${contacts.length} connections matching "${query}". ` +
-      `Key figures include ${contacts
-        .slice(0, 3)
-        .map((c) => c.name)
-        .join(", ")}. ` +
-      `Consider reaching out to strengthen these relationships.`
-    );
-  }
-
-  const cacheKey = query.trim().toLowerCase().replace(/\s+/g, " ");
+  signal?.throwIfAborted();
+  if (isMockMode()) throw new AppError("AI summary is unavailable", 503);
+  const capability = resolveCapability("quick");
+  const cacheKey = contentHash(
+    JSON.stringify([
+      query.trim().toLowerCase(),
+      contacts,
+      plan,
+      capability?.providerId,
+      capability?.model,
+    ]),
+  );
   const cached = aiCache.get<string>("synthesis", cacheKey);
   if (cached) {
     recordInvocation({
@@ -461,7 +474,7 @@ export async function synthesizeSearchResults(
 You are a CRM intelligence analyst. You produce a 2-3 sentence grounded executive brief about a set of contacts that match a query.
 
 CRITICAL GROUNDING RULES:
-1. NEVER make a claim that does not apply to AT LEAST 80% of the contacts shown. If you say "based in America", check every contact's [location:] tag.
+1. Every factual claim must follow from the supplied fields. State counts exactly. Describe mixed groups explicitly.
 2. NEVER invent fields you can't see. No claims about industries, roles, or seniority unless they appear in the contact summaries.
 3. If contacts span multiple regions, industries, or companies, SAY SO — do not project a false homogeneity.
 4. Write in second person ("You have...", "Your strongest...").
@@ -487,8 +500,12 @@ Write a 2-3 sentence executive brief. Every claim must be true for the contacts 
       systemPrompt,
       prompt,
       responseFormat: "text",
+      maxOutputTokens: 1500,
+      signal,
+      timeoutMs: 8_000,
     });
 
+    signal?.throwIfAborted();
     const text = result.text?.trim();
     if (!text) throw new Error("Empty synthesis response");
 
@@ -548,11 +565,20 @@ Write a 2-3 sentence executive brief. Every claim must be true for the contacts 
  */
 export async function parseSearchQuery(
   query: string,
+  signal?: AbortSignal,
 ): Promise<QueryPlan | null> {
+  signal?.throwIfAborted();
   const trimmed = query.trim();
   if (trimmed.length < 2) return null;
 
-  const cacheKey = contentHash(trimmed.toLowerCase());
+  const capability = resolveCapability("quick");
+  const cacheKey = contentHash(
+    JSON.stringify([
+      trimmed.toLowerCase(),
+      capability?.providerId,
+      capability?.model,
+    ]),
+  );
   const cached = aiCache.get<QueryPlan>("queryParse", cacheKey);
   if (cached) {
     recordInvocation({
@@ -619,7 +645,9 @@ Return the structured QueryPlan JSON.`;
       systemPrompt,
       prompt,
       responseFormat: "json",
-      timeoutMs: 6_000,
+      timeoutMs: 4_000,
+      maxOutputTokens: 2_000,
+      signal,
       jsonSchema: {
         type: "object",
         properties: {
@@ -659,8 +687,29 @@ Return the structured QueryPlan JSON.`;
       },
     });
 
-    const raw = safeParseJson<QueryPlan>(result.text, "parseSearchQuery");
-    if (!raw) return null;
+    signal?.throwIfAborted();
+    const matcherList = z.array(z.string().max(200)).max(200).optional();
+    const parsed = z
+      .object({
+        must: z.object({
+          locationMatchers: matcherList,
+          companyMatchers: matcherList,
+          roleMatchers: matcherList,
+          industryMatchers: matcherList,
+          temporal: z
+            .object({
+              type: z.enum(["lastContact", "neverContacted"]),
+              daysAgo: z.number().int().min(0).max(36_500).optional(),
+            })
+            .optional(),
+        }),
+        should: z.object({ traits: matcherList }),
+        confidence: z.enum(["high", "medium", "low"]),
+        rationale: z.string().max(1000),
+      })
+      .safeParse(safeParseJson<unknown>(result.text, "parseSearchQuery"));
+    if (!parsed.success) return null;
+    const raw = parsed.data;
 
     // Defensive cleaning — strip empties so downstream can treat presence
     // as "filter is active". An empty list shouldn't gate anything.
@@ -668,7 +717,8 @@ Return the structured QueryPlan JSON.`;
       if (!Array.isArray(xs)) return undefined;
       const out = xs
         .map((s) => (typeof s === "string" ? s.trim() : ""))
-        .filter((s) => s.length > 0);
+        .filter((s) => s.length > 0 && s.length <= 100)
+        .slice(0, 100);
       return out.length > 0 ? out : undefined;
     };
 
@@ -699,7 +749,13 @@ Return the structured QueryPlan JSON.`;
       if (role) cleaned.must.roleMatchers = role;
       const ind = cleanList(raw.must.industryMatchers);
       if (ind) cleaned.must.industryMatchers = ind;
-      if (raw.must.temporal?.type) cleaned.must.temporal = raw.must.temporal;
+      const temporal = z
+        .object({
+          type: z.enum(["lastContact", "neverContacted"]),
+          daysAgo: z.number().int().min(0).max(36_500).optional(),
+        })
+        .safeParse(raw.must.temporal);
+      if (temporal.success) cleaned.must.temporal = temporal.data;
     }
 
     if (raw.should) {
@@ -729,6 +785,7 @@ Return the structured QueryPlan JSON.`;
     });
     return cleaned;
   } catch (err: unknown) {
+    signal?.throwIfAborted();
     log.warn(
       "AIService",
       `parseSearchQuery failed: ${getErrorMessage(err)} — caller should run hybrid search without hard filters`,

--- a/server/ai/types.ts
+++ b/server/ai/types.ts
@@ -77,6 +77,9 @@ export interface AIGenerateOptions {
    */
   timeoutMs?: number;
 
+  /** Maximum output tokens for this generation. */
+  maxOutputTokens?: number;
+
   /**
    * Caller cancellation signal. When the signal aborts (e.g. the HTTP client
    * disconnected) the active SDK call is cancelled and no further retries
@@ -274,6 +277,7 @@ export interface MentionEntity {
  */
 export interface CompressedContact {
   id: string;
+  headline?: string;
   name: string;
   role?: string;
   company?: string;

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -1,3 +1,6 @@
+import { sqlite } from "../db.ts";
+import { ACTIVE_CONTACT_SQL } from "../services/search/ftsIndex.ts";
+import { withTimeout } from "../ai/resilience.ts";
 import type { FacetFilter } from "../../shared/searchFacets.ts";
 import { z } from "zod";
 import { ValidationError } from "../utils/AppError.ts";
@@ -6,7 +9,7 @@ import { log } from "../utils/logger.ts";
 import { searchService } from "../services/searchService.ts";
 import { AppError } from "../utils/AppError.ts";
 import { asyncHandler } from "../utils/asyncHandler.ts";
-import { parseSearchQuery, synthesizeSearchResults } from "../ai/index.ts";
+import { synthesizeSearchResults } from "../ai/index.ts";
 import { getErrorMessage } from "../utils/helpers.ts";
 
 const router = Router();
@@ -61,17 +64,7 @@ router.get(
   }),
 );
 
-/**
- * POST /api/search/semantic — Ask Contrack v3 two-phase streaming search.
- *
- * Streams NDJSON (newline-delimited JSON):
- *   Phase 1: { phase: "instant", matches: [...] }   — sent in <15ms
- *   Phase 2: { phase: "enriched", matches: [...] }  — sent ~500ms later (optional)
- *   Final:   { phase: "complete", matches: [...] }   — for cache hits + short-circuits
- *
- * If the client sends `Accept: application/json`, falls back to the
- * non-streaming single-response mode for backward compatibility.
- */
+/** Stream local candidates before AI refinement, followed by one terminal result. */
 router.post(
   "/semantic",
   asyncHandler(async (req, res) => {
@@ -94,29 +87,48 @@ router.post(
       // Two-phase streaming response
       res.setHeader("Content-Type", "application/x-ndjson");
       res.setHeader("Transfer-Encoding", "chunked");
-      res.setHeader("Cache-Control", "no-cache");
+      res.setHeader("Cache-Control", "no-store");
+      res.setHeader("X-Accel-Buffering", "no");
       res.flushHeaders();
 
       // Create an AbortController bound to request closure
       const controller = new AbortController();
-      req.on("close", () => {
+      const onClose = () => {
         log.info(
           "API",
           `[${rid}] Client disconnected mid-search stream. Aborting AI operations.`,
         );
-        controller.abort();
-      });
+        if (!res.writableEnded) controller.abort();
+      };
+      res.on("close", onClose);
 
-      await searchService.semanticSearchStream(
-        query,
-        rid,
-        res,
-        controller.signal,
-      );
+      try {
+        await searchService.semanticSearchStream(
+          query,
+          rid,
+          res,
+          controller.signal,
+        );
+      } finally {
+        res.off("close", onClose);
+      }
     } else {
       // Single-response mode (backward compatible)
-      const result = await searchService.semanticSearch(query, rid);
-      res.json(result);
+      const controller = new AbortController();
+      const onClose = () => {
+        if (!res.writableEnded) controller.abort();
+      };
+      res.on("close", onClose);
+      try {
+        const result = await searchService.semanticSearch(
+          query,
+          rid,
+          controller.signal,
+        );
+        if (!res.destroyed) res.json(result);
+      } finally {
+        res.off("close", onClose);
+      }
     }
   }),
 );
@@ -127,7 +139,7 @@ router.post(
  * Accepts a query and the already-returned search results, streams an
  * NDJSON executive summary via the AI service.
  *
- * Body: { query: string, contacts: { name, role?, company?, aiReason? }[] }
+ * Body: { query: string, contactIds: string[] }. Facts come from the database.
  *
  * Streams:
  *   { phase: "start" }
@@ -137,60 +149,74 @@ router.post(
   "/synthesize",
   asyncHandler(async (req, res) => {
     const rid = req.requestId;
-    const { query, contacts } = req.body as {
-      query?: string;
-      contacts?: {
-        name: string;
-        role?: string;
-        company?: string;
-        location?: string;
-        aiReason?: string;
-      }[];
-    };
-
-    if (!query || typeof query !== "string" || query.trim().length === 0) {
-      throw new AppError("query is required", 400);
-    }
-    if (!contacts || !Array.isArray(contacts) || contacts.length === 0) {
+    const { query, contactIds } = z
+      .object({
+        query: z.string().trim().min(1).max(500),
+        contactIds: z.array(z.string().trim().min(1).max(100)).min(1).max(30),
+      })
+      .parse(req.body);
+    const ids = [...new Set(contactIds)];
+    const contacts = sqlite
+      .prepare(
+        `SELECT c.id,c.name,c.role,c.company,c.location FROM contacts c WHERE ${ACTIVE_CONTACT_SQL} AND c.id IN (SELECT value FROM json_each(?))`,
+      )
+      .all(JSON.stringify(ids)) as {
+      id: string;
+      name: string;
+      role?: string;
+      company?: string;
+      location?: string;
+    }[];
+    if (contacts.length !== ids.length)
       throw new AppError(
-        "contacts array is required and must be non-empty",
-        400,
+        "Some contacts are no longer available. Search again.",
+        409,
       );
-    }
-    if (contacts.length > 30) {
-      throw new AppError("contacts array must have ≤ 30 entries", 400);
-    }
-
-    log.info(
-      "API",
-      `[${rid}] POST /api/search/synthesize query="${query.slice(0, 50)}" contacts=${contacts.length}`,
-    );
+    const source = JSON.stringify(contacts);
+    const controller = new AbortController();
+    const onClose = () => {
+      if (!res.writableEnded) controller.abort();
+    };
+    res.on("close", onClose);
 
     // Stream the response
     res.setHeader("Content-Type", "application/x-ndjson");
     res.setHeader("Transfer-Encoding", "chunked");
-    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Cache-Control", "no-store");
+    res.setHeader("X-Accel-Buffering", "no");
     res.flushHeaders();
 
     // Send start signal
     res.write(JSON.stringify({ phase: "start" }) + "\n");
 
     try {
-      // Re-derive the QueryPlan so the synthesizer can ground itself
-      // against the same hard filters that the retrieval applied. The
-      // parser is cached (24h TTL by content-hash) so this is ~free on
-      // the typical synthesize-after-search flow.
-      const plan = await parseSearchQuery(query.trim());
-      const text = await synthesizeSearchResults(query.trim(), contacts, plan);
-      res.write(JSON.stringify({ phase: "complete", text }) + "\n");
+      const text = await withTimeout(
+        (signal) => synthesizeSearchResults(query, contacts, null, signal),
+        10_000,
+        controller.signal,
+      );
+      const current = sqlite
+        .prepare(
+          `SELECT c.id,c.name,c.role,c.company,c.location FROM contacts c WHERE ${ACTIVE_CONTACT_SQL} AND c.id IN (SELECT value FROM json_each(?))`,
+        )
+        .all(JSON.stringify(ids));
+      if (JSON.stringify(current) !== source)
+        throw new Error("Contacts changed. Generate a new summary.");
+      if (!res.destroyed)
+        res.write(JSON.stringify({ phase: "complete", text }) + "\n");
     } catch (err: unknown) {
       log.error("API", `[${rid}] Synthesis failed: ${getErrorMessage(err)}`);
-      res.write(
-        JSON.stringify({ phase: "error", error: getErrorMessage(err) }) + "\n",
-      );
+      if (!res.destroyed)
+        res.write(
+          JSON.stringify({
+            phase: "error",
+            error: "Could not create a summary. Please try again.",
+          }) + "\n",
+        );
     }
 
-    res.end();
+    res.off("close", onClose);
+    if (!res.destroyed) res.end();
   }),
 );
 

--- a/server/services/search/hybridRetrieval.ts
+++ b/server/services/search/hybridRetrieval.ts
@@ -1,44 +1,6 @@
-// =============================================================================
-// Hybrid Retrieval Engine v5 — "Plan → Filter → Rank → Verify"
-// =============================================================================
-// The retrieval backbone of "Ask Contrack" and the command palette AI mode.
-// Designed for sub-1s latency on a ~960 contact local-first CRM.
-//
-// v5 changes (Plan/Verify architecture):
-// - The LLM query planner emits a QueryPlan with `must` (hard) and `should`
-//   (soft) buckets. `must.*Matchers` arrays are applied as HARD pre-filters
-//   via word-boundary substring matching against the relevant contact field
-//   BEFORE FTS5/vector run. This is the architectural fix for false
-//   positives like "Sydney" surfacing on "Who lives in America?".
-// - The QueryPlan is returned in RetrievalResult so the reranker can
-//   verify per-filter and the synthesizer can ground its claims.
-// - `should.traits` remains a soft RRF boost channel (descriptive intent).
-// - When AI is unavailable OR the planner reports low confidence, we run
-//   pure hybrid search (FTS + HyDE-vector) without hard filters — the
-//   pipeline still produces results.
-// - Removed the legacy regex `extractPreFilters` soft boost — the planner
-//   subsumes it. Regex is no longer in the hot path.
-//
-// Carried over:
-// - Local embeddings via Transformers.js (zero embed-side API dependency)
-// - HyDE-expanded query for vector channel
-// - RRF k=15 for sharper discrimination on small datasets
-// - Weighted BM25 for column-priority FTS5 scoring
-// - High-confidence FTS short-circuit (skip LLM rerank for exact matches)
-//
-// Pipeline:
-//   1. Parallel LLM augmentation (parseSearchQuery → QueryPlan,
-//      expandQueryForEmbedding → HyDE doc)
-//   2. Build the candidate corpus:
-//        - if plan has hard filters AND confidence != low:
-//            JS-side word-boundary filter on relevant columns → Set<id>
-//        - else: null (= no pre-filter, full corpus)
-//   3. FTS5 weighted search (within filtered corpus, raw query)
-//   4. Vector KNN of HyDE-expanded query (within filtered corpus)
-//   5. should.traits soft boost channels (only over the filtered corpus)
-//   6. RRF fusion (k=15) over all channels
-//   7. Confidence signal → decides if LLM reranker is needed downstream
-// =============================================================================
+// Hybrid retrieval applies a bounded AI query plan, then combines local
+// keyword and vector rankings. SearchService sends local results before this
+// stage starts. Every semantic result still requires verified field evidence.
 
 import { sqlite } from "../../db.ts";
 import { lexicalSearch } from "./lexical.ts";
@@ -51,10 +13,7 @@ import {
   getSearchEmbeddingCount,
 } from "./localEmbeddings.ts";
 import { getErrorMessage } from "../../utils/helpers.ts";
-import {
-  parseSearchQuery,
-  expandQueryForEmbedding,
-} from "../../ai/aiService.ts";
+import { parseSearchQuery } from "../../ai/aiService.ts";
 import type { QueryPlan } from "../../ai/types.ts";
 
 // =============================================================================
@@ -71,7 +30,7 @@ export interface RetrievalCandidate {
 
 export interface RetrievalResult {
   candidates: RetrievalCandidate[];
-  /** If true, FTS5 returned high-confidence exact matches — skip LLM reranker */
+  /** Semantic candidates require downstream evidence verification. */
   highConfidence: boolean;
   /** Pre-filter summary for logs and debug UI. */
   preFilterSummary: string;
@@ -106,13 +65,6 @@ const FTS_LIMIT = 100;
 
 /** Max vector neighbors */
 const VECTOR_LIMIT = 100;
-
-/**
- * High-confidence threshold: if ≥ this fraction of candidates came from
- * the FTS5 channel, the query is likely a keyword/exact match
- * and we can skip the LLM reranker.
- */
-const HIGH_CONFIDENCE_FTS_RATIO = 0.85;
 
 /** Limit per soft boost channel — keeps RRF math bounded. */
 const BOOST_LIMIT = 50;
@@ -423,35 +375,17 @@ export function reciprocalRankFusion(
 // Main Entry Point
 // =============================================================================
 
-/**
- * Run the v5 hybrid retrieval pipeline.
- *
- * 1. Parallel LLM augmentation:
- *      a. parseSearchQuery   → QueryPlan  (~150-300ms, cached 24h)
- *      b. expandQueryForEmbedding → HyDE doc (~150-300ms, cached 24h)
- *    Both gracefully degrade — pipeline still runs without them.
- *
- * 2. Hard pre-filter: QueryPlan.must.*Matchers applied JS-side via
- *    word-boundary regex. Empty result set short-circuits the search.
- *
- * 3. FTS5 weighted BM25 within the filtered corpus.
- * 4. Local vector KNN of HyDE-expanded query within the filtered corpus.
- * 5. should.traits soft boost channels within the filtered corpus.
- * 6. RRF fusion (k=15).
- * 7. High-confidence detection for downstream LLM rerank decision.
- *
- * Total: ~300-600ms with AI (cache cold), ~10-30ms cached.
- */
+/** Apply hard filters before keyword/vector limits, then fuse ranked candidates. */
 export async function hybridRetrieval(
   query: string,
   rid: string,
+  signal?: AbortSignal,
 ): Promise<RetrievalResult> {
   const t0 = Date.now();
 
-  const [plan, hypoDoc] = await Promise.all([
-    parseSearchQuery(query),
-    expandQueryForEmbedding(query),
-  ]);
+  signal?.throwIfAborted();
+  const plan = await parseSearchQuery(query, signal);
+  signal?.throwIfAborted();
 
   // ── Phase 0: hard pre-filter ──────────────────────────────────────────
   let allowedIds: Set<string> | null = null;
@@ -479,8 +413,7 @@ export async function hybridRetrieval(
     }
   }
 
-  const embedInput = hypoDoc ?? query;
-  const usingHyde = !!hypoDoc;
+  const embedInput = [query, ...(plan?.should.traits ?? [])].join(". ");
 
   // ── Phase 1: parallel retrieval (within filtered corpus) ──────────────
   const [ftsResults, vectorResults] = await Promise.all([
@@ -489,6 +422,7 @@ export async function hybridRetrieval(
   ]);
 
   // ── Phase 1c: soft boost channels (traits) ─────────────────────────────
+  signal?.throwIfAborted();
   const traitBoosts = plan ? buildTraitBoosts(plan, allowedIds) : [];
 
   // ── Phase 2: RRF fusion across FTS + vector + trait boosts ────────────
@@ -499,23 +433,15 @@ export async function hybridRetrieval(
   ]);
 
   // ── Phase 3: confidence assessment ─────────────────────────────────────
-  // Dominant FTS = exact keyword match → LLM reranker is unnecessary.
-  // We also skip the short-circuit when hard filters are active and the
-  // result set is large enough that the rerank-as-verifier is worth doing.
-  const ftsCount = fused.filter((c) => c.channels.includes("fts")).length;
-  const highConfidence =
-    fused.length > 0 &&
-    ftsCount / fused.length >= HIGH_CONFIDENCE_FTS_RATIO &&
-    ftsResults.length >= 2 &&
-    // Hard filters mean we WANT the LLM verifier to run — don't bypass.
-    allowedIds === null;
+  // A high FTS ratio does not prove a natural-language constraint.
+  // The service uses a separate local name-prefix shortcut.
+  const highConfidence = false;
 
   const elapsed = Date.now() - t0;
   log.info(
     "HybridRetrieval",
     `[${rid}] "${query.slice(0, 60)}" → ` +
       `FTS:${ftsResults.length} + Vec:${vectorResults.length}` +
-      `${usingHyde ? "(hyde)" : "(raw)"}` +
       ` + Traits:${traitBoosts.length}ch ` +
       `→ ${fused.length} fused in ${elapsed}ms ` +
       `(plan: ${plan ? `conf=${plan.confidence}` : "none"}, ` +

--- a/server/services/searchService.ts
+++ b/server/services/searchService.ts
@@ -1,25 +1,4 @@
 import { matchesFacet, type FacetFilter } from "../../shared/searchFacets.ts";
-// =============================================================================
-// Search Service — Ask Contrack v3 "Spotlight" Pipeline Orchestrator
-// =============================================================================
-// Orchestrates the full Ask Contrack search pipeline with two-phase delivery:
-//
-//   Cache → Pre-Filter → Hybrid Retrieval → Hydrate → Deliver Phase 1 (instant)
-//                                                    → LLM Rerank → Deliver Phase 2 (async enriched)
-//
-// v3 "Spotlight" Architecture:
-// - Phase 1 renders results to the user in <15ms (zero API calls)
-// - Phase 2 streams AI reasons back asynchronously (~500ms later)
-// - Short-circuit bypass: skip LLM for high-confidence keyword matches
-// - SQL pre-filters via chrono-node, not parallel RRF channel
-// - Local embeddings via Transformers.js, not Gemini API
-//
-// Graceful degradation at each stage:
-// - Local model not loaded → skip vector channel, use FTS5 only
-// - LLM reranking fails   → keep Phase 1 results (no AI reasons)
-// - Everything fails       → FTS5 keyword fallback
-// =============================================================================
-
 import { sqlite } from "../db.ts";
 import { lexicalSearch } from "./search/lexical.ts";
 import { ACTIVE_CONTACT_SQL } from "./search/ftsIndex.ts";
@@ -27,13 +6,11 @@ import { log } from "../utils/logger.ts";
 import { contactRepo } from "../repositories/contactRepository.ts";
 import { rerankCandidates, type CompressedContact } from "../ai/aiService.ts";
 import { getCachedSearch, setCachedSearch } from "../utils/aiCache.ts";
-import {
-  hybridRetrieval,
-  type RetrievalResult,
-} from "./search/hybridRetrieval.ts";
+import { hybridRetrieval } from "./search/hybridRetrieval.ts";
 import type { Response } from "express";
 import { getErrorMessage } from "../utils/helpers.ts";
-import { recordInvocation } from "./aiStatsService.ts";
+import { resolveCapability } from "../ai/capabilities.ts";
+import { withTimeout } from "../ai/resilience.ts";
 
 // =============================================================================
 // Constants
@@ -111,83 +88,163 @@ function hydrateCandidates(
  * Strips heavy fields (avatar, timestamps, child arrays) to minimize token usage.
  */
 function buildCompressedCandidates(
-  candidateIds: string[],
-  limit: number,
+  matches: HydratedMatch[],
 ): CompressedContact[] {
-  const tagsStmt = sqlite.prepare(
-    "SELECT tag FROM contact_tags WHERE contactId = ?",
-  );
-  const interestsStmt = sqlite.prepare(
-    "SELECT interest FROM contact_interests WHERE contactId = ?",
-  );
-
   const compressed: CompressedContact[] = [];
-
-  for (const id of candidateIds.slice(0, limit)) {
-    const row = sqlite
-      .prepare(
-        "SELECT id, name, role, company, location, about, industry, preferences FROM contacts WHERE id = ?",
-      )
-      .get(id) as
-      | {
-          id: string;
-          name: string;
-          role: string | null;
-          company: string | null;
-          location: string | null;
-          about: string | null;
-          industry: string | null;
-          preferences: string | null;
-        }
-      | undefined;
-    if (!row) continue;
-
-    const tags = (tagsStmt.all(id) as { tag: string }[]).map((t) => t.tag);
-    const interests = (interestsStmt.all(id) as { interest: string }[]).map(
-      (t) => t.interest,
-    );
-
-    const entry: CompressedContact = { id: row.id, name: row.name };
-    if (row.role) entry.role = row.role;
-    if (row.company) entry.company = row.company;
-    if (row.location) entry.location = row.location;
-    if (row.about) entry.about = row.about;
-    if (row.industry) entry.industry = row.industry;
-    if (row.preferences) entry.preferences = row.preferences;
-    if (tags.length || interests.length)
-      entry.interests = [...tags, ...interests].join(", ");
+  let size = 2;
+  for (const match of matches.slice(0, RERANKER_LIMIT)) {
+    const entry: CompressedContact = {
+      id: match.id,
+      name: match.name.slice(0, 160),
+    };
+    for (const field of [
+      "headline",
+      "role",
+      "company",
+      "location",
+      "about",
+      "industry",
+      "preferences",
+    ] as const) {
+      if (typeof match[field] === "string")
+        entry[field] = match[field].slice(0, field === "about" ? 500 : 200);
+    }
+    const tags = Array.isArray(match.tags) ? match.tags : [];
+    const interests = Array.isArray(match.interests) ? match.interests : [];
+    entry.interests = [
+      ...tags.map((t) => t.tag),
+      ...interests.map((t) => t.interest),
+    ]
+      .filter((v) => typeof v === "string")
+      .join(", ")
+      .slice(0, 400);
+    const bytes = JSON.stringify(entry).length + 1;
+    if (size + bytes > 23_000) break;
     compressed.push(entry);
+    size += bytes;
   }
-
   return compressed;
 }
 
-/**
- * Hydrate AI reranker results into full contact objects with AI reasons.
- */
-function hydrateAiMatches(
-  aiMatches: { contact_id: string; reason: string }[],
-): HydratedMatch[] {
-  if (!aiMatches.length) return [];
-  const ids = aiMatches.map((m) => m.contact_id);
-  const placeholders = ids.map(() => "?").join(",");
+function searchRevision(): number {
+  return (
+    sqlite.prepare("SELECT revision FROM search_revision WHERE id=1").get() as {
+      revision: number;
+    }
+  ).revision;
+}
 
-  const rows = sqlite
-    .prepare(
-      `SELECT c.* FROM contacts c WHERE c.id IN (${placeholders}) AND ${ACTIVE_CONTACT_SQL}`,
-    )
-    .all(ids);
-  const hydratedRows = contactRepo.hydrateMany(rows);
+interface SearchResult {
+  matches: HydratedMatch[];
+  fallback: boolean;
+  cached?: boolean;
+}
+interface SearchChunk extends SearchResult {
+  phase: "instant" | "complete";
+  latencyMs?: number;
+}
 
-  const hydratedMap = new Map(hydratedRows.map((r) => [r.id, r]));
-
-  return aiMatches
-    .map((m) => {
-      const fullContact = hydratedMap.get(m.contact_id);
-      if (!fullContact) return null;
-      return { ...fullContact, aiReason: m.reason };
+/** A short name prefix can use the local index without an AI generation. */
+function isNameLookup(query: string, matches: HydratedMatch[]): boolean {
+  const tokens = query.toLocaleLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+  return (
+    matches.length > 0 &&
+    tokens.length > 0 &&
+    tokens.length <= 3 &&
+    matches.every((match) => {
+      const names =
+        match.name.toLocaleLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+      return tokens.every((token) =>
+        names.some((name) => name.startsWith(token)),
+      );
     })
-    .filter(Boolean) as HydratedMatch[];
+  );
+}
+
+/** One pipeline supplies both streaming and JSON callers. */
+async function runSearch(
+  query: string,
+  rid: string,
+  emit?: (chunk: SearchChunk) => void,
+  signal?: AbortSignal,
+): Promise<SearchResult> {
+  signal?.throwIfAborted();
+  const start = Date.now();
+  const revision = searchRevision();
+  const capability = resolveCapability("quick");
+  const cacheKey = `${revision}:${Math.floor(start / 300_000)}:${capability?.providerId}:${capability?.model}:${query.trim().toLowerCase()}`;
+  const cached = getCachedSearch(cacheKey);
+  if (cached)
+    return {
+      ...cached,
+      matches: cached.matches as HydratedMatch[],
+      cached: true,
+    };
+  const keyword = searchService.searchFts(query);
+  if (isNameLookup(query, keyword)) {
+    const result = { matches: keyword, fallback: false };
+    setCachedSearch(cacheKey, result);
+    return result;
+  }
+  emit?.({
+    phase: "instant",
+    matches: keyword,
+    fallback: true,
+    latencyMs: Date.now() - start,
+  });
+  let result: SearchResult;
+  try {
+    result = await withTimeout(
+      async (budget) => {
+        const retrieval = await hybridRetrieval(query, rid, budget);
+        budget.throwIfAborted();
+        if (!retrieval.candidates.length)
+          return { matches: [], fallback: false };
+        const candidates = [
+          ...hydrateCandidates(
+            retrieval.candidates.map((c) => c.contactId),
+            PHASE1_LIMIT,
+          ).values(),
+        ];
+        const verified = await rerankCandidates(
+          query,
+          buildCompressedCandidates(candidates),
+          retrieval.plan,
+          budget,
+        );
+        budget.throwIfAborted();
+        const allowed = new Set(candidates.map((c) => c.id));
+        const fresh = hydrateCandidates(
+          verified
+            .filter((match) => allowed.has(match.contact_id))
+            .map((match) => match.contact_id),
+          PHASE1_LIMIT,
+        );
+        return {
+          matches: verified.flatMap((match) => {
+            const contact = fresh.get(match.contact_id);
+            return contact ? [{ ...contact, aiReason: match.reason }] : [];
+          }),
+          fallback: false,
+        };
+      },
+      12_000,
+      signal,
+    );
+  } catch (error) {
+    signal?.throwIfAborted();
+    log.warn(
+      "SemanticSearch",
+      `[${rid}] AI refinement unavailable: ${getErrorMessage(error)}`,
+    );
+    result = { matches: searchService.searchFts(query), fallback: true };
+  }
+  signal?.throwIfAborted();
+  // A concurrent edit invalidates all evidence gathered before that edit.
+  if (searchRevision() !== revision)
+    return { matches: searchService.searchFts(query), fallback: true };
+  if (!result.fallback) setCachedSearch(cacheKey, result);
+  return result;
 }
 
 // =============================================================================
@@ -232,319 +289,40 @@ export const searchService = {
     return [...hydrateCandidates(ids, 20).values()];
   },
 
-  // ===========================================================================
-  // Ask Contrack v3 — Two-Phase Streaming Pipeline
-  // ===========================================================================
-
-  /**
-   * Execute the full search pipeline and stream results in two phases:
-   *
-   * Phase 1 (instant, <15ms):
-   *   Hybrid retrieval + hydration → send immediately (top 30 candidates)
-   *
-   * Phase 2 (async, ~500ms, optional):
-   *   LLM reranks top candidates → stream enriched results
-   *
-   * Uses NDJSON (newline-delimited JSON) for streaming.
-   */
+  /** Stream local candidates, then one terminal result. Never write after disconnect. */
   async semanticSearchStream(
     query: string,
     rid: string,
     res: Response,
     signal?: AbortSignal,
   ) {
-    const startTime = Date.now();
-    const revision = (
-      sqlite
-        .prepare("SELECT revision FROM search_revision WHERE id = 1")
-        .get() as { revision: number }
-    ).revision;
-    const cacheKey = `${revision}:${Math.floor(startTime / 300_000)}:${query.trim().toLowerCase()}`;
-
-    // ── 1. Cache check ─────────────────────────────────────────────────
-    const cached = getCachedSearch(cacheKey);
-    if (cached) {
-      log.info(
-        "SemanticSearch",
-        `[${rid}] Cache HIT for "${query.trim().slice(0, 60)}" (${Date.now() - startTime}ms)`,
-      );
-      recordInvocation({
-        operation: "rerank",
-        latencyMs: Date.now() - startTime,
-        cached: true,
-        description: `Rerank cache hit: "${query.slice(0, 40)}"`,
-      });
-      res.write(
-        JSON.stringify({
-          phase: "complete",
-          matches: cached.matches,
-          fallback: cached.fallback,
-          cached: true,
-          latencyMs: Date.now() - startTime,
-        }) + "\n",
-      );
-      res.end();
-      return;
-    }
-
-    // ── 2. Hybrid retrieval (Stage 1) ──────────────────────────────────
-    let retrieval: RetrievalResult;
+    const send = (chunk: SearchChunk) => {
+      if (!signal?.aborted && !res.destroyed && !res.writableEnded)
+        res.write(JSON.stringify(chunk) + "\n");
+    };
     try {
-      retrieval = await hybridRetrieval(query, rid);
-    } catch (err: unknown) {
-      log.error(
-        "SemanticSearch",
-        `[${rid}] Hybrid retrieval failed: ${getErrorMessage(err)}`,
-      );
-      res.write(
-        JSON.stringify({
-          phase: "complete",
-          matches: [],
-          fallback: true,
-          cached: false,
-          latencyMs: Date.now() - startTime,
-        }) + "\n",
-      );
-      res.end();
-      return;
-    }
-
-    if (retrieval.candidates.length === 0) {
-      const elapsed = Date.now() - startTime;
-      log.info(
-        "SemanticSearch",
-        `[${rid}] "${query}" → 0 candidates in ${elapsed}ms`,
-      );
-      res.write(
-        JSON.stringify({
-          phase: "complete",
-          matches: [],
-          fallback: false,
-          cached: false,
-          latencyMs: elapsed,
-        }) + "\n",
-      );
-      res.end();
-      return;
-    }
-
-    // ── 3. Hydrate top candidates ──────────────────────────────────────
-    const candidateIds = retrieval.candidates.map((c) => c.contactId);
-    const hydratedMap = hydrateCandidates(candidateIds, PHASE1_LIMIT);
-
-    // ── 4. Phase 1 (instant) — Send hydrated results immediately ──────
-    const phase1Matches = candidateIds
-      .slice(0, PHASE1_LIMIT)
-      .filter((id) => hydratedMap.has(id))
-      .map((id) => hydratedMap.get(id));
-
-    const phase1Elapsed = Date.now() - startTime;
-
-    res.write(
-      JSON.stringify({
-        phase: "instant",
-        matches: phase1Matches,
-        fallback: false,
-        cached: false,
-        candidateCount: retrieval.candidates.length,
-        highConfidence: retrieval.highConfidence,
-        latencyMs: phase1Elapsed,
-      }) + "\n",
-    );
-
-    log.info(
-      "SemanticSearch",
-      `[${rid}] Phase 1: "${query.slice(0, 50)}" → ${phase1Matches.length} results in ${phase1Elapsed}ms` +
-        (retrieval.highConfidence ? " [HIGH CONFIDENCE — skipping LLM]" : ""),
-    );
-
-    // ── 5. Short-circuit: high-confidence → skip LLM ──────────────────
-    if (retrieval.highConfidence) {
-      // Cache the high-confidence result (no need for LLM enrichment)
-      setCachedSearch(cacheKey, { matches: phase1Matches, fallback: false });
-      recordInvocation({
-        operation: "rerank",
-        latencyMs: Date.now() - startTime,
-        cached: false,
-        description: `Search: High-confidence short-circuit (skipped LLM) for "${query.slice(0, 40)}"`,
-      });
-      res.write(
-        JSON.stringify({
-          phase: "complete",
-          matches: phase1Matches,
-          fallback: false,
-          cached: false,
-          skippedLlm: true,
-          latencyMs: Date.now() - startTime,
-        }) + "\n",
-      );
-      res.end();
-      return;
-    }
-
-    // ── 6. Phase 2 (async) — LLM verification + rerank ─────────────────
-    const compressedCandidates = buildCompressedCandidates(
-      candidateIds,
-      RERANKER_LIMIT,
-    );
-
-    try {
-      const aiMatches = await rerankCandidates(
-        query.trim(),
-        compressedCandidates,
-        retrieval.plan,
-        signal,
-      );
-
-      if (aiMatches.length > 0) {
-        const enrichedMatches = hydrateAiMatches(aiMatches);
-
-        const totalElapsed = Date.now() - startTime;
-        log.info(
-          "SemanticSearch",
-          `[${rid}] Phase 2: "${query.slice(0, 50)}" → ${enrichedMatches.length} AI-enriched results in ${totalElapsed}ms`,
-        );
-
-        const result = { matches: enrichedMatches, fallback: false };
-        setCachedSearch(cacheKey, result);
-
+      const result = await runSearch(query, rid, send, signal);
+      send({ phase: "complete", ...result });
+    } catch (error) {
+      if (!signal?.aborted && !res.destroyed && !res.writableEnded)
         res.write(
           JSON.stringify({
-            phase: "enriched",
-            matches: enrichedMatches,
-            fallback: false,
-            cached: false,
-            latencyMs: totalElapsed,
+            phase: "error",
+            error: "Search failed. Please try again.",
+            requestId: rid,
           }) + "\n",
         );
-      } else {
-        // LLM returned 0 matches — keep Phase 1 results
-        setCachedSearch(cacheKey, { matches: phase1Matches, fallback: false });
-      }
-    } catch (aiErr: unknown) {
       log.warn(
         "SemanticSearch",
-        `[${rid}] LLM reranker failed (${getErrorMessage(aiErr)}), keeping Phase 1 results`,
+        `[${rid}] Search stopped: ${getErrorMessage(error)}`,
       );
-      // Phase 1 results are already sent — no action needed
+    } finally {
+      if (!res.destroyed && !res.writableEnded) res.end();
     }
-
-    res.end();
   },
 
-  // ===========================================================================
-  // Non-streaming fallback (for tests or simple clients)
-  // ===========================================================================
-
-  /**
-   * Ask Contrack v3 — non-streaming version.
-   * Returns a single response after full pipeline completion.
-   * Used by backward-compat clients or test harness.
-   */
-  async semanticSearch(query: string, rid: string) {
-    const startTime = Date.now();
-    const revision = (
-      sqlite
-        .prepare("SELECT revision FROM search_revision WHERE id = 1")
-        .get() as { revision: number }
-    ).revision;
-    const cacheKey = `${revision}:${Math.floor(startTime / 300_000)}:${query.trim().toLowerCase()}`;
-
-    // 1. Cache check
-    const cached = getCachedSearch(cacheKey);
-    if (cached) {
-      log.info(
-        "SemanticSearch",
-        `[${rid}] Cache HIT for "${query.trim().slice(0, 60)}" (${Date.now() - startTime}ms)`,
-      );
-      recordInvocation({
-        operation: "rerank",
-        latencyMs: Date.now() - startTime,
-        cached: true,
-        description: `Rerank cache hit: "${query.slice(0, 40)}"`,
-      });
-      return { ...cached, cached: true };
-    }
-
-    // 2. Hybrid retrieval
-    const retrieval = await hybridRetrieval(query, rid);
-
-    if (retrieval.candidates.length === 0) {
-      const elapsed = Date.now() - startTime;
-      log.info(
-        "SemanticSearch",
-        `[${rid}] "${query}" → 0 candidates in ${elapsed}ms`,
-      );
-      return { matches: [], fallback: false, cached: false };
-    }
-
-    // 3. Hydrate candidates
-    const candidateIds = retrieval.candidates.map((c) => c.contactId);
-    const hydratedMap = hydrateCandidates(candidateIds, PHASE1_LIMIT);
-    const hydratedPhase1 = candidateIds
-      .slice(0, PHASE1_LIMIT)
-      .map((id) => hydratedMap.get(id))
-      .filter(Boolean);
-
-    // 4. Short-circuit if high confidence
-    if (retrieval.highConfidence) {
-      const elapsed = Date.now() - startTime;
-      log.info(
-        "SemanticSearch",
-        `[${rid}] v3 "${query}" → ${hydratedPhase1.length} results (high confidence, skipped LLM) in ${elapsed}ms`,
-      );
-      setCachedSearch(cacheKey, { matches: hydratedPhase1, fallback: false });
-      recordInvocation({
-        operation: "rerank",
-        latencyMs: elapsed,
-        cached: false,
-        description: `Search: High-confidence short-circuit (skipped LLM) for "${query.slice(0, 40)}"`,
-      });
-      return { matches: hydratedPhase1, fallback: false, cached: false };
-    }
-
-    // 5. LLM verify + rerank
-    const compressedCandidates = buildCompressedCandidates(
-      candidateIds,
-      RERANKER_LIMIT,
-    );
-
-    let fallback = false;
-    try {
-      const aiMatches = await rerankCandidates(
-        query.trim(),
-        compressedCandidates,
-        retrieval.plan,
-      );
-
-      if (aiMatches.length > 0) {
-        const enriched = hydrateAiMatches(aiMatches);
-
-        const elapsed = Date.now() - startTime;
-        log.info(
-          "SemanticSearch",
-          `[${rid}] v3 "${query}" → ${enriched.length} AI matches in ${elapsed}ms — caching`,
-        );
-
-        const result = { matches: enriched, fallback: false };
-        setCachedSearch(cacheKey, result);
-        return { ...result, cached: false };
-      }
-    } catch {
-      log.warn(
-        "SemanticSearch",
-        `[${rid}] LLM reranker failed, returning Stage 1 results`,
-      );
-      fallback = true;
-    }
-
-    // Fallback: return Phase 1 results
-    if (fallback) {
-      const capped = hydratedPhase1.slice(0, 15);
-      return { matches: capped, fallback: true, cached: false };
-    }
-
-    // LLM returned 0 matches from candidates
-    return { matches: [], fallback: false, cached: false };
+  /** Return the same final result as the streaming endpoint. */
+  semanticSearch(query: string, rid: string, signal?: AbortSignal) {
+    return runSearch(query, rid, undefined, signal);
   },
 };

--- a/src/api/ndjson.ts
+++ b/src/api/ndjson.ts
@@ -1,0 +1,49 @@
+/** Read bounded NDJSON, including a final line without a newline. Always release the reader. */
+export async function readNdjson(
+  response: Response,
+  onValue: (value: unknown) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error("The server returned an empty response.");
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let buffer = "";
+  let total = 0;
+  const consume = (line: string) => {
+    if (!line.trim()) return;
+    signal?.throwIfAborted();
+    onValue(JSON.parse(line));
+  };
+  const cancel = () => {
+    void reader.cancel(signal?.reason).catch(() => undefined);
+  };
+  signal?.addEventListener("abort", cancel, { once: true });
+  try {
+    while (true) {
+      signal?.throwIfAborted();
+      const { done, value } = await reader.read();
+      signal?.throwIfAborted();
+      if (done) {
+        buffer += decoder.decode();
+        if (buffer.trim()) consume(buffer);
+        break;
+      }
+      total += value.byteLength;
+      if (total > 16 * 1024 * 1024)
+        throw new Error("The search response is too large.");
+      buffer += decoder.decode(value, { stream: true });
+      let newline: number;
+      while ((newline = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        consume(line);
+      }
+      if (buffer.length > 4 * 1024 * 1024)
+        throw new Error("The search response is too large.");
+    }
+  } finally {
+    signal?.removeEventListener("abort", cancel);
+    await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+}

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -1,19 +1,14 @@
+import { z } from "zod";
+import { readNdjson } from "./ndjson";
 import type { FacetFilter } from "../../shared/searchFacets";
 import { apiFetch } from "./client";
-/**
- * Search API Hooks — React Query hooks for FTS5 keyword and Ask Contrack v3 semantic search.
- *
- * v3 uses NDJSON streaming for two-phase delivery:
- *   Phase 1 (instant): results appear in <15ms
- *   Phase 2 (enriched): AI reasons fade in ~500ms later
- *
- * @module api/search
- */
+/** Search hooks validate streamed results and cancel obsolete requests. */
 import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import {
   useState,
   useCallback,
   useRef,
+  useEffect,
   type Dispatch,
   type SetStateAction,
 } from "react";
@@ -67,25 +62,32 @@ export const useSemanticSearch = (externalState?: {
   const setPhase = externalState ? externalState.setPhase : setInternalPhase;
 
   const [isPending, setIsPending] = useState(false);
-  const [isError, setIsError] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
   const [isSuccess, setIsSuccess] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
+  useEffect(
+    () => () => {
+      abortRef.current?.abort();
+      abortRef.current = null;
+    },
+    [],
+  );
   const mutate = useCallback(
     async (query: string) => {
-      // Abort any in-flight request
       abortRef.current?.abort();
       const controller = new AbortController();
       abortRef.current = controller;
-
+      const current = () =>
+        abortRef.current === controller && !controller.signal.aborted;
       setIsPending(true);
-      setIsError(false);
+      setError(null);
       setIsSuccess(false);
       setPhase("idle");
       setData(null);
-
+      let complete = false;
       try {
-        const res = await apiFetch(`/search/semantic`, {
+        const response = await apiFetch("/search/semantic", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -94,70 +96,38 @@ export const useSemanticSearch = (externalState?: {
           body: JSON.stringify({ query }),
           signal: controller.signal,
         });
-
-        if (!res.ok) throw new Error("Semantic search failed");
-
-        const reader = res.body?.getReader();
-        if (!reader) throw new Error("No response body");
-
-        const decoder = new TextDecoder();
-        let buffer = "";
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-
-          // Process complete NDJSON lines
-          const lines = buffer.split("\n");
-          buffer = lines.pop() || ""; // Keep incomplete last line
-
-          for (const line of lines) {
-            if (!line.trim()) continue;
-
-            try {
-              const chunk = JSON.parse(line);
-
-              if (chunk.phase === "instant") {
-                // Phase 1: show results immediately
-                setData({
-                  matches: chunk.matches,
-                  fallback: chunk.fallback,
-                });
-                setPhase(chunk.highConfidence ? "done" : "enriching");
-                setIsSuccess(true);
-              } else if (chunk.phase === "enriched") {
-                // Phase 2: replace with AI-enriched results
-                setData({
-                  matches: chunk.matches,
-                  fallback: chunk.fallback,
-                });
-                setPhase("done");
-                setIsSuccess(true);
-              } else if (chunk.phase === "complete") {
-                // Single-phase response (cache hit or short-circuit)
-                setData({
-                  matches: chunk.matches,
-                  fallback: chunk.fallback,
-                });
-                setPhase("done");
-                setIsSuccess(true);
-              }
-            } catch {
-              // Ignore malformed lines
-            }
-          }
-        }
-      } catch (err: unknown) {
-        if (!(err instanceof Error && err.name === "AbortError")) {
-          setIsError(true);
-          console.error("Semantic search error:", err);
+        await readNdjson(
+          response,
+          (value) => {
+            if (!current()) return;
+            const chunk = searchChunkSchema.parse(value);
+            if (chunk.phase === "error") throw new Error(chunk.error);
+            if (complete)
+              throw new Error("The server sent data after search completed.");
+            setData({
+              matches:
+                chunk.matches as unknown as SemanticSearchResult["matches"],
+              fallback: chunk.fallback,
+            });
+            complete = chunk.phase === "complete" || chunk.phase === "enriched";
+            setPhase(complete ? "done" : "enriching");
+            setIsSuccess(complete);
+          },
+          controller.signal,
+        );
+        if (!complete)
+          throw new Error(
+            "The search connection ended early. Please try again.",
+          );
+      } catch (cause) {
+        if (current()) {
+          setError(cause instanceof Error ? cause : new Error("Search failed"));
+          setIsSuccess(false);
         }
       } finally {
-        if (!controller.signal.aborted) {
+        if (current()) {
           setIsPending(false);
-          setPhase((prev) => (prev === "idle" ? "done" : prev));
+          setPhase("done");
         }
       }
     },
@@ -166,10 +136,11 @@ export const useSemanticSearch = (externalState?: {
 
   const reset = useCallback(() => {
     abortRef.current?.abort();
+    abortRef.current = null;
     setData(null);
     setPhase("idle");
     setIsPending(false);
-    setIsError(false);
+    setError(null);
     setIsSuccess(false);
   }, [setData, setPhase]);
 
@@ -177,10 +148,21 @@ export const useSemanticSearch = (externalState?: {
     data,
     phase,
     isPending,
-    isError,
+    isError: !!error,
     isSuccess,
-    error: isError ? new Error("Semantic search failed") : null,
+    error,
     mutate,
     reset,
   };
 };
+
+const searchChunkSchema = z.discriminatedUnion("phase", [
+  z.object({
+    phase: z.enum(["instant", "enriched", "complete"]),
+    matches: z
+      .array(z.object({ id: z.string(), name: z.string() }).passthrough())
+      .max(30),
+    fallback: z.boolean(),
+  }),
+  z.object({ phase: z.literal("error"), error: z.string() }),
+]);

--- a/src/components/command-palette/CommandPalette.tsx
+++ b/src/components/command-palette/CommandPalette.tsx
@@ -203,19 +203,25 @@ export const CommandPalette = () => {
   // both reduces cost and dramatically improves answer quality (partial
   // queries embed/rerank poorly compared to fully-formed questions).
   useEffect(() => {
-    if (mode !== "ai" || debouncedAiQuery.length < 3) return;
+    if (
+      !open ||
+      mode !== "ai" ||
+      debouncedAiQuery.length < 3 ||
+      aiQuery !== debouncedAiQuery
+    )
+      return;
     if (debouncedAiQuery === prevAiQueryRef.current) return;
     prevAiQueryRef.current = debouncedAiQuery;
     runSemanticSearch(debouncedAiQuery);
-  }, [mode, debouncedAiQuery, runSemanticSearch]);
+  }, [open, mode, aiQuery, debouncedAiQuery, runSemanticSearch]);
 
   // Reset mutation state when mode changes away from AI
   useEffect(() => {
-    if (mode !== "ai") {
+    if (!open || mode !== "ai" || aiQuery.length < 3) {
       resetSemanticSearch();
       prevAiQueryRef.current = "";
     }
-  }, [mode, resetSemanticSearch]);
+  }, [open, mode, aiQuery, resetSemanticSearch]);
 
   // Note: normal (FTS) searches are intentionally NOT recorded on debounce.
   // Debounced recording inevitably leaks prefixes ("Ri", "Ric", "Rich"...) as
@@ -828,66 +834,67 @@ export const CommandPalette = () => {
                   )}
 
                   {/* Loading shimmer */}
-                  {aiQuery.length >= 3 && isAiLoading && (
-                    <div className="px-1 py-2 space-y-1">
-                      <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-primary flex items-center gap-1.5">
-                        <Sparkles className="w-3 h-3 animate-pulse" /> Asking
-                        AI…
+                  {aiQuery.length >= 3 &&
+                    isAiLoading &&
+                    aiResults.length === 0 && (
+                      <div className="px-1 py-2 space-y-1">
+                        <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-primary flex items-center gap-1.5">
+                          <Sparkles className="w-3 h-3 animate-pulse" /> Asking
+                          AI…
+                        </div>
+                        <AIShimmerRow delay={0} />
+                        <AIShimmerRow delay={0.08} />
+                        <AIShimmerRow delay={0.16} />
                       </div>
-                      <AIShimmerRow delay={0} />
-                      <AIShimmerRow delay={0.08} />
-                      <AIShimmerRow delay={0.16} />
-                    </div>
-                  )}
+                    )}
 
                   {/* AI results */}
-                  {aiQuery.length >= 3 &&
-                    !isAiLoading &&
-                    aiResults.length > 0 && (
-                      <Command.Group
-                        heading={
-                          aiFallback
+                  {aiQuery.length >= 3 && aiResults.length > 0 && (
+                    <Command.Group
+                      heading={
+                        isAiLoading
+                          ? "Keyword candidates · checking with AI"
+                          : aiFallback
                             ? "Keyword Results (AI Fallback)"
                             : "AI Query Results"
-                        }
-                        className={GROUP_HEADING_PRIMARY}
-                      >
-                        {aiFallback && (
-                          <div className="flex items-center gap-1.5 px-3 pb-1 text-xs text-warning">
-                            <AlertTriangle className="w-3 h-3" />
-                            <span>
-                              AI unavailable — showing keyword matches
-                            </span>
-                          </div>
-                        )}
-                        {aiResults.map((match, i) => (
-                          <AIResultCard
-                            key={match.id}
-                            match={match}
-                            index={i}
-                            isFallback={aiFallback}
-                            onSelect={() => {
-                              recordVisit(match.id);
-                              navigate(`/contact/${match.id}`);
-                              handleClose();
-                            }}
-                            hasGroundingCapacity={
-                              groundingCapacity?.hasCapacity ?? false
-                            }
-                            isEnriching={enrichContact.isPending}
-                            enrichingContactId={enrichingContactId}
-                            onRefresh={handleRefreshContact}
-                          />
-                        ))}
-                      </Command.Group>
-                    )}
+                      }
+                      className={GROUP_HEADING_PRIMARY}
+                    >
+                      {aiFallback && !isAiLoading && (
+                        <div className="flex items-center gap-1.5 px-3 pb-1 text-xs text-warning">
+                          <AlertTriangle className="w-3 h-3" />
+                          <span>AI unavailable — showing keyword matches</span>
+                        </div>
+                      )}
+                      {aiResults.map((match, i) => (
+                        <AIResultCard
+                          key={match.id}
+                          match={match}
+                          index={i}
+                          isFallback={aiFallback}
+                          onSelect={() => {
+                            recordVisit(match.id);
+                            navigate(`/contact/${match.id}`);
+                            handleClose();
+                          }}
+                          hasGroundingCapacity={
+                            groundingCapacity?.hasCapacity ?? false
+                          }
+                          isEnriching={enrichContact.isPending}
+                          enrichingContactId={enrichingContactId}
+                          onRefresh={handleRefreshContact}
+                        />
+                      ))}
+                    </Command.Group>
+                  )}
 
                   {/* Synthesis executive brief (Feature 6) */}
                   {aiQuery.length >= 3 &&
                     !isAiLoading &&
+                    !aiFallback &&
                     aiResults.length > 0 && (
                       <SynthesisBar
-                        query={aiQuery}
+                        query={debouncedAiQuery}
                         contacts={aiResults}
                         resultCount={aiResults.length}
                         compact
@@ -915,6 +922,12 @@ export const CommandPalette = () => {
                     )}
 
                   {/* No AI matches */}
+                  {semanticSearch.isError && (
+                    <div role="alert" className="px-4 py-3 text-sm text-error">
+                      {semanticSearch.error?.message ||
+                        "Search failed. Please try again."}
+                    </div>
+                  )}
                   {aiQuery.length >= 3 &&
                     !isAiLoading &&
                     aiResults.length === 0 &&

--- a/src/components/command-palette/SynthesisBar.tsx
+++ b/src/components/command-palette/SynthesisBar.tsx
@@ -1,3 +1,6 @@
+import { apiFetch } from "../../api/client";
+import { readNdjson } from "../../api/ndjson";
+import { z } from "zod";
 /**
  * SynthesisBar — Opt-in executive brief for AI search results (Feature 6).
  *
@@ -17,6 +20,7 @@ import { Sparkles, X, Loader2, AlertTriangle } from "lucide-react";
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface SynthesisContact {
+  id: string;
   name: string;
   role?: string | null;
   company?: string | null;
@@ -37,7 +41,6 @@ type SynthesisPhase = "idle" | "loading" | "complete" | "error";
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const MIN_RESULTS_FOR_SYNTHESIS = 3;
-const API_BASE = "/api";
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -52,13 +55,29 @@ export const SynthesisBar: React.FC<SynthesisBarProps> = ({
   const [errorMessage, setErrorMessage] = useState("");
   const abortRef = useRef<AbortController | null>(null);
 
+  const identity = JSON.stringify([
+    query,
+    contacts.map((c) => [
+      c.id,
+      c.name,
+      c.role,
+      c.company,
+      c.location,
+      c.aiReason,
+    ]),
+  ]);
   // Reset when query or contacts change (new search)
   useEffect(() => {
     setPhase("idle");
     setSynthesisText("");
     setErrorMessage("");
     abortRef.current?.abort();
-  }, [query, resultCount]);
+    abortRef.current = null;
+    return () => {
+      abortRef.current?.abort();
+      abortRef.current = null;
+    };
+  }, [identity]);
 
   const handleSynthesize = useCallback(async () => {
     // Abort any in-flight request
@@ -73,16 +92,10 @@ export const SynthesisBar: React.FC<SynthesisBarProps> = ({
     try {
       const payload = {
         query,
-        contacts: contacts.slice(0, 30).map((c) => ({
-          name: c.name,
-          role: c.role || undefined,
-          company: c.company || undefined,
-          location: c.location || undefined,
-          aiReason: c.aiReason || undefined,
-        })),
+        contactIds: contacts.slice(0, 30).map((contact) => contact.id),
       };
 
-      const res = await fetch(`${API_BASE}/search/synthesize`, {
+      const res = await apiFetch("/search/synthesize", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -94,38 +107,37 @@ export const SynthesisBar: React.FC<SynthesisBarProps> = ({
 
       if (!res.ok) throw new Error(`Synthesis failed (${res.status})`);
 
-      const reader = res.body?.getReader();
-      if (!reader) throw new Error("No response body");
-
-      const decoder = new TextDecoder();
-      let buffer = "";
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-          if (!line.trim()) continue;
-          try {
-            const chunk = JSON.parse(line);
-            if (chunk.phase === "complete" && chunk.text) {
-              setSynthesisText(chunk.text);
-              setPhase("complete");
-            } else if (chunk.phase === "error") {
-              setErrorMessage(chunk.error || "Unknown error");
-              setPhase("error");
-            }
-          } catch {
-            // Ignore malformed lines
+      let complete = false;
+      await readNdjson(
+        res,
+        (value) => {
+          if (controller.signal.aborted || abortRef.current !== controller)
+            return;
+          const chunk = z
+            .discriminatedUnion("phase", [
+              z.object({ phase: z.literal("start") }),
+              z.object({
+                phase: z.literal("complete"),
+                text: z.string().trim().min(1).max(20_000),
+              }),
+              z.object({ phase: z.literal("error"), error: z.string() }),
+            ])
+            .parse(value);
+          if (chunk.phase === "error") throw new Error(chunk.error);
+          if (chunk.phase === "complete") {
+            complete = true;
+            setSynthesisText(chunk.text);
+            setPhase("complete");
           }
-        }
-      }
+        },
+        controller.signal,
+      );
+      if (!complete)
+        throw new Error(
+          "The summary connection ended early. Please try again.",
+        );
     } catch (err: unknown) {
-      if (!(err instanceof Error && err.name === "AbortError")) {
+      if (!controller.signal.aborted && abortRef.current === controller) {
         setErrorMessage(
           (err instanceof Error ? err.message : String(err)) ||
             "Synthesis failed",
@@ -137,6 +149,7 @@ export const SynthesisBar: React.FC<SynthesisBarProps> = ({
 
   const handleDismiss = useCallback(() => {
     abortRef.current?.abort();
+    abortRef.current = null;
     setPhase("idle");
     setSynthesisText("");
     setErrorMessage("");

--- a/src/views/SearchView.tsx
+++ b/src/views/SearchView.tsx
@@ -145,7 +145,7 @@ export const SearchView = () => {
 
   const results = semanticSearch.data?.matches ?? [];
   const isFallback = semanticSearch.data?.fallback ?? false;
-  const isLoading = semanticSearch.isPending && semanticSearch.phase === "idle";
+  const isLoading = semanticSearch.isPending && results.length === 0;
   const isEnriching = semanticSearch.phase === "enriching";
   const hasSearched =
     semanticSearch.isSuccess || semanticSearch.isError || results.length > 0;
@@ -271,7 +271,11 @@ export const SearchView = () => {
               <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5">
                 <div className="flex items-center gap-2">
                   <span className="text-xs font-bold uppercase tracking-widest text-primary">
-                    {isFallback ? "Keyword Results" : "AI Results"}
+                    {isFallback
+                      ? isEnriching
+                        ? "Keyword candidates"
+                        : "Keyword results"
+                      : "Search results"}
                   </span>
                   <span className="text-[10px] text-on-surface-variant bg-surface-container-high px-2 py-0.5 rounded-full">
                     {results.length} match{results.length !== 1 ? "es" : ""}
@@ -283,7 +287,7 @@ export const SearchView = () => {
                     <span>Enriching with AI…</span>
                   </div>
                 )}
-                {isFallback && (
+                {isFallback && !isEnriching && (
                   <div className="flex items-center gap-1.5 text-xs text-warning">
                     <AlertTriangle className="w-3 h-3 shrink-0" />
                     <span>AI unavailable — showing keyword matches</span>

--- a/tests/contract/providers.contract.test.ts
+++ b/tests/contract/providers.contract.test.ts
@@ -90,6 +90,8 @@ describe.skipIf(!gemini.usable)("Gemini", () => {
         responseFormat: "json",
         jsonSchema: CONTACT_SCHEMA,
         model: modelFor("gemini", "gemini-3.8-flash"),
+        maxOutputTokens: 500,
+        timeoutMs: 15_000,
       });
       expectUsableExtraction(result.text);
     },

--- a/tests/integration/search.pipeline.test.ts
+++ b/tests/integration/search.pipeline.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+vi.mock("../../server/ai/aiService.ts", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("../../server/ai/aiService.ts")>();
+  return { ...original, parseSearchQuery: vi.fn(), rerankCandidates: vi.fn() };
+});
+import {
+  parseSearchQuery,
+  rerankCandidates,
+} from "../../server/ai/aiService.ts";
+import { makeTestApp } from "./helpers.ts";
+import { sqlite } from "../../server/db.ts";
+import { aiCache } from "../../server/utils/aiCache.ts";
+const app = makeTestApp();
+beforeEach(() => {
+  sqlite.prepare("DELETE FROM contacts").run();
+  aiCache.invalidateAll();
+  vi.mocked(parseSearchQuery).mockReset().mockResolvedValue(null);
+  vi.mocked(rerankCandidates).mockReset().mockResolvedValue([]);
+  sqlite
+    .prepare(
+      "INSERT INTO contacts(id,name,role,company) VALUES ('a','Alice','Engineer','Acme')",
+    )
+    .run();
+});
+const chunks = (body: string) =>
+  body
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+
+describe("Ask Contrack final results", () => {
+  it("uses no AI calls for a name lookup and caches its result", async () => {
+    const first = await request(app)
+      .post("/api/search/semantic")
+      .send({ query: "Alice" });
+    expect(first.body.matches[0].id).toBe("a");
+    expect(parseSearchQuery).not.toHaveBeenCalled();
+    expect(rerankCandidates).not.toHaveBeenCalled();
+    const second = await request(app)
+      .post("/api/search/semantic")
+      .send({ query: "Alice" });
+    expect(second.body.cached).toBe(true);
+  });
+  it("finishes with an empty result when verification rejects every candidate", async () => {
+    const response = await request(app)
+      .post("/api/search/semantic")
+      .set("Accept", "application/x-ndjson")
+      .send({ query: "engineer" });
+    const stream = chunks(response.text);
+    expect(stream[0]).toMatchObject({ phase: "instant", fallback: true });
+    expect(stream.at(-1)).toMatchObject({
+      phase: "complete",
+      matches: [],
+      fallback: false,
+    });
+    const json = await request(app)
+      .post("/api/search/semantic")
+      .send({ query: "engineer" });
+    expect(json.body.matches).toEqual([]);
+  });
+  it("sends a terminal keyword fallback after a provider failure", async () => {
+    vi.mocked(rerankCandidates).mockRejectedValue(
+      new Error("Provider unavailable"),
+    );
+    const response = await request(app)
+      .post("/api/search/semantic")
+      .set("Accept", "application/x-ndjson")
+      .send({ query: "engineer" });
+    expect(chunks(response.text).at(-1)).toMatchObject({
+      phase: "complete",
+      fallback: true,
+      matches: [{ id: "a", aiReason: null }],
+    });
+  });
+  it("rejects evidence from before a contact edit and never caches it", async () => {
+    vi.mocked(rerankCandidates).mockImplementation(async () => {
+      sqlite.prepare("UPDATE contacts SET role='Designer' WHERE id='a'").run();
+      return [{ contact_id: "a", reason: "Engineer" }];
+    });
+    const response = await request(app)
+      .post("/api/search/semantic")
+      .send({ query: "engineer" });
+    expect(response.body).toMatchObject({ matches: [], fallback: true });
+  });
+  it("streams local candidates before the planner resolves", async () => {
+    let finish!: (value: null) => void;
+    vi.mocked(parseSearchQuery).mockImplementation(
+      () =>
+        new Promise((r) => {
+          finish = r;
+        }),
+    );
+    if (!app.listening)
+      await new Promise((resolve) => app.once("listening", resolve));
+    const address = app.address() as { port: number };
+    const response = await fetch(
+      `http://127.0.0.1:${address.port}/api/search/semantic`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/x-ndjson",
+        },
+        body: JSON.stringify({ query: "engineer" }),
+      },
+    );
+    const reader = response.body!.getReader();
+    const first = await reader.read();
+    expect(new TextDecoder().decode(first.value)).toContain(
+      '"phase":"instant"',
+    );
+    expect(rerankCandidates).not.toHaveBeenCalled();
+    finish(null);
+    while (!(await reader.read()).done) {
+      /* Drain the terminal result. */
+    }
+    expect(rerankCandidates).toHaveBeenCalledOnce();
+    reader.releaseLock();
+  });
+  it("does not rerank after the client disconnects", async () => {
+    let signal: AbortSignal | undefined;
+    vi.mocked(parseSearchQuery).mockImplementation((_query, current) => {
+      signal = current;
+      return new Promise((_resolve, reject) =>
+        current?.addEventListener("abort", () => reject(current.reason), {
+          once: true,
+        }),
+      );
+    });
+    const controller = new AbortController();
+    const address = app.address() as { port: number };
+    const response = await fetch(
+      `http://127.0.0.1:${address.port}/api/search/semantic`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/x-ndjson",
+        },
+        body: JSON.stringify({ query: "engineer" }),
+        signal: controller.signal,
+      },
+    );
+    const reader = response.body!.getReader();
+    await reader.read();
+    controller.abort();
+    await vi.waitFor(() => expect(signal?.aborted).toBe(true));
+    expect(rerankCandidates).not.toHaveBeenCalled();
+    await reader.cancel().catch(() => undefined);
+  });
+  it("validates synthesis IDs before starting a generation", async () => {
+    expect(
+      (
+        await request(app)
+          .post("/api/search/synthesize")
+          .send({ query: "engineers", contactIds: ["missing"] })
+      ).status,
+    ).toBe(409);
+    expect(
+      (
+        await request(app)
+          .post("/api/search/synthesize")
+          .send({ query: "q", contacts: [{}] })
+      ).status,
+    ).toBe(400);
+  });
+});

--- a/tests/unit/frontend.search.test.ts
+++ b/tests/unit/frontend.search.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { readNdjson } from "../../src/api/ndjson";
+import { useSemanticSearch } from "../../src/api/search";
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+function stream() {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  return {
+    response: new Response(body),
+    push: (text: string) => controller.enqueue(new TextEncoder().encode(text)),
+    end: () => controller.close(),
+  };
+}
+const result = (name: string, phase = "complete") =>
+  JSON.stringify({ phase, matches: [{ id: name, name }], fallback: false });
+describe("search streaming", () => {
+  it("reads split UTF-8 and a terminal line without a newline", async () => {
+    const bytes = new TextEncoder().encode('{"text":"José"}');
+    const seen: unknown[] = [];
+    const response = new Response(
+      new ReadableStream({
+        start(c) {
+          c.enqueue(bytes.slice(0, 12));
+          c.enqueue(bytes.slice(12));
+          c.close();
+        },
+      }),
+    );
+    await readNdjson(response, (value) => seen.push(value));
+    expect(seen).toEqual([{ text: "José" }]);
+  });
+  it("reports a truncated stream and settles the loading phase", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response(result("Alice", "instant") + "\n")),
+    );
+    const { result: hook } = renderHook(() => useSemanticSearch());
+    await act(async () => {
+      await hook.current.mutate("Alice");
+    });
+    expect(hook.current.isError).toBe(true);
+    expect(hook.current.isPending).toBe(false);
+    expect(hook.current.phase).toBe("done");
+  });
+  it("reports malformed chunks instead of silently dropping them", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response('{"phase":"complete","matches":"broken"}'),
+        ),
+    );
+    const { result: hook } = renderHook(() => useSemanticSearch());
+    await act(async () => {
+      await hook.current.mutate("Alice");
+    });
+    expect(hook.current.isError).toBe(true);
+    expect(hook.current.isSuccess).toBe(false);
+  });
+  it("ignores late responses from a replaced search", async () => {
+    const first = stream();
+    const second = stream();
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(first.response)
+        .mockResolvedValueOnce(second.response),
+    );
+    const { result: hook } = renderHook(() => useSemanticSearch());
+    let one!: Promise<void>;
+    let two!: Promise<void>;
+    act(() => {
+      one = hook.current.mutate("Old");
+    });
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    act(() => {
+      two = hook.current.mutate("New");
+    });
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      second.push(result("New"));
+      second.end();
+      await two;
+      await one;
+    });
+    expect(hook.current.data?.matches[0].name).toBe("New");
+    expect(hook.current.isSuccess).toBe(true);
+  });
+  it("cancels the reader when the component unmounts", async () => {
+    const pending = stream();
+    let signal!: AbortSignal;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url, options) => {
+        signal = options.signal;
+        return Promise.resolve(pending.response);
+      }),
+    );
+    const { result: hook, unmount } = renderHook(() => useSemanticSearch());
+    let work!: Promise<void>;
+    act(() => {
+      work = hook.current.mutate("Pending");
+    });
+    await waitFor(() => expect(signal).toBeTruthy());
+    unmount();
+    await work;
+    expect(signal.aborted).toBe(true);
+  });
+});

--- a/tests/unit/resilience.test.ts
+++ b/tests/unit/resilience.test.ts
@@ -156,16 +156,19 @@ describe("withTimeout", () => {
     await expect(promise).rejects.not.toBeInstanceOf(UpstreamTimeoutError);
   });
 
-  it("returns the op's success immediately if parentSignal is already aborted but op resolves synchronously", async () => {
-    // Edge case: parentSignal is aborted before withTimeout is called.
-    // The implementation calls controller.abort() inside but doesn't reject
-    // — the op is still invoked. We only fail if the op itself rejects.
+  it("never starts a generation after caller cancellation", async () => {
     const parentCtl = new AbortController();
     parentCtl.abort();
-    const op = async () => "still ok";
-    await expect(withTimeout(op, 1_000, parentCtl.signal)).resolves.toBe(
-      "still ok",
+    const op = vi.fn().mockResolvedValue("late");
+    await expect(withTimeout(op, 1000, parentCtl.signal)).rejects.toBeTruthy();
+    expect(op).not.toHaveBeenCalled();
+  });
+  it("enforces the deadline even when the operation ignores its signal", async () => {
+    const result = withTimeout(() => new Promise(() => {}), 100).catch(
+      (error) => error,
     );
+    await vi.advanceTimersByTimeAsync(101);
+    expect(await result).toBeInstanceOf(UpstreamTimeoutError);
   });
 });
 

--- a/tests/unit/search.evidence.test.ts
+++ b/tests/unit/search.evidence.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+vi.mock("../../server/ai/gateway.ts", () => ({
+  generateFor: vi.fn(),
+  isAnyProviderConfigured: () => true,
+}));
+import { generateFor } from "../../server/ai/gateway.ts";
+import {
+  rerankCandidates,
+  parseSearchQuery,
+} from "../../server/ai/services/searchIntel.ts";
+import type { AIGenerateResult, QueryPlan } from "../../server/ai/types.ts";
+const contact = {
+  id: "a",
+  name: "Alice",
+  role: "Engineer",
+  location: "Paris",
+  industry: "Software",
+};
+const match = {
+  contact_id: "a",
+  verified_field: "role",
+  verified_value: "Engineer",
+  reason: "Alice is an engineer.",
+};
+beforeEach(() => vi.mocked(generateFor).mockReset());
+const reply = (value: unknown) =>
+  vi.mocked(generateFor).mockResolvedValue({
+    text: JSON.stringify(value),
+    latencyMs: 1,
+    model: "mock",
+  } as AIGenerateResult);
+describe("AI search evidence", () => {
+  it.each([
+    {},
+    [null],
+    [{ contact_id: "a", reason: 1 }],
+    [{ ...match, verified_field: "constructor" }],
+  ])("rejects invalid output shape %j", async (value) => {
+    reply(value);
+    await expect(rerankCandidates("engineers", [contact])).rejects.toThrow(
+      "invalid search evidence",
+    );
+  });
+  it("checks missing company and mismatched industry even when other evidence is valid", async () => {
+    reply([match]);
+    const plan: QueryPlan = {
+      must: { companyMatchers: ["Acme"] },
+      should: {},
+      confidence: "high",
+      rationale: "",
+    };
+    expect(await rerankCandidates("Acme engineers", [contact], plan)).toEqual(
+      [],
+    );
+    plan.must = { industryMatchers: ["Finance"] };
+    expect(
+      await rerankCandidates("finance engineers", [contact], plan),
+    ).toEqual([]);
+  });
+  it("removes duplicate and invented IDs", async () => {
+    reply([match, match, { ...match, contact_id: "invented" }]);
+    expect(await rerankCandidates("engineers", [contact])).toEqual([
+      { contact_id: "a", reason: match.reason },
+    ]);
+  });
+  it("does not start a generation for an aborted request", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      rerankCandidates("engineers", [contact], null, controller.signal),
+    ).rejects.toThrow();
+    expect(generateFor).not.toHaveBeenCalled();
+  });
+  it.each([
+    [],
+    { must: [], should: {}, confidence: "high", rationale: "" },
+    {
+      must: { temporal: { type: "lastContact", daysAgo: -1 } },
+      should: {},
+      confidence: "high",
+      rationale: "",
+    },
+  ])("rejects an invalid query plan %j", async (value) => {
+    reply(value);
+    expect(await parseSearchQuery("invalid plan shape")).toBeNull();
+  });
+});


### PR DESCRIPTION
This PR makes Ask Contrack responsive and reliable while reducing unnecessary AI calls.

- Send local keyword candidates before AI refinement. Show those candidates in both search interfaces.
- Use local name lookups without AI. Remove the extra hypothetical-document generation from each semantic search.
- Bound refinement to 12 seconds and forward cancellation to provider requests.
- Validate query plans and claimed evidence. Treat a verified empty result as a valid final result.
- Share the streaming and JSON pipeline. Reject incomplete streams and prevent obsolete requests from replacing current results.
- Include data revisions and model choices in search cache keys. Reject evidence after concurrent edits.
- Read summary facts from active database contacts instead of trusting client-supplied profiles.

**Stack:** Part 4 of 5. Base: #20. Merge after #20.

## Testing

- `npm test -- --maxWorkers=2`: 642 tests passed across 48 files.
- `npm run lint`: passed.
- `npm run format:check`: passed.
- `npm run build`: passed.
- `CONTRACT_GEMINI_MODEL=gemini-3.5-flash-lite npm run test:contract -- -t 'Gemini.*returns schema-conformant JSON'`: 1 real provider test passed, 11 tests skipped.
- Browser: a query against synthetic contacts returned 6 verified matches in about 3 seconds. A repeated query made no additional generation calls.
- The live search used 2 Flash Lite generations and 3,042 reported tokens. The provider contract used one separate bounded generation.

Cancellation stops client work and follow-up calls. Providers can still charge for work they already accepted.
