### PR TITLE
fix(ai): bound enrichment work and protect cached contact data

### DIFF
--- a/docs/ai-hardening.md
+++ b/docs/ai-hardening.md
@@ -1,0 +1,107 @@
+# AI reliability and cost controls
+
+AI requests have bounded concurrency, deadlines, and output sizes. Contact
+enrichment validates each result before a database write. The UI reports
+failures and preserves access to active batch progress.
+
+## Request limits
+
+| Control             | Behavior                                                                                        |
+| ------------------- | ----------------------------------------------------------------------------------------------- |
+| Generation queue    | Two active calls and 16 waiting calls per server. Overflow returns `429 AI_BUSY`.               |
+| Generation deadline | 60 seconds by default, capped at 90 seconds. Queue time and retries consume this deadline.      |
+| Output limit        | 4,096 tokens by default. Individual features set smaller limits where appropriate.              |
+| Transient failures  | At most one application retry. Native SDK automatic retries are disabled.                       |
+| Invalid output      | JSON and schema failures do not trigger another generation.                                     |
+| Enrichment          | One workflow per contact. One grounding call and one extraction call for the two-pass strategy. |
+| Batch size          | 1 to 100 unique active contacts. A five-minute cooldown follows a batch.                        |
+
+Cancellation removes queued work and stops later steps. The SDK receives the
+abort signal for active work. Cancellation cannot reverse provider charges
+for a request that the provider already accepted.
+
+The OpenAI-compatible adapter can negotiate an unsupported JSON format after
+an explicit provider rejection. It uses the same total deadline.
+
+Gemini quota reservations use unique IDs. Out-of-order responses update their
+own reservation. Explicit model pins consume both model and grounding quotas.
+Unknown failures retain the estimated usage because the provider can still
+charge for them. Daily quotas reset at midnight Pacific, including daylight
+saving time. A late rejection cannot reduce the next day's grounding usage.
+
+## Contact data and caches
+
+- Enrichment rejects overlapping requests for the same contact before another
+  workflow starts.
+- A local snapshot check rejects results after edits, deletion, archival, or
+  merging. A transaction applies only validated, additive changes.
+- Schema limits cap strings and arrays. Email and URL fields require valid
+  values. Duplicate incoming child records do not create duplicate rows.
+- Existing interests, attributes, and other user values remain intact.
+- Briefing cache keys include contact facts, recent interaction content, and
+  model choice. Identical active requests share one generation.
+- Briefings and daily insights recheck their input before they save or cache
+  a result. Settings changes clear AI caches.
+- Deleted, merged, and archived contacts do not enter active research.
+  Mention extraction cannot create contacts after the source note disappears.
+- Missing AI configuration returns an actionable error. It does not return
+  demonstration summaries as real results.
+
+Gemini enrichment carries provider source links into the dossier. The UI
+renders safe external links and ignores raw HTML and images. Source links
+help users review research. They do not prove every extracted claim.
+
+The two-pass strategy requires source links from the provider. If the provider
+omits them, the server returns `502 AI_GROUNDING_MISSING` before extraction.
+It saves no contact changes and makes no additional generation call.
+
+## Progress and recovery
+
+The batch API and frontend share a runtime schema. The frontend validates both
+stream events and polling responses. It ignores responses for a different
+batch. A successful job refreshes contact data once, which avoids repeated
+list resets during polling.
+
+The progress overlay supports a short viewport, scrolling, visible errors,
+minimization, and cancellation. Polling continues after transient failures.
+Missing batches stop polling and show a restart message.
+
+Batch progress remains in memory. A server restart loses unfinished work and
+progress history. The database retains completed contact updates. Persistent
+batch state remains a separate follow-up.
+
+## Local resources and dependencies
+
+Local embedding inference uses two CPU threads and one inter-operation thread.
+`DISABLE_BACKGROUND_JOBS=true` skips startup model loading, backfills, and
+scheduled work for isolated test instances.
+
+The dependency update removes the vulnerable DiceBear initials package and
+uses the existing escaped monogram renderer. Both uploads and embeddings use
+Sharp 0.35.4 or newer. The ONNX installer uses adm-zip 0.6.0 or newer, which
+fixes the older allocation issue.
+
+The production audit still reports three moderate entries for one unresolved
+adm-zip symlink advisory and its dependency parents. ONNX imports adm-zip in
+its package installation script. Do not treat a clean application build as
+evidence that this upstream advisory is resolved.
+
+## Verification
+
+Regression tests use mocked providers. They cover queue overflow, cancellation,
+retry limits, quota ordering, edits during research, invalid output, cache
+freshness, missing batches, and frontend stream recovery.
+
+Live checks use an isolated database and a small model. Run only the relevant
+provider contract when an adapter changes. Full contract suites can make paid
+calls across all configured providers.
+
+Primary references:
+
+- [Gemini cancellation configuration](https://googleapis.github.io/js-genai/release_docs/interfaces/types.GenerateContentConfig.html)
+- [Gemini HTTP retry configuration](https://googleapis.github.io/js-genai/release_docs/interfaces/types.HttpOptions.html)
+- [OpenAI SDK retry configuration](https://github.com/openai/openai-node)
+- [Gemini structured output](https://ai.google.dev/gemini-api/docs/structured-output)
+- [Gemini rate limit resets](https://ai.google.dev/gemini-api/docs/rate-limits)
+- [Sharp advisory](https://github.com/advisories/GHSA-rgj7-g3m4-5g8c)
+- [adm-zip unresolved symlink advisory](https://github.com/advisories/GHSA-vwc7-r8mq-g2x9)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -310,7 +310,19 @@ curl -X POST http://localhost:3210/api/contacts/abc123/enrich
 }
 ```
 
-**Error codes:** `429` (grounding quota exhausted), `503` (AI not configured).
+The server accepts one active research request per contact. It validates the
+result before it writes any fields. It fills empty fields and adds missing
+child records. It preserves existing contact data.
+
+The request has a 90-second deadline. A disconnected client cancels further
+work. The provider can still charge for a request it already accepted.
+
+**Error codes:** `409` (research already active, contact unavailable, or contact
+changed during research), `429` (queue or quota full), `502` (invalid AI output),
+`503` (research or extraction model unavailable).
+
+Two-pass research requires source links. Missing provider sources return
+`502 AI_GROUNDING_MISSING` before extraction or database changes.
 
 ---
 
@@ -403,6 +415,11 @@ curl -X POST http://localhost:3210/api/contacts/abc123/briefing
   "briefing": "**Wins:** Closed Series B at $12M valuation...\n**Projects:** Building out the platform team...\n**Open Loops:** Waiting on legal review for partnership agreement..."
 }
 ```
+
+The cache key includes the contact facts, recent interaction content, and model.
+Concurrent requests for the same input share one generation. A contact edit
+during generation returns `409` and prevents a stale briefing from entering the
+database. Missing AI configuration returns `503`.
 
 ---
 
@@ -508,6 +525,11 @@ Start a batch enrichment job for selected contacts.
 
 Strategy defaults to the provider-appropriate strategy if omitted.
 
+Use 1 to 100 unique, nonempty contact IDs. Supported strategies are `two-pass`,
+`single-pass`, and `searxng`. The server checks the selected strategy and every
+contact before it creates a batch. Invalid input returns `400`. An unavailable
+contact returns `409`. Missing provider configuration returns `503`.
+
 ```bash
 curl -X POST http://localhost:3210/api/ai-search \
   -H "Content-Type: application/json" \
@@ -529,6 +551,11 @@ curl -X POST http://localhost:3210/api/ai-search \
 
 Poll the current status of a batch enrichment job.
 
+The batch status is `processing`, `complete`, or `cancelled`. Each job reports
+`queued`, `searching`, `merging`, `success`, `error`, or `cancelled`.
+A missing batch returns `404`. Batch progress lives in server memory and does
+not survive a restart. Completed contact updates remain in the database.
+
 ```bash
 curl "http://localhost:3210/api/ai-search/status?batchId=batch-abc123"
 ```
@@ -539,6 +566,11 @@ curl "http://localhost:3210/api/ai-search/status?batchId=batch-abc123"
 
 Subscribe to real-time batch progress via Server-Sent Events (SSE).
 
+The server validates the batch before it opens the stream. A missing batch
+returns a JSON `404` response. The stream sends a heartbeat every 15 seconds
+and closes when the batch completes or stops. The frontend also polls status
+to recover from a lost stream.
+
 ```bash
 curl -N "http://localhost:3210/api/ai-search/stream?batchId=batch-abc123"
 ```
@@ -548,9 +580,24 @@ const eventSource = new EventSource(`/api/ai-search/stream?batchId=${batchId}`);
 eventSource.onmessage = (event) => {
   const batch = JSON.parse(event.data);
   console.log(`Status: ${batch.status}, Jobs: ${batch.jobs.length}`);
-  if (batch.status === "complete") eventSource.close();
+  if (batch.status !== "processing") eventSource.close();
 };
 ```
+
+---
+
+### `POST /api/ai-search/:batchId/cancel`
+
+Stop an active batch. The response contains the current batch with status
+`cancelled`. Queued jobs never start. Active jobs stop before the next step
+or database write. Completed contact updates remain available.
+
+```bash
+curl -X POST http://localhost:3210/api/ai-search/batch-abc123/cancel
+```
+
+A missing batch returns `404`. Repeating cancellation returns the current
+batch. Provider charges can still apply to requests it already accepted.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ cp .env.example .env
 | `AI_DEEP_MODEL`           | Pin the Deep-tasks model                                                                                                                         | — (auto)     | No       |
 | `AI_RESEARCH_MODEL`       | Pin the Web-research model                                                                                                                       | — (auto)     | No       |
 | `AI_EMBEDDINGS_MODEL`     | Pin the Embeddings model (governs search and dedupe vectors); defaults to a local model needing no key                                           | — (built-in) | No       |
-| `DISABLE_BACKGROUND_JOBS` | `true` turns off scheduled work: backups, trash purge, geocoding queue, model-catalog refresh, `PRAGMA optimize`. For CI and secondary instances | `false`      | No       |
+| `DISABLE_BACKGROUND_JOBS` | `true` skips startup model loading, backfills, scoring, and all scheduled work. Use this for CI and secondary instances                          | `false`      | No       |
 | `NODE_ENV`                | `production` serves the built `dist/` and enables the CSP; anything else runs Vite dev middleware and the debug cache-stats route                | — (dev)      | No       |
 
 > **Rate limiting:** endpoints that trigger billable AI calls or outbound fetches
@@ -42,6 +42,11 @@ cp .env.example .env
 > `POST /api/contacts/bulk` (50 MB) for imports. Over the limit the server
 > answers `413 PAYLOAD_TOO_LARGE`. File uploads travel as multipart and have
 > their own caps (10 MB avatars, 50 MB attachments).
+
+Local embedding inference uses two CPU threads and one inter-operation thread.
+AI generation allows two concurrent calls and 16 waiting calls per server.
+Additional calls return `429 AI_BUSY`. See [AI hardening](ai-hardening.md) for
+timeouts, retry limits, cache behavior, and testing guidance.
 
 ---
 

--- a/docs/features/ai-search.md
+++ b/docs/features/ai-search.md
@@ -105,7 +105,7 @@ The enrichment strategy varies by AI provider:
 
 The AI searches the internet for each contact and can update:
 
-- Role and company (if changed)
+- Role and company when the fields are empty
 - Headline / professional summary
 - Social links (LinkedIn, GitHub, Twitter)
 - Education and experience history
@@ -113,26 +113,40 @@ The AI searches the internet for each contact and can update:
 - Website
 - AI-generated summary and background
 
+Enrichment preserves existing values. It rejects the result if the contact
+changes during research. Gemini source links appear under **Dossier → Research
+notes and sources**. The section also shows research for contacts with no other
+dossier fields.
+
 ### Progress Tracking
 
 Each batch job streams real-time progress via SSE (`GET /api/ai-search/stream`):
 
-- Per-contact status: `queued` → `searching` → `merging` → `success` / `error`
+- Per-contact status: `queued` → `searching` → `merging` → `success` / `error` / `cancelled`
 - Error classification: rate_limit, validation, network, auth, ambiguous
 - Token usage tracking
 - Latency per contact
+
+The overlay supports scrolling, visible error text, and **Stop research**.
+Minimizing the overlay keeps a progress button available. Status polling
+continues if the stream disconnects. A server restart clears progress, while
+completed contact updates remain in the database.
 
 ### Rate Limiting
 
 - Maximum 100 contacts per batch
 - 5-minute cooldown between batches
-- Provider-specific RPM limits are respected via the Parallel Queue
+- Two concurrent AI generations and 16 waiting generations per server
+- One workflow per contact, with a 90-second deadline
+- At most one retry for a transient provider failure within the deadline
+- No repeated research workflow after empty or invalid model output
 
 **APIs:**
 
 - `POST /api/ai-search` — Start a batch
 - `GET /api/ai-search/status?batchId=` — Poll status
 - `GET /api/ai-search/stream?batchId=` — SSE stream
+- `POST /api/ai-search/:batchId/cancel` — Stop a batch
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@dicebear/avataaars": "^9.4.2",
         "@dicebear/bottts": "^9.4.2",
         "@dicebear/core": "^9.4.3",
-        "@dicebear/initials": "^9.4.2",
         "@dicebear/lorelei": "^9.4.2",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -59,7 +58,7 @@
         "react-leaflet-cluster": "^4.1.3",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.15.1",
-        "sharp": "^0.35.3",
+        "sharp": "^0.35.4",
         "sonner": "^2.0.7",
         "sqlite-vec": "^0.1.9",
         "tailwind-merge": "^3.5.0",
@@ -631,18 +630,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@dicebear/initials": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@dicebear/initials/-/initials-9.4.2.tgz",
-      "integrity": "sha512-yePuIUasmwtl9IrtB6rEzE/zb5fImKP/neW0CdcTC2MwLgMuP1GLHEGRgg1zI8exIh+PMv1YdLGyyUuRTE2Qpw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@dicebear/core": "^9.0.0"
-      }
-    },
     "node_modules/@dicebear/lorelei": {
       "version": "9.4.2",
       "resolved": "https://registry.npmjs.org/@dicebear/lorelei/-/lorelei-9.4.2.tgz",
@@ -1162,9 +1149,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1179,9 +1166,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
       "cpu": [
         "arm"
       ],
@@ -1196,9 +1183,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
       "cpu": [
         "arm64"
       ],
@@ -1213,9 +1200,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
       "cpu": [
         "x64"
       ],
@@ -1230,9 +1217,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
       "cpu": [
         "arm64"
       ],
@@ -1247,9 +1234,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
       "cpu": [
         "x64"
       ],
@@ -1264,9 +1251,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
       "cpu": [
         "arm64"
       ],
@@ -1281,9 +1268,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
       "cpu": [
         "x64"
       ],
@@ -1298,9 +1285,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
       "cpu": [
         "arm"
       ],
@@ -1315,9 +1302,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
       "cpu": [
         "arm64"
       ],
@@ -1332,9 +1319,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
       "cpu": [
         "ia32"
       ],
@@ -1349,9 +1336,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
       "cpu": [
         "loong64"
       ],
@@ -1366,9 +1353,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
       "cpu": [
         "mips64el"
       ],
@@ -1383,9 +1370,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1400,9 +1387,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
       "cpu": [
         "riscv64"
       ],
@@ -1417,9 +1404,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
       "cpu": [
         "s390x"
       ],
@@ -1434,9 +1421,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
       "cpu": [
         "x64"
       ],
@@ -1451,9 +1438,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
       "cpu": [
         "arm64"
       ],
@@ -1468,9 +1455,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
       "cpu": [
         "x64"
       ],
@@ -1485,9 +1472,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
       "cpu": [
         "arm64"
       ],
@@ -1502,9 +1489,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
       "cpu": [
         "x64"
       ],
@@ -1519,9 +1506,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1536,9 +1523,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
       "cpu": [
         "x64"
       ],
@@ -1553,9 +1540,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
       "cpu": [
         "arm64"
       ],
@@ -1570,9 +1557,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
       "cpu": [
         "ia32"
       ],
@@ -1587,9 +1574,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
       "cpu": [
         "x64"
       ],
@@ -1846,566 +1833,6 @@
         "sharp": "^0.34.5"
       }
     },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -2482,9 +1909,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
-      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -2500,13 +1927,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -2522,20 +1949,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.2"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -2545,9 +1972,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
-      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -2561,9 +1988,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -2577,9 +2004,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
       ],
@@ -2596,9 +2023,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
       ],
@@ -2615,9 +2042,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
       ],
@@ -2634,9 +2061,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2653,9 +2080,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
       ],
@@ -2672,9 +2099,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
       ],
@@ -2691,9 +2118,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
       ],
@@ -2710,9 +2137,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
       ],
@@ -2729,9 +2156,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
@@ -2750,13 +2177,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.2"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
       ],
@@ -2775,13 +2202,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.2"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2800,13 +2227,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
@@ -2825,13 +2252,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
@@ -2850,13 +2277,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.2"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
       ],
@@ -2875,13 +2302,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.2"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
@@ -2900,13 +2327,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
       ],
@@ -2925,17 +2352,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
-      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.1"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -2945,16 +2372,16 @@
       }
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -2964,9 +2391,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -2983,9 +2410,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -3002,9 +2429,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -5018,9 +4445,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.9.tgz",
+      "integrity": "sha512-brTTsvFRt5C1gGHtPst/281UjPD5t9fBqbgoMPlVWy11ZLTPfu7HxK4ZYqO9H7o/yC9rSTCI85EaQ4OoY12qYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5444,12 +4871,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -5883,9 +5310,9 @@
       }
     },
     "node_modules/body-parser/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6209,9 +5636,9 @@
       }
     },
     "node_modules/cheerio/node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -7766,9 +7193,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -7779,32 +7206,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.1",
-        "@esbuild/android-arm": "0.28.1",
-        "@esbuild/android-arm64": "0.28.1",
-        "@esbuild/android-x64": "0.28.1",
-        "@esbuild/darwin-arm64": "0.28.1",
-        "@esbuild/darwin-x64": "0.28.1",
-        "@esbuild/freebsd-arm64": "0.28.1",
-        "@esbuild/freebsd-x64": "0.28.1",
-        "@esbuild/linux-arm": "0.28.1",
-        "@esbuild/linux-arm64": "0.28.1",
-        "@esbuild/linux-ia32": "0.28.1",
-        "@esbuild/linux-loong64": "0.28.1",
-        "@esbuild/linux-mips64el": "0.28.1",
-        "@esbuild/linux-ppc64": "0.28.1",
-        "@esbuild/linux-riscv64": "0.28.1",
-        "@esbuild/linux-s390x": "0.28.1",
-        "@esbuild/linux-x64": "0.28.1",
-        "@esbuild/netbsd-arm64": "0.28.1",
-        "@esbuild/netbsd-x64": "0.28.1",
-        "@esbuild/openbsd-arm64": "0.28.1",
-        "@esbuild/openbsd-x64": "0.28.1",
-        "@esbuild/openharmony-arm64": "0.28.1",
-        "@esbuild/sunos-x64": "0.28.1",
-        "@esbuild/win32-arm64": "0.28.1",
-        "@esbuild/win32-ia32": "0.28.1",
-        "@esbuild/win32-x64": "0.28.1"
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/escalade": {
@@ -12857,9 +12284,9 @@
       "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
-      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@img/colour": "^1.1.0",
@@ -12873,31 +12300,31 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.3",
-        "@img/sharp-darwin-x64": "0.35.3",
-        "@img/sharp-freebsd-wasm32": "0.35.3",
-        "@img/sharp-libvips-darwin-arm64": "1.3.2",
-        "@img/sharp-libvips-darwin-x64": "1.3.2",
-        "@img/sharp-libvips-linux-arm": "1.3.2",
-        "@img/sharp-libvips-linux-arm64": "1.3.2",
-        "@img/sharp-libvips-linux-ppc64": "1.3.2",
-        "@img/sharp-libvips-linux-riscv64": "1.3.2",
-        "@img/sharp-libvips-linux-s390x": "1.3.2",
-        "@img/sharp-libvips-linux-x64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-        "@img/sharp-linux-arm": "0.35.3",
-        "@img/sharp-linux-arm64": "0.35.3",
-        "@img/sharp-linux-ppc64": "0.35.3",
-        "@img/sharp-linux-riscv64": "0.35.3",
-        "@img/sharp-linux-s390x": "0.35.3",
-        "@img/sharp-linux-x64": "0.35.3",
-        "@img/sharp-linuxmusl-arm64": "0.35.3",
-        "@img/sharp-linuxmusl-x64": "0.35.3",
-        "@img/sharp-webcontainers-wasm32": "0.35.3",
-        "@img/sharp-win32-arm64": "0.35.3",
-        "@img/sharp-win32-ia32": "0.35.3",
-        "@img/sharp-win32-x64": "0.35.3"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
       },
       "peerDependenciesMeta": {
         "@types/node": {
@@ -13729,9 +13156,9 @@
       }
     },
     "node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13889,9 +13316,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@dicebear/avataaars": "^9.4.2",
     "@dicebear/bottts": "^9.4.2",
     "@dicebear/core": "^9.4.3",
-    "@dicebear/initials": "^9.4.2",
     "@dicebear/lorelei": "^9.4.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
@@ -98,7 +97,7 @@
     "react-leaflet-cluster": "^4.1.3",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.15.1",
-    "sharp": "^0.35.3",
+    "sharp": "^0.35.4",
     "sonner": "^2.0.7",
     "sqlite-vec": "^0.1.9",
     "tailwind-merge": "^3.5.0",
@@ -152,5 +151,11 @@
     "*.{json,css,md}": [
       "prettier --write"
     ]
+  },
+  "overrides": {
+    "@huggingface/transformers": {
+      "sharp": "$sharp"
+    },
+    "adm-zip": "^0.6.0"
   }
 }

--- a/server.ts
+++ b/server.ts
@@ -150,6 +150,14 @@ async function startServer() {
 
   registerShutdownHandlers(server);
 
+  if (process.env.DISABLE_BACKGROUND_JOBS === "true") {
+    log.info(
+      "Server",
+      "Background maintenance and embedding backfills are disabled.",
+    );
+    return;
+  }
+
   startRetroactiveGeocoding();
 
   // ── Data lifecycle: scheduled DB snapshots + trash retention ─────────────

--- a/server/ai/adapters/anthropic.ts
+++ b/server/ai/adapters/anthropic.ts
@@ -20,6 +20,7 @@ import type {
   JsonSchemaNode,
 } from "../types.ts";
 import { getLatestDiscoveredModel } from "../modelFilter.ts";
+import { contentHash } from "../../utils/aiCache.ts";
 import { log } from "../../utils/logger.ts";
 import { getErrorMessage } from "../../utils/helpers.ts";
 import {
@@ -110,7 +111,7 @@ export class AnthropicAdapter implements AIProvider {
   private schemaTooComplex = new Set<string>();
 
   constructor(apiKey: string) {
-    this.client = new Anthropic({ apiKey });
+    this.client = new Anthropic({ apiKey, maxRetries: 0 });
   }
 
   /**
@@ -181,7 +182,7 @@ export class AnthropicAdapter implements AIProvider {
     return withRetry(
       async (attempt) => {
         const startMs = Date.now();
-        const schemaKey = `${model}:${options.systemPrompt?.slice(0, 60) ?? ""}`;
+        const schemaKey = `${model}:${contentHash(JSON.stringify(options.jsonSchema ?? {}))}`;
         let useSchema = !this.schemaTooComplex.has(schemaKey);
         let result: AIGenerateResult;
         try {
@@ -207,6 +208,7 @@ export class AnthropicAdapter implements AIProvider {
             "AnthropicAdapter",
             `${model} declined the response schema (${getErrorMessage(err).slice(0, 120)}); retrying with prompt-guided JSON`,
           );
+          if (this.schemaTooComplex.size >= 100) this.schemaTooComplex.clear();
           this.schemaTooComplex.add(schemaKey);
           useSchema = false;
           result = await withTimeout(

--- a/server/ai/adapters/gemini.ts
+++ b/server/ai/adapters/gemini.ts
@@ -30,8 +30,13 @@ import {
   type ModelClass,
 } from "../routing/registry.ts";
 import { log } from "../../utils/logger.ts";
-import { getErrorMessage } from "../../utils/helpers.ts";
-import { withTimeout, parseAIJson, AI_DEFAULTS } from "../resilience.ts";
+import {
+  withTimeout,
+  parseAIJson,
+  AI_DEFAULTS,
+  withRetry,
+  isRetryableError,
+} from "../resilience.ts";
 import { AppError } from "../../utils/AppError.ts";
 
 // ---------------------------------------------------------------------------
@@ -87,53 +92,12 @@ function translateSchema(node: JsonSchemaNode): GeminiSchemaNode {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Returns true if the error looks like a transient server or quota error.
- *
- * Retryable errors from the Gemini API:
- * - 429 / "resource exhausted": Rate limit exceeded
- * - 503 / "unavailable":        Server temporarily overloaded
- * - 500 / "internal":           Transient server error
- * - 408 / "deadline exceeded":  Request timed out
- */
-function isRetryableError(error: unknown): boolean {
-  const errObj = error as Record<string, unknown> | null;
-  const msg = (
-    typeof errObj?.message === "string" ? errObj.message : ""
-  ).toLowerCase();
-  const status = (
-    typeof errObj?.status === "number" ? errObj.status : errObj?.statusCode
-  ) as number | undefined;
-  return (
-    status === 429 ||
-    status === 503 ||
-    status === 500 ||
-    status === 408 ||
-    msg.includes("429") ||
-    msg.includes("rate limit") ||
-    msg.includes("quota") ||
-    msg.includes("resource exhausted") ||
-    msg.includes("503") ||
-    msg.includes("unavailable") ||
-    msg.includes("500") ||
-    msg.includes("internal") ||
-    msg.includes("408") ||
-    msg.includes("deadline")
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 /** Duration (ms) to ban a model after a 429/503 — short enough for fast recovery */
 const CIRCUIT_BREAKER_DURATION_MS = 30_000;
-
-/** Maximum retry attempts for routed requests before giving up */
-const MAX_RETRIES = 3;
-
-/** Base delay for exponential backoff: 500ms, 1000ms, 2000ms */
-const BASE_BACKOFF_MS = 500;
 
 /**
  * Whether a discovered Gemini model can use the `googleSearch` tool.
@@ -179,7 +143,10 @@ export class GeminiAdapter implements AIProvider {
 
   constructor(apiKey: string) {
     this.apiKey = apiKey;
-    this.client = new GoogleGenAI({ apiKey });
+    this.client = new GoogleGenAI({
+      apiKey,
+      httpOptions: { retryOptions: { attempts: 1 } },
+    });
 
     // Read tier from environment once at construction time
     this.aiTier = getAITier();
@@ -303,131 +270,80 @@ export class GeminiAdapter implements AIProvider {
   // ---------------------------------------------------------------------------
 
   async generate(options: AIGenerateOptions): Promise<AIGenerateResult> {
+    options.signal?.throwIfAborted();
     const startMs = Date.now();
     const requiresGrounding = !!options.enableSearchGrounding;
-
-    // Early bail-out for already-cancelled callers — saves a routing lookup.
-    if (options.signal?.aborted) {
-      throw new AppError("AI call cancelled by caller", 499, {
-        code: "CANCELLED",
-      });
-    }
-
-    // ── Explicit model override: bypass routing entirely ──────────────
-    // TwoPassStrategy and other callers that set `options.model` manage
-    // their own fallback chain. We execute their chosen model directly
-    // without routing, reservation, or retry logic.
-    if (options.model) {
-      return this.executeWithModel(options, options.model, startMs);
-    }
-
-    // ── Smart routing with retry loop ─────────────────────────────────
-    const isJson = options.responseFormat === "json";
     const estimatedTokens = this.tracker.estimateTokens(
       options.prompt,
       options.systemPrompt,
-      isJson,
+      options.responseFormat === "json",
     );
-
-    let lastError: Error | null = null;
-
-    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-      // Ask the router for the best available model.
-      // Wrapped in try-catch because the router throws if no models match
-      // (e.g., all circuit-broken + denied by policy). Without this catch,
-      // the throw would bypass lastError and surface as an unhandled exception.
-      let route;
-      try {
-        route = this.router.getNextAvailableRoute(
-          estimatedTokens,
-          options.routing,
-          this.circuitBreakers,
-          requiresGrounding,
-        );
-      } catch (routeError: unknown) {
-        lastError =
-          routeError instanceof Error
-            ? routeError
-            : new Error(getErrorMessage(routeError));
-        log.warn(
-          "GeminiAdapter",
-          `Router exhausted on attempt ${attempt}: ${getErrorMessage(routeError)}`,
-        );
-        break; // No point retrying if no models are available
-      }
-
-      // Optimistic reservation — deduct from the in-memory ledger BEFORE
-      // the network request fires. This prevents parallel requests from
-      // all targeting the same model simultaneously.
-      this.tracker.reserve(route.modelId, estimatedTokens);
-      if (requiresGrounding) {
-        this.tracker.reserveGrounding();
-      }
-
-      try {
-        const result = await this.executeWithModel(
-          options,
-          route.modelId,
-          startMs,
-        );
-
-        // Reconcile estimated vs actual tokens to keep the ledger accurate
-        const actualTokens = result.tokenCount ?? estimatedTokens;
-        this.tracker.reconcile(route.modelId, estimatedTokens, actualTokens);
-
-        log.info(
-          "GeminiAdapter",
-          `[${route.tier.toUpperCase()}] ${route.modelId} | ` +
-            `${result.latencyMs}ms | ${actualTokens} tokens | attempt ${attempt}`,
-        );
-
-        return result;
-      } catch (error: unknown) {
-        lastError =
-          error instanceof Error ? error : new Error(getErrorMessage(error));
-
-        // Rollback the optimistic reservation — this request didn't consume quota
-        this.tracker.rollback(route.modelId);
-        if (requiresGrounding) {
-          this.tracker.rollbackGrounding();
-        }
-
-        if (isRetryableError(error)) {
-          // Trip circuit breaker: ban this model for 30s so the next
-          // iteration's router call skips it automatically
-          log.warn(
-            "GeminiAdapter",
-            `${route.modelId} hit rate limit (attempt ${attempt}/${MAX_RETRIES}). ` +
-              `Circuit breaker tripped for ${CIRCUIT_BREAKER_DURATION_MS / 1000}s.`,
+    return withRetry(
+      async () => {
+        options.signal?.throwIfAborted();
+        if (requiresGrounding && !this.tracker.hasGroundingCapacity())
+          throw new AppError("Grounding quota exhausted for today.", 429, {
+            code: "AI_BUSY",
+          });
+        const model =
+          options.model ??
+          this.router.getNextAvailableRoute(
+            estimatedTokens,
+            options.routing,
+            this.circuitBreakers,
+            requiresGrounding,
+          ).modelId;
+        const config = getModelConfig(model);
+        if (
+          options.model &&
+          config &&
+          !this.tracker.hasCapacity(
+            model,
+            estimatedTokens,
+            this.aiTier === "FREE" ? config.freeLimits : config.paidLimits,
+          )
+        )
+          throw new AppError(
+            "This model has reached its local quota limit. Try again shortly.",
+            429,
+            { code: "AI_BUSY" },
           );
-          this.circuitBreakers.add(route.modelId);
-          setTimeout(
-            () => this.circuitBreakers.delete(route.modelId),
-            CIRCUIT_BREAKER_DURATION_MS,
+        const reservation = this.tracker.reserve(model, estimatedTokens);
+        const groundingDate = requiresGrounding
+          ? this.tracker.reserveGrounding()
+          : undefined;
+        try {
+          const result = await this.executeWithModel(options, model, startMs);
+          this.tracker.reconcile(
+            model,
+            estimatedTokens,
+            result.tokenCount ?? estimatedTokens,
+            reservation,
           );
-
-          // Exponential backoff before next attempt
-          if (attempt < MAX_RETRIES) {
-            const backoffMs = BASE_BACKOFF_MS * Math.pow(2, attempt - 1);
-            await new Promise((r) => setTimeout(r, backoffMs));
+          return result;
+        } catch (error) {
+          const status =
+            (error as { status?: number; statusCode?: number })?.status ??
+            (error as { statusCode?: number })?.statusCode;
+          // Only explicit rejections prove that the provider did not execute the request.
+          if (status && [400, 401, 403, 404, 422, 429].includes(status)) {
+            this.tracker.rollback(model, reservation);
+            if (requiresGrounding)
+              this.tracker.rollbackGrounding(groundingDate);
           }
-          continue;
+          options.signal?.throwIfAborted();
+          if (isRetryableError(error, false) && !options.model) {
+            this.circuitBreakers.add(model);
+            setTimeout(
+              () => this.circuitBreakers.delete(model),
+              CIRCUIT_BREAKER_DURATION_MS,
+            ).unref();
+          }
+          throw error;
         }
-
-        // Hard error (bad request, auth, schema) — do not retry
-        log.error(
-          "GeminiAdapter",
-          `${route.modelId} hard error: ${getErrorMessage(error)}`,
-        );
-        throw error;
-      }
-    }
-
-    log.error(
-      "GeminiAdapter",
-      "All retry attempts exhausted across all available models.",
+      },
+      { signal: options.signal },
     );
-    throw lastError ?? new Error("Max API retries exceeded.");
   }
 
   // ---------------------------------------------------------------------------
@@ -492,6 +408,21 @@ export class GeminiAdapter implements AIProvider {
       parseAIJson(text, `GeminiAdapter.executeWithModel(${model})`);
     }
 
-    return { text, model, tokenCount, latencyMs };
+    const citations = response.candidates
+      ?.flatMap(
+        (candidate) =>
+          candidate.groundingMetadata?.groundingChunks?.flatMap((chunk) =>
+            chunk.web?.uri && /^https?:\/\//i.test(chunk.web.uri)
+              ? [
+                  {
+                    title: chunk.web.title ?? chunk.web.uri,
+                    uri: chunk.web.uri,
+                  },
+                ]
+              : [],
+          ) ?? [],
+      )
+      .slice(0, 30);
+    return { text, model, tokenCount, latencyMs, citations };
   }
 }

--- a/server/ai/adapters/openai.ts
+++ b/server/ai/adapters/openai.ts
@@ -89,7 +89,7 @@ export class OpenAIAdapter implements AIProvider {
   private client: OpenAI;
 
   constructor(apiKey: string) {
-    this.client = new OpenAI({ apiKey });
+    this.client = new OpenAI({ apiKey, maxRetries: 0 });
   }
 
   /**

--- a/server/ai/adapters/openaiCompatible.ts
+++ b/server/ai/adapters/openaiCompatible.ts
@@ -88,6 +88,7 @@ export class OpenAICompatibleAdapter implements AIProvider {
     this.baseUrl = options.baseUrl.replace(/\/+$/, "");
     this.client = new OpenAI({
       baseURL: this.baseUrl,
+      maxRetries: 0,
       // Local servers (Ollama, LM Studio) ignore the key but the SDK requires
       // a non-empty string.
       apiKey: options.apiKey || "not-needed",
@@ -190,6 +191,7 @@ export class OpenAICompatibleAdapter implements AIProvider {
     // is not JSON at all), so both a rejection and an unparseable body trigger
     // the downgrade.
     for (;;) {
+      signal.throwIfAborted();
       let result: AIGenerateResult;
       try {
         result = await this.attempt(options, model, mode, signal, startMs);
@@ -257,6 +259,8 @@ export class OpenAICompatibleAdapter implements AIProvider {
     messages.push({ role: "user", content: options.prompt });
 
     const requestParams: Record<string, unknown> = { model, messages };
+    if (options.maxOutputTokens)
+      requestParams.max_tokens = options.maxOutputTokens;
     if (options.responseFormat === "json") {
       if (mode === "json_schema" && options.jsonSchema) {
         requestParams.response_format = {

--- a/server/ai/gateway.ts
+++ b/server/ai/gateway.ts
@@ -15,6 +15,10 @@ import type { AICapability } from "./capabilities.ts";
 import { resolveCapability } from "./capabilities.ts";
 import { getProviderConfigs } from "./providerRegistry.ts";
 import { AppError } from "../utils/AppError.ts";
+import { GenerationQueue } from "./workQueue.ts";
+import { withTimeout } from "./resilience.ts";
+
+const generations = new GenerationQueue();
 
 /** Options accepted by the gateway (model/routing are filled in for you). */
 export type GatewayOptions = Omit<AIGenerateOptions, "routing">;
@@ -34,6 +38,7 @@ export async function generateFor(
   capability: Exclude<AICapability, "embeddings">,
   options: GatewayOptions,
 ): Promise<AIGenerateResult> {
+  options.signal?.throwIfAborted();
   const resolved = resolveCapability(capability);
   if (!resolved) {
     throw new AppError(
@@ -43,12 +48,24 @@ export async function generateFor(
     );
   }
 
-  return resolved.provider.generate({
-    ...options,
-    // An explicit per-call model override still wins (used by strategies).
-    model: options.model ?? resolved.model,
-    routing: { prefer: resolved.modelClass },
-  });
+  const timeoutMs = Math.min(options.timeoutMs ?? 60_000, 90_000);
+  return withTimeout(
+    (signal) =>
+      generations.run(
+        () =>
+          resolved.provider.generate({
+            ...options,
+            signal,
+            timeoutMs,
+            maxOutputTokens: options.maxOutputTokens ?? 4_096,
+            model: options.model ?? resolved.model,
+            routing: { prefer: resolved.modelClass },
+          }),
+        signal,
+      ),
+    timeoutMs,
+    options.signal,
+  );
 }
 
 /** Which provider currently serves a capability (for logging/telemetry). */

--- a/server/ai/resilience.ts
+++ b/server/ai/resilience.ts
@@ -33,7 +33,7 @@ export const AI_DEFAULTS = {
   /** Hard cap per single network attempt. Streaming / grounded calls may need to raise this. */
   perAttemptTimeoutMs: 60_000,
   /** Number of attempts including the first one. 1 = no retry, 3 = up to 2 retries. */
-  maxAttempts: 3,
+  maxAttempts: 2,
   /** Base backoff for exponential schedule: 500, 1000, 2000 ms (+ jitter). */
   baseBackoffMs: 500,
   /** Max jitter added on top of each backoff step (uniform [0, jitterMs)). */
@@ -58,6 +58,11 @@ export function isRetryableError(
   error: unknown,
   abortedByTimeout: boolean,
 ): boolean {
+  if (
+    error instanceof AppError &&
+    ["AI_INVALID_JSON", "AI_SCHEMA_MISMATCH", "AI_BUSY"].includes(error.code)
+  )
+    return false;
   if (abortedByTimeout) return true;
 
   const e = error as {
@@ -75,6 +80,8 @@ export function isRetryableError(
   ) {
     return true;
   }
+
+  if (typeof status === "number" && status >= 400 && status < 500) return false;
 
   const code = typeof e?.code === "string" ? e.code : "";
   if (
@@ -97,16 +104,6 @@ export function isRetryableError(
     msg.includes("timeout") ||
     msg.includes("timed out") ||
     msg.includes("deadline")
-  );
-}
-
-/** Distinguish "the client cancelled us" from "the timer cancelled us". */
-function isAbortError(err: unknown): boolean {
-  const e = err as { name?: string; code?: string };
-  return (
-    e?.name === "AbortError" ||
-    e?.code === "ABORT_ERR" ||
-    (e?.name === "Error" && (e as { message?: string }).message === "Aborted")
   );
 }
 
@@ -204,7 +201,7 @@ export async function withRetry<T>(
       lastErr = err;
 
       // Caller cancelled mid-flight — never retry.
-      if (opts.signal?.aborted && isAbortError(err)) {
+      if (opts.signal?.aborted) {
         throw new AppError("AI call cancelled by caller", 499, {
           code: "CANCELLED",
         });
@@ -233,6 +230,18 @@ export async function withRetry<T>(
     message?: string;
   };
   const status = typeof e?.status === "number" ? e.status : e?.statusCode;
+  if (status === 401 || status === 403)
+    throw new AppError(
+      "AI provider rejected its credentials. Check AI settings.",
+      503,
+      { code: "AI_AUTH_FAILED" },
+    );
+  if (status === 400 || status === 422)
+    throw new AppError(
+      "AI provider rejected the request. Check the model settings.",
+      502,
+      { code: "AI_REQUEST_REJECTED" },
+    );
   if (status === 429)
     throw new RateLimitedError("AI provider rate limit exceeded", {
       cause: e?.message,
@@ -247,21 +256,19 @@ export async function withRetry<T>(
   });
 }
 
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
-    if (signal?.aborted)
-      return reject(new AppError("Cancelled", 499, { code: "CANCELLED" }));
-    const t = setTimeout(() => resolve(), ms);
-    if (signal) {
-      signal.addEventListener(
-        "abort",
-        () => {
-          clearTimeout(t);
-          reject(new AppError("Cancelled", 499, { code: "CANCELLED" }));
-        },
-        { once: true },
-      );
-    }
+    if (signal?.aborted) return reject(signal.reason);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      reject(signal?.reason);
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 }
 

--- a/server/ai/routing/QuotaTracker.ts
+++ b/server/ai/routing/QuotaTracker.ts
@@ -16,18 +16,25 @@
 
 import type { TierLimits } from "./registry.ts";
 
+const quotaDate = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "America/Los_Angeles",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
 // ---------------------------------------------------------------------------
 // Internal Types
 // ---------------------------------------------------------------------------
 
 interface UsageWindow {
   /** Timestamps of requests within the current 60s window */
-  requests: number[];
+  requests: { id: number; ts: number }[];
 
   /** Token usage entries within the current 60s window */
-  tokens: { ts: number; count: number }[];
+  tokens: { id: number; ts: number; count: number }[];
 
-  /** Current UTC date string (YYYY-MM-DD) for daily reset */
+  /** Current Pacific date for the provider's daily reset. */
   dateKey: string;
 
   /** Requests made today (resets on dateKey change) */
@@ -40,6 +47,7 @@ interface UsageWindow {
 
 export class QuotaTracker {
   private usage = new Map<string, UsageWindow>();
+  private nextReservationId = 0;
 
   // ── Grounding RPD Tracking ──────────────────────────────────────────
   // Grounding has its own daily limit, SEPARATE from generation RPD.
@@ -53,9 +61,9 @@ export class QuotaTracker {
 
   // ── Helpers ─────────────────────────────────────────────────────────
 
-  /** UTC date key for daily counter resets (avoids repeating this pattern). */
-  private getTodayKey(): string {
-    return new Date().toISOString().split("T")[0];
+  /** Gemini resets daily quotas at midnight Pacific, including daylight saving time. */
+  private getTodayKey(timestamp = Date.now()): string {
+    return quotaDate.format(timestamp);
   }
 
   // ── Token Estimation ────────────────────────────────────────────────
@@ -113,7 +121,7 @@ export class QuotaTracker {
   /** Prune entries older than 60 seconds from the sliding window. */
   private cleanup(window: UsageWindow, now: number): void {
     const cutoff = now - 60_000;
-    window.requests = window.requests.filter((ts) => ts > cutoff);
+    window.requests = window.requests.filter((entry) => entry.ts > cutoff);
     window.tokens = window.tokens.filter((t) => t.ts > cutoff);
   }
 
@@ -170,25 +178,28 @@ export class QuotaTracker {
    * synchronously from the in-memory ledger, parallel requests see
    * each other's reservations and won't all pile onto the same model.
    */
-  reserve(modelId: string, estimatedTokens: number): void {
+  reserve(modelId: string, estimatedTokens: number): number {
     const now = Date.now();
     const window = this.getOrCreateWindow(modelId);
     this.cleanup(window, now);
 
-    window.requests.push(now);
-    window.tokens.push({ ts: now, count: estimatedTokens });
+    const id = ++this.nextReservationId;
+    window.requests.push({ id, ts: now });
+    window.tokens.push({ id, ts: now, count: estimatedTokens });
     // Guard against NaN propagation — a corrupted rpd would silently
     // block all future capacity checks for this model.
     window.rpd = Math.max(0, (window.rpd || 0) + 1);
+    return id;
   }
 
   /** Reserve one unit from the shared grounding RPD pool. */
-  reserveGrounding(): void {
+  reserveGrounding(): string {
     const today = this.getTodayKey();
     if (this.groundingUsage.dateKey !== today) {
       this.groundingUsage = { dateKey: today, rpd: 0 };
     }
     this.groundingUsage.rpd += 1;
+    return today;
   }
 
   // ── Post-Response Adjustments ───────────────────────────────────────
@@ -202,33 +213,52 @@ export class QuotaTracker {
    * (causes slightly earlier model rotation); under-estimation is
    * corrected here to prevent future capacity miscalculations.
    */
-  reconcile(modelId: string, estimated: number, actual: number): void {
+  reconcile(
+    modelId: string,
+    _estimated: number,
+    actual: number,
+    reservationId?: number,
+  ): void {
     const window = this.usage.get(modelId);
     if (!window || window.tokens.length === 0) return;
 
-    const lastEntry = window.tokens[window.tokens.length - 1];
+    const lastEntry =
+      reservationId === undefined
+        ? window.tokens.at(-1)
+        : window.tokens.find((entry) => entry.id === reservationId);
+    if (!lastEntry || !Number.isFinite(actual)) return;
     // Clamp to zero — negative token counts corrupt TPM calculations.
     // This can happen if the estimate was wildly wrong or reconcile
     // is called multiple times for the same request.
-    lastEntry.count = Math.max(0, lastEntry.count + (actual - estimated));
+    lastEntry.count = Math.max(0, actual);
   }
 
   /**
    * Rollback a reservation if the API call fails.
    * Removes the most recent request + token entry and decrements RPD.
    */
-  rollback(modelId: string): void {
+  rollback(modelId: string, reservationId?: number): void {
     const window = this.usage.get(modelId);
     if (!window) return;
 
-    if (window.requests.length > 0) window.requests.pop();
-    if (window.tokens.length > 0) window.tokens.pop();
-    window.rpd = Math.max(0, window.rpd - 1);
+    const entry =
+      reservationId === undefined
+        ? window.requests.at(-1)
+        : window.requests.find((request) => request.id === reservationId);
+    if (!entry) return;
+    window.requests = window.requests.filter(
+      (request) => request.id !== entry.id,
+    );
+    window.tokens = window.tokens.filter((token) => token.id !== entry.id);
+    if (this.getTodayKey(entry.ts) === window.dateKey)
+      window.rpd = Math.max(0, window.rpd - 1);
   }
 
   /** Rollback one unit from the shared grounding RPD pool. */
-  rollbackGrounding(): void {
-    this.groundingUsage.rpd = Math.max(0, this.groundingUsage.rpd - 1);
+  rollbackGrounding(reservedDate = this.getTodayKey()): void {
+    this.hasGroundingCapacity();
+    if (reservedDate === this.groundingUsage.dateKey)
+      this.groundingUsage.rpd = Math.max(0, this.groundingUsage.rpd - 1);
   }
 
   // ── Diagnostics ─────────────────────────────────────────────────────
@@ -245,7 +275,9 @@ export class QuotaTracker {
     const models: Record<string, { rpm: number; tpm: number; rpd: number }> =
       {};
 
-    for (const [modelId, window] of this.usage) {
+    this.hasGroundingCapacity();
+    for (const modelId of this.usage.keys()) {
+      const window = this.getOrCreateWindow(modelId);
       this.cleanup(window, now);
       models[modelId] = {
         rpm: window.requests.length,

--- a/server/ai/services/contactParsing.ts
+++ b/server/ai/services/contactParsing.ts
@@ -1,3 +1,4 @@
+import { AppError } from "../../utils/AppError.ts";
 // =============================================================================
 // AI Services — Contact Parsing (Magic Paste, bulk import)
 // =============================================================================
@@ -124,7 +125,10 @@ function normalizeParsedContact(parsed: ParsedContact): ParsedContact {
  */
 export async function parseContactRecord(text: string): Promise<ParsedContact> {
   if (isMockMode()) {
-    throw new Error("AI provider not configured. Cannot run Auto-Parser.");
+    throw new AppError(
+      "AI provider not configured. Cannot run Auto-Parser.",
+      503,
+    );
   }
 
   const systemPrompt = `You are an expert contact data extraction system.
@@ -233,7 +237,24 @@ ${UNTRUSTED_DATA_RULE}`;
   if (!parsed)
     throw new Error("AI returned malformed JSON for contact parsing");
 
+  for (const field of [
+    "emails",
+    "phones",
+    "socialLinks",
+    "education",
+    "experience",
+  ] as const) {
+    const value = parsed[field];
+    if (value != null && (!Array.isArray(value) || value.length > 100))
+      throw new AppError("AI returned an invalid contact field list.", 502, {
+        code: "AI_SCHEMA_MISMATCH",
+      });
+  }
   const clean = normalizeParsedContact(parsed);
+  if (!clean.name)
+    throw new AppError("AI did not identify a contact name.", 502, {
+      code: "AI_SCHEMA_MISMATCH",
+    });
 
   log.info(
     "AIService",
@@ -272,7 +293,10 @@ export async function bulkParseContacts(
   concurrency?: number,
 ): Promise<(ParsedContact | null)[]> {
   if (isMockMode()) {
-    throw new Error("AI provider not configured. Cannot run bulk parser.");
+    throw new AppError(
+      "AI provider not configured. Cannot run bulk parser.",
+      503,
+    );
   }
 
   if (texts.length === 0) return [];
@@ -282,8 +306,13 @@ export async function bulkParseContacts(
   // that justify the conservative FREE tier concurrency of 2.
   const tier = getAITier();
   const providerName = (process.env.AI_PROVIDER ?? "gemini").toLowerCase();
-  const effectiveConcurrency =
-    concurrency ?? (providerName !== "gemini" ? 10 : tier === "PAID" ? 10 : 2);
+  const effectiveConcurrency = Math.max(
+    1,
+    Math.min(
+      concurrency ?? (providerName !== "gemini" ? 2 : tier === "PAID" ? 2 : 1),
+      2,
+    ),
+  );
 
   log.info(
     "AIService",

--- a/server/ai/services/mentions.ts
+++ b/server/ai/services/mentions.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 // =============================================================================
 // AI Services — Mention Extraction (ghost contacts from timeline notes)
 // =============================================================================
@@ -24,7 +25,6 @@ export async function extractMentions(text: string): Promise<MentionEntity[]> {
       "AIService",
       "Using mock AI Mentions due to unconfigured AI provider",
     );
-    await new Promise((resolve) => setTimeout(resolve, 1500));
     return [];
   }
 
@@ -81,11 +81,29 @@ You are a named-entity recognition system specializing in identifying people men
       },
     });
 
-    const parsed = safeParseJson<MentionEntity[]>(
-      result.text,
-      "extractMentions",
-    );
-    if (!parsed) return [];
+    const validated = z
+      .array(
+        z.object({
+          name: z.string().trim().min(1).max(200),
+          company: z.string().max(200).nullish(),
+          context: z.string().max(500),
+        }),
+      )
+      .max(30)
+      .safeParse(safeParseJson<unknown>(result.text, "extractMentions"));
+    if (!validated.success) return [];
+    const parsed = [
+      ...new Map(
+        validated.data
+          .filter((mention) =>
+            text.toLowerCase().includes(mention.name.toLowerCase()),
+          )
+          .map((mention) => [
+            mention.name.toLowerCase(),
+            { ...mention, company: mention.company ?? undefined },
+          ]),
+      ).values(),
+    ];
 
     // Cache the result — immutable input means this is safe to cache long-term
     aiCache.set("mentions", cacheKey, parsed);

--- a/server/ai/services/relationshipIntel.ts
+++ b/server/ai/services/relationshipIntel.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+import { AppError } from "../../utils/AppError.ts";
 // =============================================================================
 // AI Services — Relationship Intelligence (briefings, email digests, insights)
 // =============================================================================
@@ -19,19 +21,11 @@ import { isMockMode, safeParseJson } from "./shared.ts";
 export async function generateCatchMeUpBriefing(
   contact: Record<string, unknown>,
   interactions: Record<string, unknown>[],
+  signal?: AbortSignal,
 ): Promise<string[]> {
-  if (isMockMode()) {
-    log.warn(
-      "AIService",
-      "Using mock AI Briefing due to unconfigured AI provider",
-    );
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    return [
-      "Met at the Design Systems Conference last year; he expressed strong interest in component-driven architecture.",
-      "Need to close the loop on the draft proposal for the new Nexus design system integration.",
-      "Icebreaker: Ask how his studio in Copenhagen is holding up with the recent sudden weather shift!",
-    ];
-  }
+  signal?.throwIfAborted();
+  if (isMockMode())
+    throw new AppError("Configure AI in settings to generate a briefing.", 503);
 
   const systemPrompt = `${UNTRUSTED_DATA_RULE}
 
@@ -60,19 +54,28 @@ You are an elite executive assistant preparing a meeting brief.
     systemPrompt,
     prompt,
     responseFormat: "json",
+    signal,
+    timeoutMs: 20_000,
+    maxOutputTokens: 1_000,
     jsonSchema: {
       type: "array",
       items: { type: "string" },
     },
   });
 
-  const parsed = safeParseJson<string[]>(
-    result.text,
-    "generateCatchMeUpBriefing",
-  );
-  if (!parsed || !Array.isArray(parsed)) {
-    throw new Error("AI returned malformed response for briefing generation");
-  }
+  signal?.throwIfAborted();
+  const validated = z
+    .array(z.string().trim().min(1).max(1500))
+    .min(1)
+    .max(5)
+    .safeParse(
+      safeParseJson<unknown>(result.text, "generateCatchMeUpBriefing"),
+    );
+  if (!validated.success)
+    throw new AppError("AI returned an invalid briefing.", 502, {
+      code: "AI_SCHEMA_MISMATCH",
+    });
+  const parsed = validated.data;
 
   log.info(
     "AIService",
@@ -94,14 +97,8 @@ You are an elite executive assistant preparing a meeting brief.
  * Designed to strip Apple Mail export jargon organically.
  */
 export async function summarizeEmlEmail(rawEml: string): Promise<string> {
-  if (isMockMode()) {
-    log.warn(
-      "AIService",
-      "Using mock EML summary due to unconfigured AI provider",
-    );
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    return "<p><strong>Re: Q3 Roadmap Planning</strong></p><p>Thread summary:</p><ul><li>Julian proposed pushing the V2 alpha back by two weeks.</li><li>Sarah agreed to coordinate with marketing.</li><li>John provided the final wireframe mocks for the reporting suite.</li></ul>";
-  }
+  if (isMockMode())
+    throw new AppError("Configure AI in settings to summarize an email.", 503);
 
   const systemPrompt = `${UNTRUSTED_DATA_RULE}
 
@@ -171,7 +168,6 @@ export async function generateDailyInsight(stats: {
       "AIService",
       "Using mock Daily Insight due to unconfigured AI provider",
     );
-    await new Promise((resolve) => setTimeout(resolve, 800));
     return null;
   }
 
@@ -210,7 +206,15 @@ export async function generateDailyInsight(stats: {
       result.text,
       "generateDailyInsight",
     );
-    if (!parsed) return null;
+    if (
+      !parsed ||
+      typeof parsed.text !== "string" ||
+      !parsed.text.trim() ||
+      parsed.text.length > 2000 ||
+      typeof parsed.category !== "string" ||
+      parsed.category.length > 100
+    )
+      return null;
 
     log.info(
       "AIService",

--- a/server/ai/types.ts
+++ b/server/ai/types.ts
@@ -158,6 +158,8 @@ export interface RoutingPolicy {
  * Normalizes response metadata across providers.
  */
 export interface AIGenerateResult {
+  /** Source links reported by the provider grounding metadata. */
+  citations?: Array<{ title: string; uri: string }>;
   /** Raw text content of the model's response. */
   text: string;
 

--- a/server/ai/workQueue.ts
+++ b/server/ai/workQueue.ts
@@ -1,0 +1,106 @@
+import { AppError } from "../utils/AppError.ts";
+
+/** Bound concurrent provider calls and remove cancelled work before it starts. */
+export class GenerationQueue {
+  private active = 0;
+  private waiting: Array<{ start: () => void; cancel: () => void }> = [];
+
+  constructor(
+    private readonly concurrency = 2,
+    private readonly capacity = 16,
+  ) {}
+
+  run<T>(operation: () => Promise<T>, signal: AbortSignal): Promise<T> {
+    signal.throwIfAborted();
+    if (this.active >= this.concurrency && this.waiting.length >= this.capacity)
+      return Promise.reject(
+        new AppError("AI is busy. Please try again shortly.", 429, {
+          code: "AI_BUSY",
+        }),
+      );
+    return new Promise<T>((resolve, reject) => {
+      const cleanup = () => signal.removeEventListener("abort", job.cancel);
+      const job = {
+        cancel: () => {
+          this.waiting = this.waiting.filter((entry) => entry !== job);
+          cleanup();
+          reject(signal.reason);
+        },
+        start: () => {
+          cleanup();
+          if (signal.aborted) {
+            reject(signal.reason);
+            return;
+          }
+          this.active++;
+          Promise.resolve()
+            .then(() => {
+              signal.throwIfAborted();
+              return operation();
+            })
+            .then(resolve, reject)
+            .finally(() => {
+              this.active--;
+              this.waiting.shift()?.start();
+            });
+        },
+      };
+      if (this.active < this.concurrency) job.start();
+      else {
+        this.waiting.push(job);
+        signal.addEventListener("abort", job.cancel, { once: true });
+      }
+    });
+  }
+}
+
+/** Share identical work. One caller cannot cancel work another caller still needs. */
+export class SharedWork<T> {
+  private entries = new Map<
+    string,
+    { controller: AbortController; promise: Promise<T>; users: number }
+  >();
+
+  async run(
+    key: string,
+    operation: (signal: AbortSignal) => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    signal?.throwIfAborted();
+    let entry = this.entries.get(key);
+    if (!entry || entry.controller.signal.aborted) {
+      const controller = new AbortController();
+      const created = {
+        controller,
+        users: 0,
+        promise: Promise.resolve().then(() => {
+          controller.signal.throwIfAborted();
+          return operation(controller.signal);
+        }),
+      };
+      entry = created;
+      this.entries.set(key, created);
+      const remove = () => {
+        if (this.entries.get(key) === created) this.entries.delete(key);
+      };
+      created.promise.then(remove, remove);
+    }
+    const current = entry;
+    current.users++;
+    let onAbort: (() => void) | undefined;
+    const cancelled = new Promise<never>((_, reject) => {
+      onAbort = () => reject(signal?.reason);
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+    try {
+      return await Promise.race([current.promise, cancelled]);
+    } finally {
+      if (onAbort) signal?.removeEventListener("abort", onAbort);
+      current.users--;
+      if (current.users === 0) {
+        current.controller.abort();
+        if (this.entries.get(key) === current) this.entries.delete(key);
+      }
+    }
+  }
+}

--- a/server/routes/aiSearch.ts
+++ b/server/routes/aiSearch.ts
@@ -11,16 +11,12 @@ import { z } from "zod";
 import { validateBody } from "../utils/validators.ts";
 import { asyncHandler } from "../utils/asyncHandler.ts";
 import { jobQueue } from "../services/aiSearch/index.ts";
-import { contactService } from "../services/contactService.ts";
-import { ai } from "../ai/index.ts";
 import { log } from "../utils/logger.ts";
 import type { AISearchBatch } from "../services/aiSearch/types.ts";
 import { getErrorMessage } from "../utils/helpers.ts";
-import {
-  getDefaultStrategyForProvider,
-  getStrategy,
-} from "../services/aiSearch/strategies/index.ts";
-import { providerIdFor } from "../ai/gateway.ts";
+import { validateEnrichmentStrategy } from "../services/aiSearch/strategies/index.ts";
+import { enrichmentContact } from "../services/aiSearch/contactSnapshot.ts";
+import { AppError } from "../utils/AppError.ts";
 
 export const aiSearchRouter = Router();
 
@@ -34,8 +30,15 @@ export const aiSearchRouter = Router();
 // the in-memory 5-minute cooldown in jobQueue.canStartBatch() provides
 // equivalent protection. Add express-rate-limit if deploying multi-tenant.
 const aiSearchBodySchema = z.object({
-  contactIds: z.array(z.string()).min(1).max(100),
-  strategy: z.string().optional(),
+  contactIds: z
+    .array(z.string().trim().min(1).max(100))
+    .min(1)
+    .max(100)
+    .refine(
+      (ids) => new Set(ids).size === ids.length,
+      "Contact IDs must be unique",
+    ),
+  strategy: z.enum(["two-pass", "single-pass", "searxng"]).optional(),
 });
 
 // =============================================================================
@@ -48,28 +51,7 @@ aiSearchRouter.post(
   asyncHandler(async (req, res) => {
     const { contactIds, strategy: requestedStrategy } = req.body;
 
-    const researchProvider = providerIdFor("research");
-    const strategy =
-      requestedStrategy ?? getDefaultStrategyForProvider(researchProvider);
-
-    try {
-      getStrategy(strategy);
-    } catch (err) {
-      return res.status(400).json({ error: getErrorMessage(err) });
-    }
-
-    // Check AI provider is configured
-    if (!ai.isConfigured) {
-      const KEY_MAP: Record<string, string> = {
-        gemini: "GEMINI_API_KEY",
-        openai: "OPENAI_API_KEY",
-        anthropic: "ANTHROPIC_API_KEY",
-      };
-      const keyVar = KEY_MAP[researchProvider ?? "gemini"] ?? "GEMINI_API_KEY";
-      return res.status(503).json({
-        error: `AI provider is not configured. Set ${keyVar} in your .env file.`,
-      });
-    }
+    const strategy = validateEnrichmentStrategy(requestedStrategy);
 
     // Canary guard — checks both in-progress lock and cooldown
     const check = jobQueue.canStartBatch();
@@ -80,25 +62,15 @@ aiSearchRouter.post(
     // Fetch contact names for the job queue UI display
     const contacts: Array<{ id: string; name: string }> = [];
     for (const id of contactIds) {
-      const contact = contactService.getContactById(id);
-      if (contact) {
-        contacts.push({ id: contact.id, name: contact.name });
-      } else {
-        log.warn("AISearchRoute", `Contact ${id} not found — skipping`);
-      }
-    }
-
-    if (contacts.length === 0) {
-      return res
-        .status(400)
-        .json({ error: "None of the selected contacts were found." });
+      const contact = enrichmentContact(id);
+      contacts.push({ id: contact.id, name: contact.name });
     }
 
     // Create batch
     const batch = jobQueue.createBatch(contacts, strategy);
 
     // Kick off processing async (fire-and-forget — don't await)
-    jobQueue.processBatch(batch.id, ai).catch((err) => {
+    jobQueue.processBatch(batch.id).catch((err) => {
       log.error(
         "AISearchRoute",
         `Batch ${batch.id} processing error: ${getErrorMessage(err)}`,
@@ -117,7 +89,7 @@ aiSearchRouter.post(
 aiSearchRouter.get(
   "/ai-search/status",
   asyncHandler(async (req, res) => {
-    const batchId = req.query.batchId as string;
+    const batchId = z.string().min(1).max(100).parse(req.query.batchId);
     if (!batchId) {
       return res
         .status(400)
@@ -138,50 +110,41 @@ aiSearchRouter.get(
 // =============================================================================
 
 aiSearchRouter.get("/ai-search/stream", (req, res) => {
-  const batchId = req.query.batchId as string;
-  if (!batchId) {
-    return res
-      .status(400)
-      .json({ error: "batchId query parameter is required." });
-  }
-
-  // Set up SSE headers
-  res.setHeader("Content-Type", "text/event-stream");
-  res.setHeader("Cache-Control", "no-cache");
-  res.setHeader("Connection", "keep-alive");
-  res.flushHeaders();
-
-  // Send current state immediately
+  const batchId = z.string().min(1).max(100).parse(req.query.batchId);
   const batch = jobQueue.getBatch(batchId);
-  if (!batch) {
-    res.write(`data: ${JSON.stringify({ error: "Batch not found" })}\n\n`);
-    return res.end();
-  }
-
-  res.write(`data: ${JSON.stringify(batch)}\n\n`);
-
-  // If already complete, close immediately
-  if (batch.status === "complete" || batch.status === "cancelled") {
-    return res.end();
-  }
-
-  // Subscribe to live updates from the job queue EventEmitter
-  const handler = (updatedBatch: AISearchBatch) => {
-    res.write(`data: ${JSON.stringify(updatedBatch)}\n\n`);
+  if (!batch)
+    throw new AppError("Batch not found. The server may have restarted.", 404);
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("X-Accel-Buffering", "no");
+  res.flushHeaders();
+  const send = (updated: AISearchBatch) => {
+    if (res.destroyed || res.writableEnded) return;
     if (
-      updatedBatch.status === "complete" ||
-      updatedBatch.status === "cancelled"
-    ) {
-      // Self-cleanup: remove listener before ending response
-      jobQueue.off(batchId, handler);
+      !res.write(`data: ${JSON.stringify(updated)}\n\n`) ||
+      updated.status !== "processing"
+    )
       res.end();
-    }
   };
+  send(batch);
+  if (res.writableEnded) return;
+  const heartbeat = setInterval(() => {
+    if (!res.destroyed && !res.writableEnded && !res.write(": heartbeat\n\n"))
+      res.end();
+  }, 15_000);
+  heartbeat.unref();
+  const cleanup = () => {
+    clearInterval(heartbeat);
+    jobQueue.off(batchId, send);
+  };
+  jobQueue.on(batchId, send);
+  res.once("close", cleanup);
+  res.once("finish", cleanup);
+});
 
-  jobQueue.on(batchId, handler);
-
-  // Also cleanup on client disconnect
-  req.on("close", () => {
-    jobQueue.off(batchId, handler);
-  });
+aiSearchRouter.post("/ai-search/:batchId/cancel", (req, res) => {
+  const batchId = z.string().min(1).max(100).parse(req.params.batchId);
+  const batch = jobQueue.cancelBatch(batchId);
+  if (!batch) throw new AppError("Batch not found.", 404);
+  res.json(batch);
 });

--- a/server/routes/contacts.ts
+++ b/server/routes/contacts.ts
@@ -1,3 +1,9 @@
+import {
+  enrichmentContact,
+  lockEnrichment,
+} from "../services/aiSearch/contactSnapshot.ts";
+import { withTimeout } from "../ai/resilience.ts";
+import { validateEnrichmentStrategy } from "../services/aiSearch/strategies/index.ts";
 import { requireContact } from "../services/contactGuard.ts";
 import { idsSchema } from "../utils/validators.ts";
 import { Router } from "express";
@@ -18,12 +24,8 @@ import { z } from "zod";
 import { AppError } from "../utils/AppError.ts";
 import { asyncHandler } from "../utils/asyncHandler.ts";
 import { sqlite } from "../db.ts";
-import { ai } from "../ai/index.ts";
 import { providerIdFor } from "../ai/gateway.ts";
-import {
-  getStrategy,
-  getDefaultStrategyForProvider,
-} from "../services/aiSearch/strategies/index.ts";
+import { getStrategy } from "../services/aiSearch/strategies/index.ts";
 import {
   buildSearchPrompt,
   type AISearchOutput,
@@ -720,70 +722,58 @@ router.post(
     const rid = req.requestId;
     const id = String(req.params.id);
 
-    // Check AI provider is configured (F-03: provider-aware error message)
-    if (!ai.isConfigured) {
-      const KEY_MAP: Record<string, string> = {
-        gemini: "GEMINI_API_KEY",
-        openai: "OPENAI_API_KEY",
-        anthropic: "ANTHROPIC_API_KEY",
-      };
-      const keyVar = KEY_MAP[ai.providerName] ?? "GEMINI_API_KEY";
-      throw new AppError(
-        `AI provider is not configured. Set ${keyVar} in your .env file.`,
-        503,
+    const strategyName = validateEnrichmentStrategy();
+    const contact = enrichmentContact(id);
+    const release = lockEnrichment(id);
+    const controller = new AbortController();
+    const onClose = () => {
+      if (!res.writableEnded) controller.abort();
+    };
+    res.on("close", onClose);
+    try {
+      const startMs = Date.now();
+      // F-02: Use provider-aware strategy instead of hardcoded 'two-pass'
+      // Strategy follows whichever provider serves the *research* capability,
+      // not the legacy default provider.
+      const researchProvider = providerIdFor("research");
+      const strategy = getStrategy(strategyName);
+      const prompt = buildSearchPrompt(contact);
+
+      log.info(
+        "API",
+        `[${rid}] POST /api/contacts/${id}/enrich — starting ${strategyName} for "${contact.name}" (provider: ${researchProvider ?? "none"})`,
       );
+
+      const result = await withTimeout(
+        (signal) => strategy.execute(contact, prompt, signal),
+        90_000,
+        controller.signal,
+      );
+      controller.signal.throwIfAborted();
+      const fieldsUpdated = mergeSearchResult(
+        id,
+        contact,
+        result.data as AISearchOutput,
+        result.citations,
+      );
+      const latencyMs = Date.now() - startMs;
+
+      log.info(
+        "API",
+        `[${rid}] POST /api/contacts/${id}/enrich — ${fieldsUpdated} field(s) merged in ${latencyMs}ms`,
+      );
+
+      res.json({
+        success: true,
+        fieldsUpdated,
+        latencyMs,
+        models: result.models,
+        tokenCount: result.tokenCount,
+      });
+    } finally {
+      release();
+      res.off("close", onClose);
     }
-
-    // Check grounding capacity (F-04: only for Gemini — other providers don't have grounding RPD)
-    if (ai.providerName === "gemini") {
-      const snapshot = ai.getQuotaSnapshot();
-      if (snapshot.grounding.remaining <= 0) {
-        return res.status(429).json({
-          error: "Grounding quota exhausted for today. Try again tomorrow.",
-          remaining: 0,
-          limit: snapshot.grounding.limit,
-        });
-      }
-    }
-
-    // Fetch the contact
-    const contact = contactService.getContactById(id);
-    if (!contact) throw new AppError("Contact not found", 404);
-
-    const startMs = Date.now();
-    // F-02: Use provider-aware strategy instead of hardcoded 'two-pass'
-    // Strategy follows whichever provider serves the *research* capability,
-    // not the legacy default provider.
-    const researchProvider = providerIdFor("research");
-    const strategyName = getDefaultStrategyForProvider(researchProvider);
-    const strategy = getStrategy(strategyName);
-    const prompt = buildSearchPrompt(contact);
-
-    log.info(
-      "API",
-      `[${rid}] POST /api/contacts/${id}/enrich — starting ${strategyName} for "${contact.name}" (provider: ${researchProvider ?? "none"})`,
-    );
-
-    const result = await strategy.execute(contact, prompt);
-    const fieldsUpdated = mergeSearchResult(
-      id,
-      contact,
-      result.data as AISearchOutput,
-    );
-    const latencyMs = Date.now() - startMs;
-
-    log.info(
-      "API",
-      `[${rid}] POST /api/contacts/${id}/enrich — ${fieldsUpdated} field(s) merged in ${latencyMs}ms`,
-    );
-
-    res.json({
-      success: true,
-      fieldsUpdated,
-      latencyMs,
-      models: result.models,
-      tokenCount: result.tokenCount,
-    });
   }),
 );
 

--- a/server/routes/interactions.ts
+++ b/server/routes/interactions.ts
@@ -90,9 +90,20 @@ router.post(
   requireContact,
   asyncHandler(async (req, res) => {
     const rid = req.requestId;
-    const points = await interactionService.generateBriefing(
-      String(req.params.id),
-    );
+    const controller = new AbortController();
+    const onClose = () => {
+      if (!res.writableEnded) controller.abort();
+    };
+    res.on("close", onClose);
+    let points;
+    try {
+      points = await interactionService.generateBriefing(
+        String(req.params.id),
+        controller.signal,
+      );
+    } finally {
+      res.off("close", onClose);
+    }
     if (!points) throw new AppError("Contact not found", 404);
 
     log.info(

--- a/server/services/aiSearch/contactSnapshot.ts
+++ b/server/services/aiSearch/contactSnapshot.ts
@@ -1,0 +1,51 @@
+import { contactRepo } from "../../repositories/contactRepository.ts";
+import { sqlite } from "../../db.ts";
+import type { HydratedContact } from "../../repositories/types.ts";
+import { contentHash } from "../../utils/aiCache.ts";
+import { ACTIVE_CONTACT_SQL } from "../search/ftsIndex.ts";
+import { AppError } from "../../utils/AppError.ts";
+
+/** Read an active local contact before accepting an enrichment result. */
+export function enrichmentContact(id: string): HydratedContact {
+  const row = sqlite
+    .prepare(
+      `SELECT c.* FROM contacts c WHERE c.id = ? AND ${ACTIVE_CONTACT_SQL}`,
+    )
+    .get(id);
+  const contact = row ? contactRepo.hydrate(row) : null;
+  if (!contact)
+    throw new AppError("Contact is no longer available for enrichment.", 409);
+  return contact;
+}
+
+/** Retain user fields and child records when comparing local contact versions. */
+export function contactFingerprint(contact: object): string {
+  const derived = new Set([
+    "updatedAt",
+    "relationshipScore",
+    "relationshipHealth",
+    "aiBriefing",
+    "aiBriefingAt",
+    "aiHydratedAt",
+  ]);
+  return contentHash(
+    JSON.stringify(contact, (key, value) =>
+      derived.has(key) ? undefined : value,
+    ),
+  );
+}
+
+const active = new Set<string>();
+
+/** Reject overlapping actions for the same contact before either can write a stale result. */
+export function lockEnrichment(id: string): () => void {
+  if (active.has(id))
+    throw new AppError(
+      "Research for this contact is already in progress.",
+      409,
+    );
+  active.add(id);
+  return () => {
+    active.delete(id);
+  };
+}

--- a/server/services/aiSearch/jobQueue.ts
+++ b/server/services/aiSearch/jobQueue.ts
@@ -25,11 +25,11 @@ import type {
 import type { AIProvider } from "../../ai/provider.ts";
 import { buildSearchPrompt, type AISearchOutput } from "./promptTemplate.ts";
 import { mergeSearchResult } from "./mergeEngine.ts";
-import { contactService } from "../contactService.ts";
 import { getStrategy } from "./strategies/index.ts";
 import { log } from "../../utils/logger.ts";
 import { getErrorMessage } from "../../utils/helpers.ts";
-import { aiCache } from "../../utils/aiCache.ts";
+import { withTimeout, sleep } from "../../ai/resilience.ts";
+import { enrichmentContact, lockEnrichment } from "./contactSnapshot.ts";
 
 // =============================================================================
 // Error Classification
@@ -51,6 +51,7 @@ function classifyError(error: unknown): AISearchErrorType {
   if (
     msg.includes("zod") ||
     msg.includes("validation") ||
+    msg.includes("source links") ||
     msg.includes("json.parse") ||
     msg.includes("schema") ||
     msg.includes("json parse")
@@ -73,6 +74,7 @@ function classifyError(error: unknown): AISearchErrorType {
   }
   if (
     msg.includes("api key") ||
+    msg.includes("credentials") ||
     msg.includes("unauthorized") ||
     msg.includes("403") ||
     msg.includes("permission")
@@ -104,19 +106,10 @@ const GC_TTL_MS = 30 * 60 * 1000;
 /** Delay between sequential jobs to avoid Gemini grounding API rate limits */
 const INTER_JOB_DELAY_MS = 2_500;
 
-/** Max retries for retryable errors (rate_limit, network, validation, unknown) per job */
-const MAX_RETRIES = 4;
-
-/** Initial backoff delay for retries (doubles each attempt: 3s → 6s → 12s → 24s) */
-const INITIAL_BACKOFF_MS = 3_000;
-
-/** Non-blocking sleep for inter-job delay and exponential backoff */
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => setTimeout(resolve, ms));
-
 class AISearchJobQueue extends EventEmitter {
   private batches = new Map<string, AISearchBatch>();
   private processing = false;
+  private controllers = new Map<string, AbortController>();
   private lastBatchCompletedAt: Date | null = null;
 
   /**
@@ -152,7 +145,9 @@ class AISearchJobQueue extends EventEmitter {
     this.gc();
 
     const batchId = crypto.randomUUID();
-    const jobs: AISearchJob[] = contacts.map((c) => ({
+    const jobs: AISearchJob[] = [
+      ...new Map(contacts.map((c) => [c.id, c])).values(),
+    ].map((c) => ({
       id: crypto.randomUUID(),
       contactId: c.id,
       contactName: c.name,
@@ -181,143 +176,91 @@ class AISearchJobQueue extends EventEmitter {
    * Process all jobs in a batch sequentially.
    * One contact at a time. Individual failures never block the batch.
    */
-  async processBatch(batchId: string, _adapter: AIProvider): Promise<void> {
-    if (this.processing) {
+  async processBatch(batchId: string, _adapter?: AIProvider): Promise<void> {
+    if (this.processing)
       throw new Error("An AI Search batch is already in progress");
-    }
-    this.processing = true;
-
     const batch = this.batches.get(batchId);
-    if (!batch) {
-      this.processing = false;
-      throw new Error(`Batch ${batchId} not found`);
-    }
-
+    if (!batch || batch.status !== "processing") return;
     const strategy = getStrategy(batch.strategy);
-    log.info(
-      "AISearchQueue",
-      `Processing batch ${batchId} with strategy: ${strategy.name}`,
-    );
-
+    const controller = new AbortController();
+    this.controllers.set(batchId, controller);
+    this.processing = true;
     try {
-      // Batch mode: defer cache invalidations during the entire batch.
-      // Each mergeSearchResult call triggers invalidateSearchCache() —
-      // without batch mode, that's N full cache flushes. With batch mode,
-      // exactly 1 flush after all jobs complete.
-      aiCache.enterBatchMode();
-
-      for (let jobIdx = 0; jobIdx < batch.jobs.length; jobIdx++) {
-        const job = batch.jobs[jobIdx];
-        const jobStartMs = Date.now();
-
-        // Inter-job delay to prevent Gemini grounding API rate limiting.
-        // The first job runs immediately; subsequent jobs wait 1.5s.
-        if (jobIdx > 0) {
-          await sleep(INTER_JOB_DELAY_MS);
-        }
-
-        // Retry loop: retryable errors (rate_limit, network) get up to MAX_RETRIES
-        for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-          try {
-            if (attempt > 0) {
-              // Exponential backoff: 2s → 4s → 8s
-              const backoffMs = INITIAL_BACKOFF_MS * Math.pow(2, attempt - 1);
-              log.info(
-                "AISearchQueue",
-                `Job ${job.id} (${job.contactName}): retry ${attempt}/${MAX_RETRIES} after ${backoffMs}ms backoff`,
-              );
-              job.status = "searching"; // Reset status for retry
-              this.emit(batchId, batch);
-              await sleep(backoffMs);
-            }
-
-            // 1. Set status → 'searching'
-            job.status = "searching";
-            job.startedAt = job.startedAt ?? new Date().toISOString();
-            this.emit(batchId, batch);
-
-            // 2. Fetch full HydratedContact
-            const contact = contactService.getContactById(job.contactId);
-            if (!contact) {
-              throw new Error(`Contact ${job.contactId} not found`);
-            }
-
-            // 3. Build prompt
-            const prompt = buildSearchPrompt(contact);
-
-            // 4. Execute strategy (two-pass internally)
-            const result = await strategy.execute(contact, prompt);
-
-            // 5. Set status → 'merging'
-            job.status = "merging";
-            this.emit(batchId, batch);
-
-            // 6. Run merge engine
-            const fieldsUpdated = mergeSearchResult(
-              job.contactId,
-              contact,
-              result.data as AISearchOutput,
-            );
-
-            // 7. Set status → 'success'
-            job.status = "success";
-            job.fieldsUpdated = fieldsUpdated;
-            job.completedAt = new Date().toISOString();
-            job.latencyMs = Date.now() - jobStartMs;
-
-            // Accumulate token usage
-            batch.totalTokens += result.tokenCount ?? 0;
-
-            log.info(
-              "AISearchQueue",
-              `Job ${job.id} (${job.contactName}): success — ${fieldsUpdated} field(s) merged in ${job.latencyMs}ms`,
-            );
-            this.emit(batchId, batch);
-            break; // Success — exit retry loop
-          } catch (err: unknown) {
-            const errorType = classifyError(err);
-            const isRetryable =
-              errorType === "rate_limit" ||
-              errorType === "network" ||
-              errorType === "validation" ||
-              errorType === "unknown";
-
-            if (!isRetryable || attempt === MAX_RETRIES) {
-              // Non-retryable error or exhausted retries — mark as failed
-              job.status = "error";
-              job.error = getErrorMessage(err) || "Unknown error";
-              job.errorType = errorType;
-              job.completedAt = new Date().toISOString();
-              job.latencyMs = Date.now() - jobStartMs;
-
-              log.error(
-                "AISearchQueue",
-                `Job ${job.id} (${job.contactName}): ${errorType} — ${getErrorMessage(err)}${attempt > 0 ? ` (after ${attempt} retries)` : ""}`,
-              );
-              this.emit(batchId, batch);
-              break; // Exit retry loop
-            }
-
-            // Retryable error — will loop and try again
+      for (let index = 0; index < batch.jobs.length; index++) {
+        controller.signal.throwIfAborted();
+        if (index > 0) await sleep(INTER_JOB_DELAY_MS, controller.signal);
+        const job = batch.jobs[index];
+        const startMs = Date.now();
+        let release: (() => void) | undefined;
+        try {
+          const contact = enrichmentContact(job.contactId);
+          release = lockEnrichment(job.contactId);
+          job.status = "searching";
+          job.startedAt = new Date().toISOString();
+          this.emit(batchId, batch);
+          const prompt = buildSearchPrompt(contact);
+          const result = await withTimeout(
+            (signal) => strategy.execute(contact, prompt, signal),
+            90_000,
+            controller.signal,
+          );
+          controller.signal.throwIfAborted();
+          job.status = "merging";
+          this.emit(batchId, batch);
+          job.fieldsUpdated = mergeSearchResult(
+            job.contactId,
+            contact,
+            result.data as AISearchOutput,
+            result.citations,
+          );
+          job.status = "success";
+          batch.totalTokens += result.tokenCount ?? 0;
+        } catch (error) {
+          if (controller.signal.aborted) {
+            job.status = "cancelled";
+          } else {
+            job.status = "error";
+            job.errorType = classifyError(error);
+            job.error = getErrorMessage(error);
             log.warn(
               "AISearchQueue",
-              `Job ${job.id} (${job.contactName}): ${errorType} — ${getErrorMessage(err)} (will retry)`,
+              `Job ${job.id} failed. The batch does not repeat completed research stages.`,
             );
           }
+        } finally {
+          release?.();
+          job.completedAt = new Date().toISOString();
+          job.latencyMs = Date.now() - startMs;
+          this.emit(batchId, batch);
         }
       }
+    } catch (error) {
+      if (!controller.signal.aborted) throw error;
     } finally {
-      aiCache.exitBatchMode();
-      this.processing = false;
-      this.lastBatchCompletedAt = new Date();
-      batch.status = "complete";
-      // Final emit signals SSE clients to close
+      if (this.controllers.get(batchId) === controller) {
+        this.processing = false;
+        this.lastBatchCompletedAt = new Date();
+        this.controllers.delete(batchId);
+      }
+      batch.status = controller.signal.aborted ? "cancelled" : "complete";
       this.emit(batchId, batch);
-      log.info(
-        "AISearchQueue",
-        `Batch ${batchId} complete: ${batch.jobs.filter((j) => j.status === "success").length}/${batch.jobs.length} succeeded, ${batch.totalTokens} tokens used`,
-      );
     }
+  }
+
+  /** Stop active research and prevent queued contacts from starting. */
+  cancelBatch(batchId: string): AISearchBatch | null {
+    const batch = this.batches.get(batchId);
+    if (!batch || batch.status !== "processing") return batch ?? null;
+    batch.status = "cancelled";
+    for (const job of batch.jobs) {
+      if (["queued", "searching", "merging"].includes(job.status)) {
+        job.status = "cancelled";
+        job.completedAt = new Date().toISOString();
+      }
+    }
+    this.controllers.get(batchId)?.abort();
+    this.emit(batchId, batch);
+    return batch;
   }
 
   /** Get a batch by ID, or null if not found. */
@@ -358,6 +301,8 @@ class AISearchJobQueue extends EventEmitter {
 
   /** Reset queue state for tests. */
   __resetForTests(): void {
+    for (const controller of this.controllers.values()) controller.abort();
+    this.controllers.clear();
     this.batches.clear();
     this.processing = false;
     this.lastBatchCompletedAt = null;

--- a/server/services/aiSearch/mergeEngine.ts
+++ b/server/services/aiSearch/mergeEngine.ts
@@ -21,12 +21,14 @@ import { sqlite } from "../../db.ts";
 import { sanitizeAiOutputValue } from "../../ai/promptSafety.ts";
 import { contactRepo } from "../../repositories/contactRepository.ts";
 import { scheduleSearchIndex } from "../search/indexQueue.ts";
-import { invalidateSearchCache } from "../../utils/aiCache.ts";
+import { invalidateSearchCache, aiCache } from "../../utils/aiCache.ts";
 import type {
   HydratedContact,
   ChildRecordsPayload,
 } from "../../repositories/types.ts";
-import type { AISearchOutput } from "./promptTemplate.ts";
+import { aiSearchOutputSchema, type AISearchOutput } from "./promptTemplate.ts";
+import { contactFingerprint, enrichmentContact } from "./contactSnapshot.ts";
+import { AppError } from "../../utils/AppError.ts";
 import { log } from "../../utils/logger.ts";
 
 // =============================================================================
@@ -57,8 +59,55 @@ const ALLOWED_SCALAR_FIELDS = new Set([
 export function mergeSearchResult(
   contactId: string,
   existing: HydratedContact,
-  searchResult: AISearchOutput,
+  output: unknown,
+  citations: Array<{ title: string; uri: string }> = [],
 ): number {
+  const fresh = enrichmentContact(contactId);
+  if (contactFingerprint(fresh) !== contactFingerprint(existing))
+    throw new AppError(
+      "Contact changed during research. Review the contact and try again.",
+      409,
+    );
+  existing = fresh;
+  const parsed = aiSearchOutputSchema.safeParse(output);
+  if (!parsed.success)
+    throw new AppError("AI research failed schema validation.", 502, {
+      code: "AI_SCHEMA_MISMATCH",
+    });
+  const searchResult = parsed.data;
+  // Deduplicate incoming arrays before comparing them with existing records.
+  const keys = {
+    emails: (entry: { email: string }) => entry.email.trim().toLowerCase(),
+    phones: (entry: { phone: string }) => entry.phone.replace(/\D/g, ""),
+    socialLinks: (entry: { url: string }) =>
+      entry.url.toLowerCase().replace(/\/$/, ""),
+    education: (entry: { school: string; degree?: string }) =>
+      `${entry.school}|${entry.degree ?? ""}`.toLowerCase(),
+    experience: (entry: {
+      company: string;
+      role?: string;
+      startDate?: string;
+    }) =>
+      `${entry.company}|${entry.role ?? ""}|${entry.startDate ?? ""}`.toLowerCase(),
+    tags: (entry: { tag: string }) => entry.tag.toLowerCase(),
+    interests: (entry: { interest: string }) => entry.interest.toLowerCase(),
+    attributes: (entry: { name: string }) => entry.name.toLowerCase(),
+    addresses: (entry: { address: string }) => entry.address.toLowerCase(),
+  };
+  for (const field of Object.keys(keys) as (keyof typeof keys)[]) {
+    const entries = searchResult[field];
+    if (!entries) continue;
+    const seen = new Set<string>();
+    const key = keys[field] as (entry: unknown) => string;
+    Object.assign(searchResult, {
+      [field]: entries.filter((entry) => {
+        const value = key(entry);
+        if (seen.has(value)) return false;
+        seen.add(value);
+        return true;
+      }),
+    });
+  }
   let fieldsUpdated = 0;
   const scalarUpdate: Record<string, unknown> = {};
 
@@ -93,7 +142,7 @@ export function mergeSearchResult(
 
   // 1b. aiBackground (dossier) — synthesize a clean markdown brief from extraction
   if (!existing.aiBackground) {
-    const dossier = synthesizeDossier(existing, searchResult);
+    const dossier = synthesizeDossier(existing, searchResult, citations);
     if (dossier) {
       const safeDossier = sanitizeAiOutputValue(dossier, 12_000);
       if (safeDossier !== null) {
@@ -226,10 +275,18 @@ export function mergeSearchResult(
     Array.isArray(searchResult.interests) &&
     searchResult.interests.length > 0
   ) {
-    childData.interests = searchResult.interests.map((i) => ({
-      interest: i.interest,
-      isAiGenerated: true,
-    }));
+    childData.interests = searchResult.interests
+      .filter(
+        (i) =>
+          !existing.interests.some(
+            (saved) =>
+              saved.interest.toLowerCase() === i.interest.toLowerCase(),
+          ),
+      )
+      .map((i) => ({
+        interest: i.interest,
+        isAiGenerated: true,
+      }));
     fieldsUpdated += childData.interests.length;
   }
 
@@ -238,7 +295,12 @@ export function mergeSearchResult(
     Array.isArray(searchResult.attributes) &&
     searchResult.attributes.length > 0
   ) {
-    childData.attributes = searchResult.attributes;
+    childData.attributes = searchResult.attributes.filter(
+      (attribute) =>
+        !existing.attributes.some(
+          (saved) => saved.name.toLowerCase() === attribute.name.toLowerCase(),
+        ),
+    );
     fieldsUpdated += childData.attributes.length;
   }
 
@@ -297,6 +359,8 @@ export function mergeSearchResult(
 
   // Invalidate the semantic search cache so updated data is searchable
   invalidateSearchCache();
+  aiCache.invalidate("briefing", contactId);
+  aiCache.invalidate("dailyInsight");
   scheduleSearchIndex(contactId);
 
   log.info(
@@ -320,6 +384,7 @@ export function mergeSearchResult(
 function synthesizeDossier(
   existing: HydratedContact,
   searchResult: AISearchOutput,
+  citations: Array<{ title: string; uri: string }>,
 ): string | null {
   const name = existing.name || "This contact";
   const sections: string[] = [];
@@ -394,6 +459,20 @@ function synthesizeDossier(
   // Only produce a dossier if we have at least one substantive section
   if (sections.length === 0) return null;
 
+  const urls = [...new Set(citations.map((source) => source.uri))]
+    .filter((uri) => {
+      try {
+        const url = new URL(uri);
+        return /^https?:$/.test(url.protocol) && !url.username && !url.password;
+      } catch {
+        return false;
+      }
+    })
+    .slice(0, 10);
+  if (urls.length)
+    sections.push(
+      `### Sources\n${urls.map((uri, index) => `- [Source ${index + 1}](<${uri.replace(/[<>\s]/g, (character) => encodeURIComponent(character))}>)`).join("\n")}`,
+    );
   return sections.join("\n\n");
 }
 

--- a/server/services/aiSearch/promptTemplate.ts
+++ b/server/services/aiSearch/promptTemplate.ts
@@ -226,95 +226,83 @@ Return null for fields you cannot verify through internet search.
 // .strict() which rejects the entire response if one unexpected field appears.
 // =============================================================================
 
+const shortText = z.string().trim().max(500);
+const optionalText = shortText
+  .nullish()
+  .transform((value) => value ?? undefined);
+const webUrl = z
+  .string()
+  .trim()
+  .max(2000)
+  .url()
+  .refine(
+    (value) => /^https?:\/\//i.test(value),
+    "Expected an HTTP or HTTPS URL",
+  );
+const optionalUrl = z.preprocess(
+  (value) => (value === "" ? null : value),
+  webUrl.nullish(),
+);
+const list = <T extends z.ZodType>(item: T) =>
+  z
+    .array(item)
+    .max(50)
+    .nullish()
+    .transform((value) => value ?? undefined);
+
 export const aiSearchOutputSchema = z.object({
-  role: z.string().nullish(),
-  company: z.string().nullish(),
-  headline: z.string().nullish(),
-  about: z.string().nullish(),
-  industry: z.string().nullish(),
-  website: z.string().nullish(),
-  location: z.string().nullish(),
-  pronouns: z.string().nullish(),
-  birthday: z.string().nullish(),
-  emails: z
-    .array(
-      z.object({
-        email: z.string(),
-        label: z.string().optional(),
-      }),
-    )
-    .optional(),
-  phones: z
-    .array(
-      z.object({
-        phone: z.string(),
-        label: z.string().optional(),
-      }),
-    )
-    .optional(),
-  socialLinks: z
-    .array(
-      z.object({
-        platform: z.string(),
-        url: z.string(),
-      }),
-    )
-    .optional(),
-  education: z
-    .array(
-      z.object({
-        school: z.string(),
-        degree: z.string().optional(),
-        fieldOfStudy: z.string().optional(),
-        startDate: z.string().optional(),
-        endDate: z.string().optional(),
-      }),
-    )
-    .optional(),
-  experience: z
-    .array(
-      z.object({
-        company: z.string(),
-        role: z.string().optional(),
-        startDate: z.string().optional(),
-        endDate: z.string().optional(),
-        isCurrent: z.boolean().optional(),
-        description: z.string().optional(),
-        location: z.string().optional(),
-      }),
-    )
-    .optional(),
-  tags: z
-    .array(
-      z.object({
-        tag: z.string(),
-      }),
-    )
-    .optional(),
-  interests: z
-    .array(
-      z.object({
-        interest: z.string(),
-        isAiGenerated: z.boolean().optional(),
-      }),
-    )
-    .optional(),
-  attributes: z
-    .array(
-      z.object({
-        name: z.string(),
-        value: z.string(),
-      }),
-    )
-    .optional(),
-  addresses: z
-    .array(
-      z.object({
-        address: z.string(),
-        label: z.string().optional(),
-      }),
-    )
-    .optional(),
+  role: optionalText,
+  company: optionalText,
+  headline: optionalText,
+  about: z.string().trim().max(4000).nullish(),
+  industry: optionalText,
+  website: optionalUrl,
+  location: optionalText,
+  pronouns: optionalText,
+  birthday: optionalText,
+  emails: list(z.object({ email: z.email().max(320), label: optionalText })),
+  phones: list(
+    z.object({ phone: z.string().trim().min(1).max(80), label: optionalText }),
+  ),
+  socialLinks: list(z.object({ platform: shortText.min(1), url: webUrl })),
+  education: list(
+    z.object({
+      school: shortText.min(1),
+      degree: optionalText,
+      fieldOfStudy: optionalText,
+      startDate: optionalText,
+      endDate: optionalText,
+    }),
+  ),
+  experience: list(
+    z.object({
+      company: shortText.min(1),
+      role: optionalText,
+      startDate: optionalText,
+      endDate: optionalText,
+      isCurrent: z
+        .boolean()
+        .nullish()
+        .transform((value) => value ?? undefined),
+      description: z
+        .string()
+        .max(4000)
+        .nullish()
+        .transform((value) => value ?? undefined),
+      location: optionalText,
+    }),
+  ),
+  tags: list(z.object({ tag: shortText.min(1) })),
+  interests: list(
+    z.object({
+      interest: shortText.min(1),
+      isAiGenerated: z.boolean().optional(),
+    }),
+  ),
+  attributes: list(
+    z.object({ name: shortText.min(1), value: shortText.min(1) }),
+  ),
+  addresses: list(z.object({ address: shortText.min(1), label: optionalText })),
 });
 
 export type AISearchOutput = z.infer<typeof aiSearchOutputSchema>;

--- a/server/services/aiSearch/strategies/index.ts
+++ b/server/services/aiSearch/strategies/index.ts
@@ -1,3 +1,5 @@
+import { resolveCapability } from "../../../ai/capabilities.ts";
+import { AppError } from "../../../utils/AppError.ts";
 // =============================================================================
 // AI Search — Strategy Registry
 // =============================================================================
@@ -33,8 +35,9 @@ const STRATEGIES: Record<string, () => AISearchStrategy> = {
 export function getStrategy(name: string = "two-pass"): AISearchStrategy {
   const factory = STRATEGIES[name];
   if (!factory)
-    throw new Error(
+    throw new AppError(
       `Unknown AI Search strategy: "${name}". Available: ${Object.keys(STRATEGIES).join(", ")}`,
+      400,
     );
   return factory();
 }
@@ -60,4 +63,36 @@ export function getDefaultStrategyForProvider(
     default:
       return "two-pass";
   }
+}
+
+/** Validate configuration locally before accepting an enrichment action. */
+export function validateEnrichmentStrategy(requested?: string): string {
+  const research = resolveCapability("research");
+  const name =
+    requested ?? getDefaultStrategyForProvider(research?.providerId ?? null);
+  getStrategy(name);
+  if (name === "searxng") {
+    if (!getSearxngUrl() || !resolveCapability("deep"))
+      throw new AppError(
+        "Configure SearXNG and an AI extraction model in settings.",
+        503,
+      );
+  } else {
+    if (!research)
+      throw new AppError(
+        "AI provider is not configured for contact research. Check AI settings.",
+        503,
+      );
+    if (name === "single-pass" && research.providerId === "gemini")
+      throw new AppError(
+        "Gemini research requires the two-pass strategy.",
+        400,
+      );
+    if (name === "two-pass" && !resolveCapability("quick"))
+      throw new AppError(
+        "Configure a quick AI model for research extraction.",
+        503,
+      );
+  }
+  return name;
 }

--- a/server/services/aiSearch/strategies/searxng.ts
+++ b/server/services/aiSearch/strategies/searxng.ts
@@ -66,6 +66,7 @@ function buildQueries(contact: HydratedContact): string[] {
 async function searxngSearch(
   baseUrl: string,
   query: string,
+  signal?: AbortSignal,
 ): Promise<SearxngResult[]> {
   const url = new URL(`${baseUrl}/search`);
   url.searchParams.set("q", query);
@@ -75,7 +76,11 @@ async function searxngSearch(
   // The SearXNG instance itself is operator-configured (often a private
   // address), so it deliberately bypasses the public-URL guard that applies
   // to the *result* pages below.
-  const response = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+  const response = await fetch(url, {
+    signal: signal
+      ? AbortSignal.any([signal, AbortSignal.timeout(15_000)])
+      : AbortSignal.timeout(15_000),
+  });
   if (!response.ok) {
     throw new AppError(
       `SearXNG returned ${response.status} ${response.statusText}`,
@@ -83,20 +88,25 @@ async function searxngSearch(
       { code: "SEARXNG_ERROR" },
     );
   }
-  const body = (await response.json()) as { results?: SearxngResult[] };
+  const body = JSON.parse(await readBodyCapped(response, signal)) as {
+    results?: SearxngResult[];
+  };
   return body.results ?? [];
 }
 
 /** Fetch a result page and reduce it to readable text. */
-async function fetchPageText(pageUrl: string): Promise<string | null> {
+async function fetchPageText(
+  pageUrl: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
   try {
-    const { response } = await safeFetch(pageUrl, { timeoutMs: 8_000 });
+    const { response } = await safeFetch(pageUrl, { timeoutMs: 8_000, signal });
     if (!response.ok) return null;
     const contentType = response.headers.get("content-type") ?? "";
     if (!/text\/html|text\/plain|application\/xhtml/i.test(contentType)) {
       return null;
     }
-    const html = await readBodyCapped(response);
+    const html = await readBodyCapped(response, signal);
     const $ = cheerio.load(html);
     $("script, style, nav, footer, header, noscript, svg").remove();
     const text = $("body").text().replace(/\s+/g, " ").trim();
@@ -113,7 +123,9 @@ export class SearxngStrategy implements AISearchStrategy {
   async execute(
     contact: HydratedContact,
     prompt: string,
+    signal?: AbortSignal,
   ): Promise<AISearchResult> {
+    signal?.throwIfAborted();
     const startMs = Date.now();
     const baseUrl = getSearxngUrl();
     if (!baseUrl) {
@@ -128,8 +140,9 @@ export class SearxngStrategy implements AISearchStrategy {
     for (const query of buildQueries(contact)) {
       let results: SearxngResult[] = [];
       try {
-        results = await searxngSearch(baseUrl, query);
+        results = await searxngSearch(baseUrl, query, signal);
       } catch (err) {
+        signal?.throwIfAborted();
         log.warn(
           "SearxngStrategy",
           `Search failed for "${query}": ${getErrorMessage(err)}`,
@@ -156,7 +169,7 @@ export class SearxngStrategy implements AISearchStrategy {
     const citations: Array<{ title: string; uri: string }> = [];
     const documents: string[] = [];
     for (const result of picked) {
-      const text = await fetchPageText(result.url!);
+      const text = await fetchPageText(result.url!, signal);
       // Fall back to the search snippet when the page can't be read.
       const body = text ?? result.content ?? "";
       if (!body.trim()) continue;
@@ -194,9 +207,12 @@ ${wrapUntrusted("web research text", researchText, 32_000)}`;
       prompt: extractionPrompt,
       responseFormat: "json",
       jsonSchema: extractionJsonSchema,
-      timeoutMs: 90_000,
+      timeoutMs: 30_000,
+      signal,
+      maxOutputTokens: 4_000,
     });
 
+    signal?.throwIfAborted();
     recordInvocation({
       operation: "aiSearchExtraction",
       model: extraction.model,
@@ -228,7 +244,7 @@ ${wrapUntrusted("web research text", researchText, 32_000)}`;
       groundedText: researchText.slice(0, 20_000),
       citations,
       models: ["searxng", extraction.model],
-      tokenCount: extraction.tokenCount ?? 0,
+      tokenCount: extraction.tokenCount,
       latencyMs: Date.now() - startMs,
     };
   }

--- a/server/services/aiSearch/strategies/singlePass.ts
+++ b/server/services/aiSearch/strategies/singlePass.ts
@@ -1,3 +1,4 @@
+import { AppError } from "../../../utils/AppError.ts";
 // =============================================================================
 // AI Search — Single-Pass Strategy
 // =============================================================================
@@ -33,7 +34,9 @@ export class SinglePassStrategy implements AISearchStrategy {
   async execute(
     _contact: HydratedContact,
     prompt: string,
+    signal?: AbortSignal,
   ): Promise<AISearchResult> {
+    signal?.throwIfAborted();
     const startMs = Date.now();
 
     // Single combined request: web search + structured JSON output
@@ -43,8 +46,12 @@ export class SinglePassStrategy implements AISearchStrategy {
       responseFormat: "json",
       jsonSchema: extractionJsonSchema,
       enableSearchGrounding: true,
+      signal,
+      timeoutMs: 60_000,
+      maxOutputTokens: 4_000,
     });
 
+    signal?.throwIfAborted();
     // Record invocation for AI Stats tracking
     recordInvocation({
       operation: "aiSearchSinglePass",
@@ -68,13 +75,15 @@ export class SinglePassStrategy implements AISearchStrategy {
     } catch (parseErr: unknown) {
       throw new Error(
         `JSON parse failed for single-pass output: ${getErrorMessage(parseErr)}. ` +
-          `Raw text: ${(result.text || "").slice(0, 200)}`,
+          "",
       );
     }
 
     const validated = aiSearchOutputSchema.safeParse(rawParsed);
     if (!validated.success) {
-      throw new Error(`Zod validation failed: ${validated.error.message}`);
+      throw new AppError("AI research failed schema validation", 502, {
+        code: "AI_SCHEMA_MISMATCH",
+      });
     }
 
     const structuredData = validated.data as Record<string, unknown>;

--- a/server/services/aiSearch/strategies/twoPass.ts
+++ b/server/services/aiSearch/strategies/twoPass.ts
@@ -1,3 +1,4 @@
+import { AppError } from "../../../utils/AppError.ts";
 // =============================================================================
 // AI Search — Two-Pass Strategy (V2.1)
 // =============================================================================
@@ -32,99 +33,53 @@ import { recordInvocation } from "../../../services/aiStatsService.ts";
 import { log } from "../../../utils/logger.ts";
 import { getErrorMessage } from "../../../utils/helpers.ts";
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/** Max attempts for Pass 1 when the search tool returns empty text */
-const GROUNDING_MAX_RETRIES = 3;
-
-/** Delay before retrying a grounding call that returned empty text */
-const GROUNDING_RETRY_DELAY_MS = 1_500;
-
-// =============================================================================
-// Strategy Implementation
-// =============================================================================
-
 export class TwoPassStrategy implements AISearchStrategy {
   readonly name = "two-pass";
 
   async execute(
     _contact: HydratedContact,
     prompt: string,
+    signal?: AbortSignal,
   ): Promise<AISearchResult> {
+    signal?.throwIfAborted();
     const startMs = Date.now();
-    const modelsUsed: string[] = [];
-    let totalTokens = 0;
-    const citations: Array<{ title: string; uri: string }> = [];
-
-    // ── Pass 1: Grounding (web search → text output) ──────────────────
-    // Prefer "pro" models for maximum search grounding accuracy.
-    // gemini-3.1-pro-preview supports grounding, thinking, and delivers
-    // the deepest, most thorough research results.
-    // The SmartRouter handles model fallback via circuit breakers.
-    let groundedText = "";
-
-    for (let attempt = 1; attempt <= GROUNDING_MAX_RETRIES; attempt++) {
-      if (attempt > 1) {
-        log.info(
-          "TwoPassStrategy",
-          `Pass 1 (grounding) — retry ${attempt} after empty result`,
-        );
-        await new Promise((r) => setTimeout(r, GROUNDING_RETRY_DELAY_MS));
-      }
-
+    const pass1Result = await generateFor("research", {
+      prompt,
+      responseFormat: "text",
+      enableSearchGrounding: true,
+      signal,
+      timeoutMs: 60_000,
+      maxOutputTokens: 2_500,
+    });
+    signal?.throwIfAborted();
+    const groundedText = pass1Result.text;
+    const modelsUsed = [pass1Result.model];
+    const citations = (pass1Result.citations ?? []).filter((source) => {
       try {
-        const pass1Start = Date.now();
-        const pass1Result = await generateFor("research", {
-          prompt,
-          responseFormat: "text",
-          enableSearchGrounding: true,
-        });
-
-        groundedText = pass1Result.text;
-        modelsUsed.push(pass1Result.model);
-        totalTokens += pass1Result.tokenCount ?? 0;
-
-        // Record invocation for AI Stats tracking
-        recordInvocation({
-          operation: "aiSearchGrounding",
-          model: pass1Result.model,
-          tokenCount: pass1Result.tokenCount,
-          latencyMs: Date.now() - pass1Start,
-          cached: false,
-          description: `AI Search grounding: ${_contact.name}`,
-        });
-
-        log.info(
-          "TwoPassStrategy",
-          `Pass 1 complete via ${pass1Result.model} in ${pass1Result.latencyMs}ms` +
-            ` (${pass1Result.tokenCount ?? "?"} tokens)`,
-        );
-
-        if (groundedText.trim()) {
-          break; // Got non-empty text — success
-        }
-
-        log.warn(
-          "TwoPassStrategy",
-          `Pass 1 returned empty text (attempt ${attempt})`,
-        );
-      } catch (err: unknown) {
-        log.warn("TwoPassStrategy", `Pass 1 failed: ${getErrorMessage(err)}`);
-        // On the last attempt, surface the error
-        if (attempt === GROUNDING_MAX_RETRIES) {
-          throw err;
-        }
+        const url = new URL(source.uri);
+        return /^https?:$/.test(url.protocol) && !url.username && !url.password;
+      } catch {
+        return false;
       }
-    }
-
-    if (!groundedText.trim()) {
-      throw new Error(
-        "No public information found for this contact. " +
-          "The AI searched the internet but could not identify or find data about this person.",
+    });
+    recordInvocation({
+      operation: "aiSearchGrounding",
+      model: pass1Result.model,
+      tokenCount: pass1Result.tokenCount,
+      latencyMs: pass1Result.latencyMs,
+      cached: false,
+      description: `AI Search grounding: ${_contact.name}`,
+    });
+    if (!groundedText.trim())
+      throw new AppError("No public information found for this contact.", 422, {
+        code: "AI_NO_RESEARCH",
+      });
+    if (citations.length === 0)
+      throw new AppError(
+        "Research did not include source links. No contact fields changed. Choose another research model in AI settings.",
+        502,
+        { code: "AI_GROUNDING_MISSING" },
       );
-    }
 
     // ── Pass 2: Extraction (grounded text → structured JSON) ──────────
     // Prefer "lite" models — this is a pure formatting/extraction task.
@@ -158,10 +113,18 @@ ${wrapUntrusted("web research text", groundedText, 32_000)}
       prompt: extractionPrompt,
       responseFormat: "json",
       jsonSchema: extractionJsonSchema,
+      signal,
+      timeoutMs: 30_000,
+      maxOutputTokens: 4_000,
     });
 
     modelsUsed.push(pass2Result.model);
-    totalTokens += pass2Result.tokenCount ?? 0;
+    signal?.throwIfAborted();
+    const totalTokens =
+      pass1Result.tokenCount === undefined ||
+      pass2Result.tokenCount === undefined
+        ? undefined
+        : pass1Result.tokenCount + pass2Result.tokenCount;
 
     // Record invocation for AI Stats tracking
     recordInvocation({
@@ -180,14 +143,16 @@ ${wrapUntrusted("web research text", groundedText, 32_000)}
       rawParsed = JSON.parse(pass2Result.text || "{}");
     } catch (parseErr: unknown) {
       throw new Error(
-        `JSON parse failed for extraction output: ${getErrorMessage(parseErr)}. Raw text: ${(pass2Result.text || "").slice(0, 200)}`,
+        `JSON parse failed for extraction output: ${getErrorMessage(parseErr)}. `,
       );
     }
 
     const validated = aiSearchOutputSchema.safeParse(rawParsed);
 
     if (!validated.success) {
-      throw new Error(`Zod validation failed: ${validated.error.message}`);
+      throw new AppError("AI research failed schema validation", 502, {
+        code: "AI_SCHEMA_MISMATCH",
+      });
     }
 
     const structuredData = validated.data as Record<string, unknown>;

--- a/server/services/aiSearch/types.ts
+++ b/server/services/aiSearch/types.ts
@@ -11,40 +11,12 @@ import type { HydratedContact } from "../../repositories/types.ts";
 // Job Lifecycle
 // =============================================================================
 
-/** Status lifecycle: queued → searching → merging → success | error */
-export type AISearchJobStatus =
-  "queued" | "searching" | "merging" | "success" | "error";
-
-/** Error classification for contextual UI messages and future retry logic. */
-export type AISearchErrorType =
-  | "rate_limit" // 429 / quota — retryable
-  | "validation" // Zod parse failure — not retryable
-  | "network" // Timeout / connection — retryable once
-  | "auth" // API key invalid — fatal
-  | "ambiguous" // LLM couldn't identify unique person — not retryable
-  | "unknown"; // Catch-all
-
-export interface AISearchJob {
-  id: string; // UUID
-  contactId: string; // FK → contacts.id
-  contactName: string; // Denormalized for UI
-  status: AISearchJobStatus;
-  error?: string; // Human-readable error message
-  errorType?: AISearchErrorType; // Classified error type
-  fieldsUpdated: number; // Count of fields/records merged
-  startedAt?: string; // ISO timestamp
-  completedAt?: string; // ISO timestamp
-  latencyMs?: number; // Wall-clock time for this job
-}
-
-export interface AISearchBatch {
-  id: string; // Batch UUID
-  strategy: string; // e.g., 'two-pass'
-  jobs: AISearchJob[]; // Ordered list
-  createdAt: string; // ISO timestamp
-  status: "processing" | "complete" | "cancelled";
-  totalTokens: number; // Accumulated token usage across all jobs
-}
+export type {
+  AISearchBatch,
+  AISearchJob,
+  AISearchJobStatus,
+  AISearchErrorType,
+} from "../../../shared/aiSearchContract.ts";
 
 // =============================================================================
 // Strategy Interface
@@ -82,5 +54,9 @@ export interface AISearchStrategy {
    * @returns Structured result with extracted data, models used, and metrics
    * @throws Error if both passes fail (rate limit, validation, network, etc.)
    */
-  execute(contact: HydratedContact, prompt: string): Promise<AISearchResult>;
+  execute(
+    contact: HydratedContact,
+    prompt: string,
+    signal?: AbortSignal,
+  ): Promise<AISearchResult>;
 }

--- a/server/services/aiSettingsService.ts
+++ b/server/services/aiSettingsService.ts
@@ -1,3 +1,4 @@
+import { aiCache } from "../utils/aiCache.ts";
 // =============================================================================
 // AI Settings Service — provider credentials, capability assignments, models
 // =============================================================================
@@ -61,6 +62,7 @@ export function setProviderKey(providerId: string, apiKey: string): void {
   keys[providerId] = apiKey.trim();
   setSetting(SETTING_KEYS.aiProviderKeys, keys);
   invalidateProviderCache();
+  aiCache.invalidateAll();
 }
 
 /** Remove a stored API key (env-provided keys are unaffected). */
@@ -71,6 +73,7 @@ export function deleteProviderKey(providerId: string): void {
   setSetting(SETTING_KEYS.aiProviderKeys, keys);
   releasePinsFor(providerId);
   invalidateProviderCache();
+  aiCache.invalidateAll();
 }
 
 /**
@@ -120,6 +123,7 @@ export function upsertCustomEndpoint(endpoint: CustomEndpointConfig): void {
   else endpoints.push(endpoint);
   setSetting(SETTING_KEYS.aiCustomEndpoints, endpoints);
   invalidateProviderCache();
+  aiCache.invalidateAll();
 }
 
 export function deleteCustomEndpoint(id: string): void {
@@ -129,6 +133,7 @@ export function deleteCustomEndpoint(id: string): void {
   );
   releasePinsFor(`custom:${id}`);
   invalidateProviderCache();
+  aiCache.invalidateAll();
 }
 
 // ---------------------------------------------------------------------------
@@ -158,6 +163,7 @@ export function setCapabilityAssignment(
   const assignments = getCapabilityAssignments();
   assignments[capability] = assignment;
   setSetting(SETTING_KEYS.aiCapabilities, assignments);
+  aiCache.invalidateAll();
 }
 
 // ---------------------------------------------------------------------------

--- a/server/services/avatarService.ts
+++ b/server/services/avatarService.ts
@@ -23,7 +23,6 @@ import { createAvatar } from "@dicebear/core";
 import * as avataaars from "@dicebear/avataaars";
 import * as lorelei from "@dicebear/lorelei";
 import * as bottts from "@dicebear/bottts";
-import * as initials from "@dicebear/initials";
 import { classifyName } from "../utils/smartAvatar.ts";
 import { log } from "../utils/logger.ts";
 import { getErrorMessage } from "../utils/helpers.ts";
@@ -227,7 +226,7 @@ function renderStyle({ style, seed, background = false }: RenderAvatarOptions) {
     case "bottts":
       return createAvatar(bottts, base).toString();
     case "initials":
-      return createAvatar(initials, base).toString();
+      return plainMonogram(seed);
     default:
       // TypeScript proves this is unreachable for well-typed callers, but the
       // style can arrive from a persisted URL or a hand-edited database row.
@@ -276,7 +275,7 @@ function plainMonogram(seed: string): string {
       .trim()
       .split(/\s+/)
       .slice(0, 2)
-      .map((word) => word[0] ?? "")
+      .map((word) => Array.from(word)[0] ?? "")
       .join("")
       .toUpperCase() || "?";
   // Escape for XML: a contact name can legitimately contain & or <.

--- a/server/services/dashboardService.ts
+++ b/server/services/dashboardService.ts
@@ -1,3 +1,4 @@
+import { resolveCapability } from "../ai/capabilities.ts";
 import { sqlite } from "../db.ts";
 import { log } from "../utils/logger.ts";
 import { actionItemService } from "./actionItemService.ts";
@@ -61,7 +62,7 @@ export const dashboardService = {
              COUNT(DISTINCT im.interactionId) as mentionCount
       FROM contacts c
       JOIN interaction_mentions im ON c.id = im.contactId
-      WHERE c.isGhost = 1 AND (c.isArchived = 0 OR c.isArchived IS NULL)
+      WHERE c.deletedAt IS NULL AND c.canonicalId IS NULL AND c.isGhost = 1 AND (c.isArchived = 0 OR c.isArchived IS NULL)
       GROUP BY c.id
       ORDER BY mentionCount DESC
       LIMIT 5
@@ -73,12 +74,12 @@ export const dashboardService = {
     const metrics = sqlite
       .prepare(
         `
-      SELECT 
-        (SELECT COUNT(*) FROM contacts WHERE isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)) as totalActive,
-        (SELECT ROUND(AVG(CAST(julianday('now') - julianday(lastContactedAt) AS REAL))) FROM contacts WHERE isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL) AND lastContactedAt IS NOT NULL) as avgDaysSinceInteraction,
-        (SELECT COUNT(*) FROM contacts WHERE relationshipScore < 40 AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)) as atRiskCount,
-        (SELECT COUNT(*) FROM interactions WHERE date >= date('now', '-30 days')) as totalInteractions30d,
-        (SELECT COUNT(*) FROM contacts WHERE addedAt >= date('now', '-30 days') AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)) as newContacts30d
+      SELECT
+        (SELECT COUNT(*) FROM contacts WHERE deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)) as totalActive,
+        (SELECT ROUND(AVG(CAST(julianday('now') - julianday(lastContactedAt) AS REAL))) FROM contacts WHERE deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL) AND lastContactedAt IS NOT NULL) as avgDaysSinceInteraction,
+        (SELECT COUNT(*) FROM contacts WHERE relationshipScore < 40 AND deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)) as atRiskCount,
+        (SELECT COUNT(*) FROM interactions WHERE date >= date('now', '-30 days') AND contactId IN (SELECT id FROM contacts WHERE deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND COALESCE(isArchived, 0) = 0)) as totalInteractions30d,
+        (SELECT COUNT(*) FROM contacts WHERE addedAt >= date('now', '-30 days') AND deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)) as newContacts30d
     `,
       )
       .get() as DashboardMetricsRow;
@@ -95,7 +96,7 @@ export const dashboardService = {
              CAST(julianday('now') - julianday(c.lastContactedAt) AS INTEGER) as daysSinceContact,
              (SELECT title FROM interactions WHERE contactId = c.id ORDER BY date DESC LIMIT 1) as lastInteractionTitle
       FROM contacts c
-      WHERE c.isGhost = 0
+      WHERE c.deletedAt IS NULL AND c.canonicalId IS NULL AND c.isGhost = 0
         AND (c.isArchived = 0 OR c.isArchived IS NULL)
         AND c.relationshipScore < 40
         AND c.lastContactedAt IS NOT NULL
@@ -115,7 +116,7 @@ export const dashboardService = {
         `
       SELECT id, name, company, avatarUrl, themeColor, addedAt
       FROM contacts
-      WHERE isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)
+      WHERE deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)
       ORDER BY addedAt DESC
       LIMIT 5
     `,
@@ -126,11 +127,11 @@ export const dashboardService = {
     const industryComposition = sqlite
       .prepare(
         `
-      SELECT industry, COUNT(*) as count 
-      FROM contacts 
-      WHERE isArchived = 0 AND isGhost = 0 AND industry IS NOT NULL AND industry != ''
-      GROUP BY industry 
-      ORDER BY count DESC 
+      SELECT industry, COUNT(*) as count
+      FROM contacts
+      WHERE deletedAt IS NULL AND canonicalId IS NULL AND isArchived = 0 AND isGhost = 0 AND industry IS NOT NULL AND industry != ''
+      GROUP BY industry
+      ORDER BY count DESC
       LIMIT 8
     `,
       )
@@ -140,11 +141,11 @@ export const dashboardService = {
     const locationComposition = sqlite
       .prepare(
         `
-      SELECT location, COUNT(*) as count 
-      FROM contacts 
-      WHERE isArchived = 0 AND isGhost = 0 AND location IS NOT NULL AND location != ''
-      GROUP BY location 
-      ORDER BY count DESC 
+      SELECT location, COUNT(*) as count
+      FROM contacts
+      WHERE deletedAt IS NULL AND canonicalId IS NULL AND isArchived = 0 AND isGhost = 0 AND location IS NOT NULL AND location != ''
+      GROUP BY location
+      ORDER BY count DESC
       LIMIT 8
     `,
       )
@@ -154,11 +155,11 @@ export const dashboardService = {
     const roleComposition = sqlite
       .prepare(
         `
-      SELECT role, COUNT(*) as count 
-      FROM contacts 
-      WHERE isArchived = 0 AND isGhost = 0 AND role IS NOT NULL AND role != ''
-      GROUP BY role 
-      ORDER BY count DESC 
+      SELECT role, COUNT(*) as count
+      FROM contacts
+      WHERE deletedAt IS NULL AND canonicalId IS NULL AND isArchived = 0 AND isGhost = 0 AND role IS NOT NULL AND role != ''
+      GROUP BY role
+      ORDER BY count DESC
       LIMIT 8
     `,
       )
@@ -170,7 +171,7 @@ export const dashboardService = {
         `
       SELECT type, COUNT(*) as count
       FROM interactions
-      WHERE date >= date('now', '-30 days')
+      WHERE date >= date('now', '-30 days') AND contactId IN (SELECT id FROM contacts WHERE deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND COALESCE(isArchived, 0) = 0)
       GROUP BY type
       ORDER BY count DESC
     `,
@@ -183,7 +184,7 @@ export const dashboardService = {
         `
       SELECT id, name, company, avatarUrl, themeColor, addedAt
       FROM contacts
-      WHERE addedAt >= date('now', '-30 days') AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)
+      WHERE addedAt >= date('now', '-30 days') AND deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)
       ORDER BY addedAt DESC
       LIMIT 20
     `,
@@ -210,8 +211,15 @@ export const dashboardService = {
   },
 
   async getInsight() {
+    const revision = (
+      sqlite
+        .prepare("SELECT revision FROM search_revision WHERE id = 1")
+        .get() as { revision: number }
+    ).revision;
+    const model = resolveCapability("quick");
+    const cacheKey = `${revision}:${new Date().toISOString().slice(0, 10)}:${model?.providerId}:${model?.model}`;
     // Check unified cache (24h TTL managed by aiCache)
-    const cached = aiCache.get<DailyInsight>("dailyInsight", "singleton");
+    const cached = aiCache.get<DailyInsight>("dailyInsight", cacheKey);
     if (cached) {
       import("./aiStatsService.ts").then(({ recordInvocation }) => {
         recordInvocation({
@@ -232,7 +240,7 @@ export const dashboardService = {
     const totalActive = (
       sqlite
         .prepare(
-          `SELECT COUNT(*) as count FROM contacts WHERE isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)`,
+          `SELECT COUNT(*) as count FROM contacts WHERE deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)`,
         )
         .get() as { count: number }
     ).count;
@@ -240,9 +248,9 @@ export const dashboardService = {
     const industryRows = sqlite
       .prepare(
         `
-      SELECT industry, COUNT(*) as count 
-      FROM contacts 
-      WHERE industry IS NOT NULL AND industry != '' AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)
+      SELECT industry, COUNT(*) as count
+      FROM contacts
+      WHERE industry IS NOT NULL AND industry != '' AND deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)
       GROUP BY industry
     `,
       )
@@ -253,8 +261,8 @@ export const dashboardService = {
     const notReached = sqlite
       .prepare(
         `
-      SELECT name FROM contacts 
-      WHERE isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL) 
+      SELECT name FROM contacts
+      WHERE deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)
         AND lastContactedAt < date('now', '-60 days')
       LIMIT 10
     `,
@@ -265,8 +273,8 @@ export const dashboardService = {
       sqlite
         .prepare(
           `
-      SELECT COUNT(*) as count FROM contacts 
-      WHERE addedAt >= date('now', '-30 days') AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)
+      SELECT COUNT(*) as count FROM contacts
+      WHERE addedAt >= date('now', '-30 days') AND deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)
     `,
         )
         .get() as { count: number }
@@ -275,8 +283,8 @@ export const dashboardService = {
     const topRel = sqlite
       .prepare(
         `
-      SELECT name FROM contacts 
-      WHERE isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)
+      SELECT name FROM contacts
+      WHERE deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)
       ORDER BY relationshipScore DESC
       LIMIT 3
     `,
@@ -286,8 +294,8 @@ export const dashboardService = {
     const bottomRel = sqlite
       .prepare(
         `
-      SELECT name FROM contacts 
-      WHERE isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL) AND lastContactedAt IS NOT NULL
+      SELECT name FROM contacts
+      WHERE deletedAt IS NULL AND canonicalId IS NULL AND isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL) AND lastContactedAt IS NOT NULL
       ORDER BY relationshipScore ASC
       LIMIT 3
     `,
@@ -309,8 +317,16 @@ export const dashboardService = {
     };
 
     const insight = await generateDailyInsight(stats);
+    if (
+      (
+        sqlite
+          .prepare("SELECT revision FROM search_revision WHERE id = 1")
+          .get() as { revision: number }
+      ).revision !== revision
+    )
+      return null;
     if (insight) {
-      aiCache.set("dailyInsight", "singleton", insight);
+      aiCache.set("dailyInsight", cacheKey, insight);
     }
 
     return insight;

--- a/server/services/interactionService.ts
+++ b/server/services/interactionService.ts
@@ -14,7 +14,10 @@ import {
   summarizeEmlEmail,
 } from "../ai/aiService.ts";
 import { relationshipService } from "./relationshipService.ts";
-import { aiCache } from "../utils/aiCache.ts";
+import { aiCache, contentHash } from "../utils/aiCache.ts";
+import { AppError } from "../utils/AppError.ts";
+import { resolveCapability } from "../ai/capabilities.ts";
+import { SharedWork } from "../ai/workQueue.ts";
 
 // =============================================================================
 // Interaction Payload Types
@@ -56,42 +59,50 @@ async function runMentionExtraction(
     const mentions = await extractMentions(content);
     if (!mentions || mentions.length === 0) return;
 
-    const mappedMentions = [];
-    for (const m of mentions) {
-      let existing = db
-        .select()
-        .from(schema.contacts)
-        .where(eq(schema.contacts.name, m.name))
-        .get();
-      if (!existing) {
-        const ghostId = crypto.randomUUID();
-        const newTheme = ["brand", "indigo", "rose", "emerald", "amber"][
-          Math.floor(Math.random() * 5)
-        ];
-        existing = db
-          .insert(schema.contacts)
-          .values({
-            id: ghostId,
-            name: m.name,
-            company: m.company || null,
-            isGhost: 1,
-            themeColor: newTheme,
-          })
-          .returning()
+    const current = sqlite
+      .prepare(
+        "SELECT i.content FROM interactions i JOIN contacts c ON c.id = i.contactId WHERE i.id = ? AND i.contactId = ? AND c.deletedAt IS NULL AND c.canonicalId IS NULL",
+      )
+      .get(interactionId, contactId) as { content: string } | undefined;
+    if (!current || current.content !== content) return;
+    sqlite.transaction(() => {
+      const mappedMentions = [];
+      for (const m of mentions) {
+        let existing = db
+          .select()
+          .from(schema.contacts)
+          .where(eq(schema.contacts.name, m.name))
           .get();
-        log.info("AI Service", `Inferred ghost contact: ${m.name}`);
+        if (!existing) {
+          const ghostId = crypto.randomUUID();
+          const newTheme = ["brand", "indigo", "rose", "emerald", "amber"][
+            Math.floor(Math.random() * 5)
+          ];
+          existing = db
+            .insert(schema.contacts)
+            .values({
+              id: ghostId,
+              name: m.name,
+              company: m.company || null,
+              isGhost: 1,
+              themeColor: newTheme,
+            })
+            .returning()
+            .get();
+          log.info("AI Service", `Inferred ghost contact: ${m.name}`);
+        }
+        mappedMentions.push({
+          contactId: existing.id,
+          name: existing.name,
+          context: m.context,
+          isGhost: existing.isGhost === 1,
+        });
       }
-      mappedMentions.push({
-        contactId: existing.id,
-        name: existing.name,
-        context: m.context,
-        isGhost: existing.isGhost === 1,
-      });
-    }
-    db.update(schema.interactions)
-      .set({ mentions: JSON.stringify(mappedMentions) })
-      .where(eq(schema.interactions.id, interactionId))
-      .run();
+      db.update(schema.interactions)
+        .set({ mentions: JSON.stringify(mappedMentions) })
+        .where(eq(schema.interactions.id, interactionId))
+        .run();
+    })();
   } catch (e: unknown) {
     log.error(
       "AI Service",
@@ -99,6 +110,23 @@ async function runMentionExtraction(
       { error: getErrorMessage(e) },
     );
   }
+}
+
+const briefings = new SharedWork<string[]>();
+
+function briefingSource(contactId: string) {
+  const contact = sqlite
+    .prepare(
+      "SELECT id, name, company, role, headline, about, location, preferences, lastContactedAt FROM contacts WHERE id = ? AND deletedAt IS NULL AND canonicalId IS NULL",
+    )
+    .get(contactId) as Record<string, unknown> | undefined;
+  if (!contact) throw new AppError("Contact is no longer available.", 404);
+  const interactions = sqlite
+    .prepare(
+      "SELECT id, type, title, content, date FROM interactions WHERE contactId = ? ORDER BY date DESC, id DESC LIMIT 15",
+    )
+    .all(contactId) as Record<string, unknown>[];
+  return { contact, interactions };
 }
 
 export const interactionService = {
@@ -230,6 +258,7 @@ export const interactionService = {
     // Invalidate cached briefing for this contact — a new interaction means
     // any cached briefing is stale (it doesn't include this interaction)
     aiCache.invalidate("briefing", contactId);
+    aiCache.invalidate("dailyInsight");
 
     // Immediately recompute relationship score for this contact
     relationshipService.computeScore(contactId);
@@ -237,67 +266,40 @@ export const interactionService = {
     return result;
   },
 
-  async generateBriefing(contactId: string) {
-    const contact = db
-      .select()
-      .from(schema.contacts)
-      .where(eq(schema.contacts.id, contactId))
-      .get();
-    if (!contact) return null;
-
-    // ── Briefing cache: key = contactId::interactionCount
-    // If the interaction count hasn't changed since the last briefing, the
-    // cached result is still valid. Any new interaction increments the count,
-    // producing a different cache key → automatic invalidation.
-    const interactionCount = (
-      sqlite
-        .prepare("SELECT COUNT(*) as c FROM interactions WHERE contactId = ?")
-        .get(contactId) as { c: number }
-    ).c;
-    const cacheKey = `${contactId}::${interactionCount}`;
-
+  async generateBriefing(contactId: string, signal?: AbortSignal) {
+    signal?.throwIfAborted();
+    const source = briefingSource(contactId);
+    const fingerprint = JSON.stringify(source);
+    const model = resolveCapability("quick");
+    const cacheKey = `${contactId}::${contentHash(JSON.stringify([source, model?.providerId, model?.model]))}`;
     const cached = aiCache.get<string[]>("briefing", cacheKey);
-    if (cached) {
-      log.info(
-        "Briefing",
-        `Cache HIT for ${contact.name} (${interactionCount} interactions)`,
-      );
-      import("./aiStatsService.ts").then(({ recordInvocation }) => {
-        recordInvocation({
-          operation: "briefing",
-          latencyMs: 0,
-          cached: true,
-          description: `Catch-Me-Up cache hit for ${contact.name}`,
-        });
-      });
-      return cached;
-    }
-
-    const recentInteractions = db
-      .select()
-      .from(schema.interactions)
-      .where(eq(schema.interactions.contactId, contactId))
-      .orderBy(sql`${schema.interactions.date} DESC`)
-      .limit(15)
-      .all();
-
-    const points = await generateCatchMeUpBriefing(contact, recentInteractions);
-    const now = new Date().toISOString();
-
-    db.update(schema.contacts)
-      .set({
-        aiBriefing: JSON.stringify(points),
-        aiBriefingAt: now,
-        updatedAt: now,
-      })
-      .where(eq(schema.contacts.id, contactId))
-      .run();
-
-    // Cache the freshly generated briefing
-    aiCache.set("briefing", cacheKey, points);
-    log.info("Briefing", `Cached for ${contact.name} (key: ${cacheKey})`);
-
-    return points;
+    if (cached) return cached;
+    return briefings.run(
+      cacheKey,
+      async (budget) => {
+        const points = await generateCatchMeUpBriefing(
+          source.contact,
+          source.interactions,
+          budget,
+        );
+        budget.throwIfAborted();
+        if (JSON.stringify(briefingSource(contactId)) !== fingerprint)
+          throw new AppError(
+            "This contact changed during briefing generation. Try again.",
+            409,
+          );
+        db.update(schema.contacts)
+          .set({
+            aiBriefing: JSON.stringify(points),
+            aiBriefingAt: new Date().toISOString(),
+          })
+          .where(eq(schema.contacts.id, contactId))
+          .run();
+        aiCache.set("briefing", cacheKey, points);
+        return points;
+      },
+      signal,
+    );
   },
 
   promoteGhost(contactId: string) {
@@ -368,6 +370,7 @@ export const interactionService = {
       return interaction;
     })();
     aiCache.invalidate("briefing", contactId);
+    aiCache.invalidate("dailyInsight");
     aiCache.invalidate("dailyInsight");
     relationshipService.computeScore(contactId);
     return result;

--- a/server/services/search/localEmbeddings.ts
+++ b/server/services/search/localEmbeddings.ts
@@ -80,6 +80,7 @@ export async function initLocalEmbeddings(): Promise<void> {
 
       extractor = await pipelineFactory("feature-extraction", MODEL_ID, {
         dtype: "q8", // quantized for speed + lower memory
+        session_options: { intraOpNumThreads: 2, interOpNumThreads: 1 },
       });
 
       modelReady = true;

--- a/server/utils/urlSafety.ts
+++ b/server/utils/urlSafety.ts
@@ -1,3 +1,4 @@
+import { withTimeout } from "../ai/resilience.ts";
 // =============================================================================
 // URL safety — SSRF guards for user/AI-supplied URLs
 // =============================================================================
@@ -113,23 +114,40 @@ export async function assertPublicHttpUrl(targetUrl: string): Promise<URL> {
 /** Read at most MAX_RESPONSE_BYTES of the body as text. */
 export async function readBodyCapped(
   res: globalThis.Response,
+  signal?: AbortSignal,
 ): Promise<string> {
-  const reader = res.body?.getReader();
-  if (!reader) return "";
-  const decoder = new TextDecoder();
-  let text = "";
-  let received = 0;
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    received += value.byteLength;
-    text += decoder.decode(value, { stream: true });
-    if (received >= MAX_RESPONSE_BYTES) {
-      await reader.cancel();
-      break;
-    }
-  }
-  return text;
+  return withTimeout(
+    async (budget) => {
+      const reader = res.body?.getReader();
+      if (!reader) return "";
+      const onAbort = () => {
+        void reader.cancel().catch(() => undefined);
+      };
+      budget.addEventListener("abort", onAbort, { once: true });
+      const decoder = new TextDecoder();
+      let text = "";
+      let received = 0;
+      try {
+        for (;;) {
+          budget.throwIfAborted();
+          const { done, value } = await reader.read();
+          budget.throwIfAborted();
+          if (done) break;
+          const bounded = value.subarray(0, MAX_RESPONSE_BYTES - received);
+          received += bounded.byteLength;
+          text += decoder.decode(bounded, { stream: true });
+          if (received >= MAX_RESPONSE_BYTES) break;
+        }
+        return text + decoder.decode();
+      } finally {
+        budget.removeEventListener("abort", onAbort);
+        void reader.cancel().catch(() => undefined);
+        reader.releaseLock();
+      }
+    },
+    8_000,
+    signal,
+  );
 }
 
 /**
@@ -196,9 +214,14 @@ const pinnedAgent = new Agent({ connect: { lookup: guardedLookup } });
  */
 export async function safeFetch(
   targetUrl: string,
-  options: { timeoutMs?: number; maxRedirects?: number } = {},
+  options: {
+    timeoutMs?: number;
+    maxRedirects?: number;
+    signal?: AbortSignal;
+  } = {},
 ): Promise<{ response: globalThis.Response; finalUrl: string }> {
   const { timeoutMs = 6000, maxRedirects = 3 } = options;
+  options.signal?.throwIfAborted();
   await assertPublicHttpUrl(targetUrl);
 
   const controller = new AbortController();
@@ -211,13 +234,16 @@ export async function safeFetch(
       // guard lives. The returned Response implements the same WHATWG shape
       // the callers consume, so only the nominal type needs the cast.
       const response = (await undiciFetch(currentUrl, {
-        signal: controller.signal,
+        signal: options.signal
+          ? AbortSignal.any([controller.signal, options.signal])
+          : controller.signal,
         redirect: "manual",
         dispatcher: pinnedAgent,
       })) as unknown as globalThis.Response;
       if (response.status >= 300 && response.status < 400) {
         const location = response.headers.get("location");
         if (!location) return { response, finalUrl: currentUrl };
+        void response.body?.cancel().catch(() => undefined);
         currentUrl = new URL(location, currentUrl).toString();
         await assertPublicHttpUrl(currentUrl);
         continue;

--- a/shared/aiSearchContract.ts
+++ b/shared/aiSearchContract.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+/** Shared status contract for batch polling, live updates, and cancellation. */
+export const aiSearchBatchSchema = z.object({
+  id: z.string().min(1).max(100),
+  strategy: z.string(),
+  createdAt: z.string(),
+  status: z.enum(["processing", "complete", "cancelled"]),
+  totalTokens: z.number().finite().nonnegative(),
+  jobs: z
+    .array(
+      z.object({
+        id: z.string(),
+        contactId: z.string(),
+        contactName: z.string(),
+        status: z.enum([
+          "queued",
+          "searching",
+          "merging",
+          "success",
+          "error",
+          "cancelled",
+        ]),
+        error: z.string().optional(),
+        errorType: z
+          .enum([
+            "rate_limit",
+            "validation",
+            "network",
+            "auth",
+            "ambiguous",
+            "unknown",
+          ])
+          .optional(),
+        fieldsUpdated: z.number().int().nonnegative(),
+        startedAt: z.string().optional(),
+        completedAt: z.string().optional(),
+        latencyMs: z.number().nonnegative().optional(),
+      }),
+    )
+    .max(100),
+});
+
+export type AISearchBatch = z.infer<typeof aiSearchBatchSchema>;
+export type AISearchJob = AISearchBatch["jobs"][number];
+export type AISearchJobStatus = AISearchJob["status"];
+export type AISearchErrorType = NonNullable<AISearchJob["errorType"]>;

--- a/src/api/aiSearch.ts
+++ b/src/api/aiSearch.ts
@@ -1,4 +1,6 @@
-import { apiFetch } from "./client";
+import { apiFetch, ApiError } from "./client";
+import { aiSearchBatchSchema } from "../../shared/aiSearchContract";
+import { invalidateContactViews } from "./contactCache";
 /**
  * AI Search — React Query hooks and SSE streaming.
  *
@@ -34,91 +36,109 @@ export const useStartAISearch = () => {
   });
 };
 
-// =============================================================================
-// SSE-based batch status hook (primary)
-// =============================================================================
+/** Poll after transient errors and stop only after a terminal result or a missing batch. */
+export const useAISearchStatusPoll = (batchId: string | null) => {
+  return useQuery({
+    queryKey: ["ai-search-status", batchId],
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch(
+        `/ai-search/status?batchId=${encodeURIComponent(batchId!)}`,
+        { signal },
+      );
+      const batch = aiSearchBatchSchema.parse(await res.json());
+      if (batch.id !== batchId)
+        throw new Error("The server returned a different research batch.");
+      return batch;
+    },
+    enabled: !!batchId,
+    refetchInterval: (query) => {
+      if (
+        query.state.error instanceof ApiError &&
+        query.state.error.status === 404
+      )
+        return false;
+      const data = query.state.data;
+      if (data && data.status !== "processing") return false;
+      return data?.jobs.some(
+        (job) => job.status === "searching" || job.status === "merging",
+      )
+        ? 2000
+        : 5000;
+    },
+  });
+};
 
-/**
- * Connects to the SSE stream endpoint for real-time batch updates.
- * Calls onUpdate for every state change. Automatically closes on completion.
- * Falls back gracefully if SSE is unavailable.
- */
+/** Live events update the same cache that polling uses, so dropped streams cannot freeze progress. */
 export const useAISearchStream = (
   batchId: string | null,
   onUpdate: (batch: AISearchBatch) => void,
 ) => {
   const queryClient = useQueryClient();
+  const poll = useAISearchStatusPoll(batchId);
   const onUpdateRef = useRef(onUpdate);
-  onUpdateRef.current = onUpdate;
-
+  const refreshed = useRef(new Set<string>());
+  useEffect(() => {
+    onUpdateRef.current = onUpdate;
+  }, [onUpdate]);
+  useEffect(() => {
+    refreshed.current.clear();
+  }, [batchId]);
+  useEffect(() => {
+    const batch = poll.data;
+    if (!batch || batch.id !== batchId) return;
+    onUpdateRef.current(batch);
+    const completed = batch.jobs.filter(
+      (job) => job.status === "success" && !refreshed.current.has(job.id),
+    );
+    if (completed.length) {
+      completed.forEach((job) => refreshed.current.add(job.id));
+      invalidateContactViews(queryClient);
+    }
+  }, [batchId, poll.data, queryClient]);
   useEffect(() => {
     if (!batchId) return;
-
     const source = new EventSource(
-      `${API_BASE}/ai-search/stream?batchId=${batchId}`,
+      `${API_BASE}/ai-search/stream?batchId=${encodeURIComponent(batchId)}`,
     );
-
     source.onmessage = (event) => {
-      try {
-        const batch: AISearchBatch = JSON.parse(event.data);
-        onUpdateRef.current(batch);
-        if (batch.status === "complete" || batch.status === "cancelled") {
-          // Invalidate all contact queries so updated data appears everywhere
-          queryClient.invalidateQueries({ queryKey: ["contacts"] });
-          // Also invalidate each individual contact that was enriched
-          for (const job of batch.jobs) {
-            if (job.fieldsUpdated > 0) {
-              queryClient.invalidateQueries({
-                queryKey: ["contacts", job.contactId],
-              });
-            }
-          }
-          source.close();
-        }
-      } catch {
-        // Ignore parse errors on individual events
+      const parsed = aiSearchBatchSchema.safeParse(safeJson(event.data));
+      if (!parsed.success || parsed.data.id !== batchId) {
+        source.close();
+        return;
       }
+      queryClient.setQueryData(["ai-search-status", batchId], parsed.data);
+      if (parsed.data.status !== "processing") source.close();
     };
-
     source.onerror = () => {
-      // SSE failed — the component can fall back to polling
       source.close();
+      void queryClient.invalidateQueries({
+        queryKey: ["ai-search-status", batchId],
+      });
     };
-
     return () => source.close();
   }, [batchId, queryClient]);
+  return { error: poll.error };
 };
 
-// =============================================================================
-// Polling fallback hook
-// =============================================================================
+function safeJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
 
-/** Polling fallback: only used when SSE is unavailable */
-export const useAISearchStatusPoll = (batchId: string | null) => {
-  const queryClient = useQueryClient();
-  return useQuery({
-    queryKey: ["ai-search-status", batchId],
-    queryFn: async ({ signal }) => {
-      const res = await apiFetch(`/ai-search/status?batchId=${batchId}`, {
-        signal,
-      });
-      if (!res.ok) throw new Error("Failed to fetch status");
-      return res.json() as Promise<AISearchBatch>;
+export const useCancelAISearch = () => {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (batchId: string) => {
+      const response = await apiFetch(
+        `/ai-search/${encodeURIComponent(batchId)}/cancel`,
+        { method: "POST" },
+      );
+      return aiSearchBatchSchema.parse(await response.json());
     },
-    enabled: !!batchId,
-    refetchInterval: (query) => {
-      const data = query.state.data;
-      if (!data || data.status === "complete" || data.status === "cancelled") {
-        if (data?.status === "complete") {
-          queryClient.invalidateQueries({ queryKey: ["contacts"] });
-        }
-        return false;
-      }
-      // Adaptive: fast when active, slower when idle between contacts
-      const active = data.jobs.filter(
-        (j) => j.status === "searching" || j.status === "merging",
-      ).length;
-      return active > 0 ? 1000 : 3000;
-    },
+    onSuccess: (batch) =>
+      client.setQueryData(["ai-search-status", batch.id], batch),
   });
 };

--- a/src/contexts/AISearchContext.tsx
+++ b/src/contexts/AISearchContext.tsx
@@ -16,9 +16,15 @@ import React, {
   useState,
   useCallback,
   useMemo,
+  useEffect,
 } from "react";
-import { useStartAISearch, useAISearchStream } from "../api/aiSearch";
+import {
+  useStartAISearch,
+  useAISearchStream,
+  useCancelAISearch,
+} from "../api/aiSearch";
 import { toast } from "sonner";
+import { ApiError } from "../api/client";
 import type { AISearchBatch } from "../types";
 import { AISearchProgressOverlay } from "../views/ai-search/components/AISearchProgressOverlay";
 
@@ -49,12 +55,30 @@ export function AISearchProvider({ children }: { children: React.ReactNode }) {
     setBatch(updatedBatch);
   }, []);
 
-  useAISearchStream(batchId, handleUpdate);
+  const stream = useAISearchStream(batchId, handleUpdate);
+  const cancelMutation = useCancelAISearch();
+  useEffect(() => {
+    if (stream.error instanceof ApiError && stream.error.status === 404) {
+      toast.error(
+        "Research status is no longer available. The server may have restarted. Completed contact updates remain saved.",
+      );
+      setBatchId(null);
+      setBatch(null);
+      setIsVisible(false);
+    }
+  }, [stream.error]);
+  const cancel = () => {
+    if (batchId)
+      cancelMutation.mutate(batchId, {
+        onError: (error) => toast.error(error.message),
+      });
+  };
 
   const startSearch = useCallback(
     (contactIds: string[]) => {
       startMutation.mutate(contactIds, {
         onSuccess: (result) => {
+          setBatch(null);
           setBatchId(result.batchId);
           setIsVisible(true);
           toast.success(
@@ -94,7 +118,14 @@ export function AISearchProvider({ children }: { children: React.ReactNode }) {
       {children}
       {/* Progress overlay rendered via portal-like positioning at root level */}
       {isVisible && batch && (
-        <AISearchProgressOverlay batch={batch} onDismiss={dismiss} />
+        <AISearchProgressOverlay
+          key={batch.id}
+          batch={batch}
+          onDismiss={dismiss}
+          onCancel={cancel}
+          isCancelling={cancelMutation.isPending}
+          connectionError={!!stream.error}
+        />
       )}
     </AISearchContext.Provider>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -468,35 +468,12 @@ export interface SemanticSearchResult {
 // AI Search Types
 // =============================================================================
 
-/** Status lifecycle: queued → searching → merging → success | error */
-export type AISearchJobStatus =
-  "queued" | "searching" | "merging" | "success" | "error";
-
-/** Error classification for contextual UI messages. */
-export type AISearchErrorType =
-  "rate_limit" | "validation" | "network" | "auth" | "ambiguous" | "unknown";
-
-export interface AISearchJob {
-  id: string;
-  contactId: string;
-  contactName: string;
-  status: AISearchJobStatus;
-  error?: string;
-  errorType?: AISearchErrorType;
-  fieldsUpdated: number;
-  startedAt?: string;
-  completedAt?: string;
-  latencyMs?: number;
-}
-
-export interface AISearchBatch {
-  id: string;
-  strategy: string;
-  jobs: AISearchJob[];
-  createdAt: string;
-  status: "processing" | "complete" | "cancelled";
-  totalTokens: number;
-}
+export type {
+  AISearchBatch,
+  AISearchJob,
+  AISearchJobStatus,
+  AISearchErrorType,
+} from "../shared/aiSearchContract";
 
 // =============================================================================
 // Command Palette Zero-State Types

--- a/src/views/ai-search/components/AISearchProgressOverlay.tsx
+++ b/src/views/ai-search/components/AISearchProgressOverlay.tsx
@@ -23,9 +23,13 @@ import { CARD } from "../../../lib/styles";
 interface Props {
   batch: AISearchBatch;
   onDismiss: () => void;
+  onCancel: () => void;
+  isCancelling?: boolean;
+  connectionError?: boolean;
 }
 
 const STATUS_ICONS: Record<string, React.ReactNode> = {
+  cancelled: <XCircle className="w-3.5 h-3.5 text-on-surface-variant" />,
   queued: <Circle className="w-3.5 h-3.5 text-on-surface-variant" />,
   searching: <Loader2 className="w-3.5 h-3.5 text-primary animate-spin" />,
   merging: <Loader2 className="w-3.5 h-3.5 text-warning animate-spin" />,
@@ -33,13 +37,23 @@ const STATUS_ICONS: Record<string, React.ReactNode> = {
   error: <XCircle className="w-3.5 h-3.5 text-error" />,
 };
 
-export function AISearchProgressOverlay({ batch, onDismiss }: Props) {
+export function AISearchProgressOverlay({
+  batch,
+  onDismiss,
+  onCancel,
+  isCancelling,
+  connectionError,
+}: Props) {
   const [isMinimized, setIsMinimized] = useState(false);
 
   const completed = useMemo(
     () =>
-      batch.jobs.filter((j) => j.status === "success" || j.status === "error")
-        .length,
+      batch.jobs.filter(
+        (j) =>
+          j.status === "success" ||
+          j.status === "error" ||
+          j.status === "cancelled",
+      ).length,
     [batch.jobs],
   );
   const succeeded = useMemo(
@@ -80,6 +94,12 @@ export function AISearchProgressOverlay({ batch, onDismiss }: Props) {
         >
           <Sparkles className="w-4 h-4 text-primary" />
           <span className="text-on-surface">
+            {!isComplete && (
+              <span>
+                {completed}/{total} researched{" "}
+              </span>
+            )}
+            {batch.status === "cancelled" && <span>Research stopped </span>}
             {succeeded > 0 && (
               <span className="text-success">{succeeded} updated</span>
             )}
@@ -96,7 +116,7 @@ export function AISearchProgressOverlay({ batch, onDismiss }: Props) {
       initial={{ y: 40, opacity: 0, scale: 0.95 }}
       animate={{ y: 0, opacity: 1, scale: 1 }}
       transition={{ type: "spring", damping: 24, stiffness: 300 }}
-      className="fixed bottom-6 right-6 z-50 w-80"
+      className="fixed bottom-4 right-4 z-50 w-80 max-w-[calc(100vw-2rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto"
     >
       <div
         className={cn(
@@ -114,13 +134,19 @@ export function AISearchProgressOverlay({ batch, onDismiss }: Props) {
             {completed}/{total}
           </span>
           <button
+            aria-label="Minimize research progress"
             onClick={() => setIsMinimized(true)}
             className="p-1 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high transition-colors"
           >
             <ChevronDown className="w-3.5 h-3.5" />
           </button>
           <button
-            onClick={onDismiss}
+            aria-label={
+              isComplete
+                ? "Dismiss research progress"
+                : "Minimize research progress"
+            }
+            onClick={isComplete ? onDismiss : () => setIsMinimized(true)}
             className="p-1 rounded-lg text-on-surface-variant hover:text-error hover:bg-rose-500/10 transition-colors"
           >
             <X className="w-3.5 h-3.5" />
@@ -137,6 +163,22 @@ export function AISearchProgressOverlay({ batch, onDismiss }: Props) {
           />
         </div>
 
+        {!isComplete && (
+          <div className="px-4 py-2 flex items-center justify-between gap-2 text-xs">
+            <span role="status">
+              {connectionError
+                ? "Reconnecting to research status…"
+                : "Completed updates save as research continues."}
+            </span>
+            <button
+              onClick={onCancel}
+              disabled={isCancelling}
+              className="shrink-0 px-2 py-1 rounded text-error hover:bg-error/10 disabled:opacity-50"
+            >
+              {isCancelling ? "Stopping…" : "Stop research"}
+            </button>
+          </div>
+        )}
         {/* Job list */}
         <div className="max-h-64 overflow-y-auto nice-scrollbar">
           {batch.jobs.map((job) => (
@@ -159,11 +201,22 @@ export function AISearchProgressOverlay({ batch, onDismiss }: Props) {
                   )}
                 </span>
               ) : (
-                <span className="opacity-60">No new data found</span>
+                <span className="opacity-60">
+                  {batch.status === "cancelled"
+                    ? "Research stopped"
+                    : failed
+                      ? "Research could not complete"
+                      : "No new data found"}
+                </span>
               )}
             </span>
             <button
-              onClick={onDismiss}
+              aria-label={
+                isComplete
+                  ? "Dismiss research progress"
+                  : "Minimize research progress"
+              }
+              onClick={isComplete ? onDismiss : () => setIsMinimized(true)}
               className="text-xs font-bold text-on-surface-variant hover:text-on-surface px-2 py-1 rounded-lg hover:bg-surface-container-high transition-colors"
             >
               Dismiss
@@ -181,7 +234,7 @@ export function AISearchProgressOverlay({ batch, onDismiss }: Props) {
 
 function JobRow({ job }: { key?: React.Key; job: AISearchJob }) {
   return (
-    <div className="flex items-center gap-3 px-4 py-2 text-sm">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2 text-sm">
       <div className="shrink-0">{STATUS_ICONS[job.status]}</div>
       <span
         className={cn(
@@ -221,6 +274,14 @@ function JobRow({ job }: { key?: React.Key; job: AISearchJob }) {
           <span className="text-warning opacity-60">Merging…</span>
         )}
       </span>
+      {job.status === "cancelled" && (
+        <span className="text-xs text-on-surface-variant">Stopped</span>
+      )}
+      {job.status === "error" && (
+        <p className="w-full pl-6 text-xs text-error break-words">
+          {job.error || "Research failed. Open this contact to retry."}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/views/contact-detail/components/DossierTab.tsx
+++ b/src/views/contact-detail/components/DossierTab.tsx
@@ -5,6 +5,7 @@
  * Extracted from ContactProfile to keep each section focused and readable.
  */
 import React, { useState } from "react";
+import ReactMarkdown from "react-markdown";
 import { Briefcase, ChevronDown, FileText, Sparkles } from "lucide-react";
 import { motion } from "motion/react";
 import { Link } from "react-router-dom";
@@ -77,6 +78,7 @@ const DossierTabInner: React.FC<DossierTabProps> = ({ contact }) => {
   // Every section below is conditional, so "nothing to show" needs answering
   // once, here, rather than as a blank space.
   const hasContent =
+    !!contact.aiBackground ||
     !!contact.about ||
     (contact.attributes?.length ?? 0) > 0 ||
     (contact.experience?.length ?? 0) > 0 ||
@@ -91,6 +93,38 @@ const DossierTabInner: React.FC<DossierTabProps> = ({ contact }) => {
       className="flex flex-col gap-6"
     >
       {contact.about && <AboutSection about={contact.about} />}
+      {contact.aiBackground && (
+        <details className={cn(CARD, "min-w-0")}>
+          <summary className="cursor-pointer font-semibold text-sm text-primary">
+            Research notes and sources
+          </summary>
+          <div className="mt-3 max-h-80 overflow-y-auto prose prose-sm max-w-none break-words text-on-surface-variant">
+            <p className="text-xs not-prose mb-3">
+              Review the source dates and contact identity before you use these
+              details.
+            </p>
+            <ReactMarkdown
+              skipHtml
+              urlTransform={(url) => (/^https?:\/\//i.test(url) ? url : "")}
+              components={{
+                a: ({ children, href }) => (
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline"
+                  >
+                    {children}
+                  </a>
+                ),
+                img: () => null,
+              }}
+            >
+              {contact.aiBackground}
+            </ReactMarkdown>
+          </div>
+        </details>
+      )}
 
       {/* AI Custom Attributes */}
       {contact.attributes && contact.attributes.length > 0 && (

--- a/tests/integration/ai.hardening.test.ts
+++ b/tests/integration/ai.hardening.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
+import request from "supertest";
+vi.mock("../../server/ai/gateway.ts", () => ({
+  generateFor: vi.fn(),
+  isAnyProviderConfigured: vi.fn(() => true),
+  providerIdFor: () => "gemini",
+}));
+vi.mock("../../server/ai/capabilities.ts", async (original) => ({
+  ...(await original<typeof import("../../server/ai/capabilities.ts")>()),
+  resolveCapability: vi.fn(() => ({
+    providerId: "gemini",
+    model: "mock-lite",
+    modelClass: "lite",
+    provider: {},
+  })),
+}));
+import {
+  generateFor,
+  isAnyProviderConfigured,
+} from "../../server/ai/gateway.ts";
+import { sqlite } from "../../server/db.ts";
+import { makeTestApp } from "./helpers.ts";
+import { enrichmentContact } from "../../server/services/aiSearch/contactSnapshot.ts";
+import { mergeSearchResult } from "../../server/services/aiSearch/mergeEngine.ts";
+import { aiSearchOutputSchema } from "../../server/services/aiSearch/promptTemplate.ts";
+import { jobQueue } from "../../server/services/aiSearch/jobQueue.ts";
+import { TwoPassStrategy } from "../../server/services/aiSearch/strategies/twoPass.ts";
+import { interactionService } from "../../server/services/interactionService.ts";
+import { dashboardService } from "../../server/services/dashboardService.ts";
+import { aiCache } from "../../server/utils/aiCache.ts";
+import type { AIGenerateResult } from "../../server/ai/types.ts";
+
+const app = makeTestApp();
+const reply = (text: string): AIGenerateResult => ({
+  text,
+  model: "mock-lite",
+  latencyMs: 1,
+  tokenCount: 10,
+  citations: [{ title: "Test source", uri: "https://example.com/profile" }],
+});
+let id: string;
+beforeEach(async () => {
+  jobQueue.__resetForTests();
+  aiCache.invalidateAll();
+  vi.mocked(generateFor).mockReset();
+  vi.mocked(isAnyProviderConfigured).mockReturnValue(true);
+  sqlite.prepare("DELETE FROM contacts").run();
+  id = (
+    await request(app)
+      .post("/api/contacts")
+      .send({ name: "Test Person", company: "Test Company" })
+  ).body.id;
+});
+afterEach(() => {
+  jobQueue.__resetForTests();
+  vi.unstubAllEnvs();
+});
+
+describe("enrichment integrity", () => {
+  it("rejects an outdated profile instead of replacing a concurrent edit", () => {
+    const original = enrichmentContact(id);
+    sqlite
+      .prepare("UPDATE contacts SET role = 'User role' WHERE id = ?")
+      .run(id);
+    expect(() => mergeSearchResult(id, original, { role: "AI role" })).toThrow(
+      "Contact changed",
+    );
+    expect(enrichmentContact(id).role).toBe("User role");
+  });
+  it.each(["isArchived = 1", "isGhost = 1", "deletedAt = CURRENT_TIMESTAMP"])(
+    "rejects unavailable contacts after research: %s",
+    (change) => {
+      const original = enrichmentContact(id);
+      sqlite.exec(`UPDATE contacts SET ${change}`);
+      expect(() =>
+        mergeSearchResult(id, original, { role: "AI role" }),
+      ).toThrow("no longer available");
+      expect(
+        sqlite.prepare("SELECT role FROM contacts WHERE id = ?").get(id),
+      ).toEqual({ role: null });
+    },
+  );
+  it("deduplicates additions and preserves user interests and attributes", async () => {
+    await request(app)
+      .put(`/api/contacts/${id}`)
+      .send({
+        interests: [{ interest: "Cycling", isAiGenerated: false }],
+        attributes: [{ name: "Preference", value: "User choice" }],
+      });
+    mergeSearchResult(id, enrichmentContact(id), {
+      emails: [{ email: "test@example.com" }, { email: "TEST@example.com" }],
+      interests: [
+        { interest: "Cycling" },
+        { interest: "Reading" },
+        { interest: "Reading" },
+      ],
+      attributes: [
+        { name: "Preference", value: "AI choice" },
+        { name: "Language", value: "French" },
+        { name: "Language", value: "French" },
+      ],
+    });
+    const current = enrichmentContact(id);
+    expect(current.emails).toHaveLength(1);
+    expect(current.interests).toHaveLength(2);
+    expect(
+      Boolean(
+        current.interests.find((interest) => interest.interest === "Cycling")
+          ?.isAiGenerated,
+      ),
+    ).toBe(false);
+    expect(current.attributes).toHaveLength(2);
+    expect(
+      current.attributes.find((attribute) => attribute.name === "Preference")
+        ?.value,
+    ).toBe("User choice");
+  });
+  it("rejects malformed output and unsafe URL schemes before writing", () => {
+    expect(() =>
+      mergeSearchResult(id, enrichmentContact(id), {
+        website: "javascript:alert(1)",
+      }),
+    ).toThrow("schema validation");
+    expect(() =>
+      mergeSearchResult(id, enrichmentContact(id), {
+        tags: Array.from({ length: 51 }, () => ({ tag: "repeated" })),
+      }),
+    ).toThrow("schema validation");
+    expect(aiSearchOutputSchema.parse({ role: null, emails: null })).toEqual({
+      role: undefined,
+      emails: undefined,
+    });
+  });
+  it("rejects overlapping requests for one contact before another generation starts", async () => {
+    let finish!: (value: AIGenerateResult) => void;
+    vi.mocked(generateFor)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve;
+          }),
+      )
+      .mockResolvedValue(reply('{"role":"Researcher"}'));
+    const first = request(app)
+      .post(`/api/contacts/${id}/enrich`)
+      .send({})
+      .then((response) => response);
+    await vi.waitFor(() => expect(generateFor).toHaveBeenCalledTimes(1));
+    const second = await request(app)
+      .post(`/api/contacts/${id}/enrich`)
+      .send({});
+    expect(second.status).toBe(409);
+    expect(generateFor).toHaveBeenCalledTimes(1);
+    finish(reply("Test Person is a researcher."));
+    expect((await first).status).toBe(200);
+    expect(enrichmentContact(id).role).toBe("Researcher");
+  });
+});
+
+describe("batch research lifecycle", () => {
+  it("does not repeat paid research for an empty grounding result", async () => {
+    vi.mocked(generateFor).mockResolvedValue(reply(""));
+    await expect(
+      new TwoPassStrategy().execute(enrichmentContact(id), "test"),
+    ).rejects.toThrow("No public information");
+    expect(generateFor).toHaveBeenCalledTimes(1);
+  });
+  it("stops before extraction when the provider omits source links", async () => {
+    vi.mocked(generateFor).mockResolvedValue({
+      ...reply("An unsupported biography"),
+      citations: [],
+    });
+    const response = await request(app).post(`/api/contacts/${id}/enrich`);
+    expect(response.status).toBe(502);
+    expect(response.body.error.code).toBe("AI_GROUNDING_MISSING");
+    expect(generateFor).toHaveBeenCalledTimes(1);
+    expect(enrichmentContact(id).aiHydratedAt).toBeNull();
+    expect(enrichmentContact(id).role).toBeNull();
+  });
+  it("persists safe provider source links with the validated research", async () => {
+    vi.mocked(generateFor)
+      .mockResolvedValueOnce(reply("A source-backed biography"))
+      .mockResolvedValueOnce(reply('{"about":"Researcher in test software"}'));
+    const response = await request(app).post(`/api/contacts/${id}/enrich`);
+    expect(response.status).toBe(200);
+    expect(enrichmentContact(id).aiBackground).toContain(
+      "https://example.com/profile",
+    );
+    expect(generateFor).toHaveBeenCalledTimes(2);
+  });
+  it("does not retry the complete workflow after a failed provider stage", async () => {
+    vi.mocked(generateFor).mockRejectedValue(new Error("Network 500"));
+    const batch = jobQueue.createBatch(
+      [{ id, name: "Test Person" }],
+      "two-pass",
+    );
+    await jobQueue.processBatch(batch.id);
+    expect(batch.status).toBe("complete");
+    expect(batch.jobs[0].status).toBe("error");
+    expect(generateFor).toHaveBeenCalledTimes(1);
+  });
+  it("cancels active work and queued contacts without late writes", async () => {
+    const nextId = (
+      await request(app).post("/api/contacts").send({ name: "Second Person" })
+    ).body.id;
+    let finish!: (value: AIGenerateResult) => void;
+    vi.mocked(generateFor).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+    );
+    const batch = jobQueue.createBatch(
+      [
+        { id, name: "Test Person" },
+        { id: nextId, name: "Second Person" },
+      ],
+      "two-pass",
+    );
+    const running = jobQueue.processBatch(batch.id);
+    await vi.waitFor(() => expect(generateFor).toHaveBeenCalledTimes(1));
+    const cancelled = await request(app).post(
+      `/api/ai-search/${batch.id}/cancel`,
+    );
+    expect(cancelled.status).toBe(200);
+    await running;
+    finish(reply("Late result"));
+    await Promise.resolve();
+    expect(batch.status).toBe("cancelled");
+    expect(batch.jobs.every((job) => job.status === "cancelled")).toBe(true);
+    expect(enrichmentContact(id).aiHydratedAt).toBeNull();
+    expect(generateFor).toHaveBeenCalledTimes(1);
+  });
+  it("rejects malformed and missing status IDs before starting SSE", async () => {
+    const malformed = await request(app).get(
+      "/api/ai-search/stream?batchId[]=one",
+    );
+    expect(malformed.status).toBe(400);
+    const missing = await request(app).get(
+      "/api/ai-search/stream?batchId=missing",
+    );
+    expect(missing.status).toBe(404);
+    expect(missing.headers["content-type"]).toContain("application/json");
+  });
+});
+
+describe("AI cache freshness", () => {
+  it("reuses unchanged briefings and refreshes them after same-count interaction edits", async () => {
+    const interaction = await request(app)
+      .post(`/api/contacts/${id}/interactions`)
+      .send({ type: "note", title: "Topic", content: "Old context" });
+    vi.mocked(generateFor).mockResolvedValue(reply('["First grounded point"]'));
+    await interactionService.generateBriefing(id);
+    await interactionService.generateBriefing(id);
+    expect(generateFor).toHaveBeenCalledTimes(1);
+    sqlite
+      .prepare("UPDATE interactions SET content = 'New context' WHERE id = ?")
+      .run(interaction.body.id);
+    vi.mocked(generateFor).mockResolvedValue(
+      reply('["Updated grounded point"]'),
+    );
+    expect(await interactionService.generateBriefing(id)).toEqual([
+      "Updated grounded point",
+    ]);
+    expect(generateFor).toHaveBeenCalledTimes(2);
+  });
+  it("does not publish briefing text after a concurrent contact edit", async () => {
+    let finish!: (value: AIGenerateResult) => void;
+    vi.mocked(generateFor).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+    );
+    const pending = interactionService
+      .generateBriefing(id)
+      .catch((error) => error);
+    await vi.waitFor(() => expect(generateFor).toHaveBeenCalledTimes(1));
+    sqlite
+      .prepare("UPDATE contacts SET company = 'New company' WHERE id = ?")
+      .run(id);
+    finish(reply('["Old context"]'));
+    expect(await pending).toMatchObject({ statusCode: 409 });
+    expect(enrichmentContact(id).aiBriefing).toBeNull();
+  });
+  it("returns a configuration error instead of invented briefing content", async () => {
+    vi.mocked(isAnyProviderConfigured).mockReturnValue(false);
+    await expect(interactionService.generateBriefing(id)).rejects.toMatchObject(
+      { statusCode: 503 },
+    );
+    expect(generateFor).not.toHaveBeenCalled();
+  });
+  it("does not create ghost contacts after the source interaction disappears", async () => {
+    let finish!: (value: AIGenerateResult) => void;
+    vi.mocked(generateFor).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+    );
+    vi.stubEnv("DISABLE_BACKGROUND_JOBS", "false");
+    const created = await request(app)
+      .post(`/api/contacts/${id}/interactions`)
+      .send({
+        type: "note",
+        title: "Meeting",
+        content: "Met Future Person today",
+      });
+    await vi.waitFor(() => expect(generateFor).toHaveBeenCalledTimes(1));
+    sqlite
+      .prepare("DELETE FROM interactions WHERE id = ?")
+      .run(created.body.id);
+    finish(reply('[{"name":"Future Person","context":"Met at meeting"}]'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(
+      sqlite
+        .prepare("SELECT id FROM contacts WHERE name = 'Future Person'")
+        .get(),
+    ).toBeUndefined();
+  });
+  it("excludes trashed contacts from dashboard metrics and AI source data", async () => {
+    const removed = (
+      await request(app)
+        .post("/api/contacts")
+        .send({ name: "Removed Person", industry: "Removed industry" })
+    ).body.id;
+    sqlite
+      .prepare("UPDATE contacts SET deletedAt = CURRENT_TIMESTAMP WHERE id = ?")
+      .run(removed);
+    const dashboard = dashboardService.getDashboardPayload();
+    expect(dashboard.metrics.totalActive).toBe(1);
+    expect(dashboard.recentlyAdded.map((contact) => contact.id)).toEqual([id]);
+    expect(dashboard.industryComposition).toEqual([]);
+  });
+});

--- a/tests/integration/api.aiSearch.test.ts
+++ b/tests/integration/api.aiSearch.test.ts
@@ -49,7 +49,7 @@ describe("POST /api/ai-search", () => {
       .send({ contactIds: [contactId] });
 
     expect(res.status).toBe(503);
-    expect(res.body.error).toContain("AI provider is not configured");
+    expect(res.body.error.message).toContain("AI provider is not configured");
   });
 
   it("dynamically resolves to 'searxng' on self-hosted setups with SearXNG configured", async () => {
@@ -61,6 +61,13 @@ describe("POST /api/ai-search", () => {
         baseUrl: "http://127.0.0.1:11434/v1",
       },
     ]);
+    setSetting(SETTING_KEYS.aiCapabilities, {
+      deep: {
+        mode: "pinned",
+        providerId: "custom:local-ollama",
+        model: "local-test",
+      },
+    });
     // Configure SearXNG for research
     setSetting(SETTING_KEYS.aiSearxng, { url: "http://127.0.0.1:8888" });
     invalidateProviderCache();
@@ -79,7 +86,7 @@ describe("POST /api/ai-search", () => {
     expect(batch?.strategy).toBe("searxng");
   });
 
-  it("defaults to 'two-pass' when no research provider or SearXNG is configured", async () => {
+  it("rejects a batch when research has no usable provider or SearXNG", async () => {
     // Configure custom endpoint without SearXNG
     setSetting(SETTING_KEYS.aiCustomEndpoints, [
       {
@@ -94,9 +101,8 @@ describe("POST /api/ai-search", () => {
       .post("/api/ai-search")
       .send({ contactIds: [contactId] });
 
-    expect(res.status).toBe(200);
-    const batch = jobQueue.getBatch(res.body.batchId);
-    expect(batch?.strategy).toBe("two-pass");
+    expect(res.status).toBe(503);
+    expect(jobQueue.getActiveBatches()).toEqual([]);
   });
 
   it("honors explicit valid strategy requested in payload", async () => {
@@ -108,15 +114,22 @@ describe("POST /api/ai-search", () => {
       },
     ]);
     setSetting(SETTING_KEYS.aiSearxng, { url: "http://127.0.0.1:8888" });
+    setSetting(SETTING_KEYS.aiCapabilities, {
+      deep: {
+        mode: "pinned",
+        providerId: "custom:local-ollama",
+        model: "local-test",
+      },
+    });
     invalidateProviderCache();
 
     const res = await request(app)
       .post("/api/ai-search")
-      .send({ contactIds: [contactId], strategy: "single-pass" });
+      .send({ contactIds: [contactId], strategy: "searxng" });
 
     expect(res.status).toBe(200);
     const batch = jobQueue.getBatch(res.body.batchId);
-    expect(batch?.strategy).toBe("single-pass");
+    expect(batch?.strategy).toBe("searxng");
   });
 
   it("rejects unknown strategy with 400 Bad Request", async () => {
@@ -134,7 +147,7 @@ describe("POST /api/ai-search", () => {
       .send({ contactIds: [contactId], strategy: "invalid-strat" });
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toContain("Unknown AI Search strategy");
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
   });
 
   it("rejects empty contactIds array with 400 Validation Error", async () => {
@@ -146,7 +159,7 @@ describe("POST /api/ai-search", () => {
     expect(res.body.error.code).toBe("VALIDATION_ERROR");
   });
 
-  it("returns 400 when none of the contacts exist", async () => {
+  it("returns 409 when selected contacts no longer exist", async () => {
     setSetting(SETTING_KEYS.aiCustomEndpoints, [
       {
         id: "local-ollama",
@@ -154,15 +167,21 @@ describe("POST /api/ai-search", () => {
         baseUrl: "http://127.0.0.1:11434/v1",
       },
     ]);
+    setSetting(SETTING_KEYS.aiCapabilities, {
+      deep: {
+        mode: "pinned",
+        providerId: "custom:local-ollama",
+        model: "local-test",
+      },
+    });
+    setSetting(SETTING_KEYS.aiSearxng, { url: "http://127.0.0.1:8888" });
     invalidateProviderCache();
 
     const res = await request(app)
       .post("/api/ai-search")
       .send({ contactIds: ["00000000-0000-0000-0000-000000000000"] });
 
-    expect(res.status).toBe(400);
-    expect(res.body.error).toContain(
-      "None of the selected contacts were found",
-    );
+    expect(res.status).toBe(409);
+    expect(res.body.error.message).toContain("no longer available");
   });
 });

--- a/tests/unit/ai.workQueue.test.ts
+++ b/tests/unit/ai.workQueue.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from "vitest";
+import { GenerationQueue, SharedWork } from "../../server/ai/workQueue.ts";
+import { QuotaTracker } from "../../server/ai/routing/QuotaTracker.ts";
+import { withRetry } from "../../server/ai/resilience.ts";
+import { AppError } from "../../server/utils/AppError.ts";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("AI work limits", () => {
+  it("bounds active work and rejects excess queued requests", async () => {
+    const queue = new GenerationQueue(1, 1);
+    const first = deferred<string>();
+    const second = vi.fn(async () => "second");
+    const signal = new AbortController().signal;
+    const one = queue.run(() => first.promise, signal);
+    const two = queue.run(second, signal);
+    await expect(queue.run(async () => "excess", signal)).rejects.toMatchObject(
+      { statusCode: 429 },
+    );
+    expect(second).not.toHaveBeenCalled();
+    first.resolve("first");
+    expect(await one).toBe("first");
+    expect(await two).toBe("second");
+  });
+  it("removes a cancelled queued request without starting it", async () => {
+    const queue = new GenerationQueue(1);
+    const first = deferred<void>();
+    const controller = new AbortController();
+    const one = queue.run(() => first.promise, new AbortController().signal);
+    const operation = vi.fn(async () => "unused");
+    const two = queue.run(operation, controller.signal).catch((error) => error);
+    controller.abort();
+    expect((await two).name).toBe("AbortError");
+    first.resolve();
+    await one;
+    expect(operation).not.toHaveBeenCalled();
+  });
+  it("does not start work cancelled before its first microtask", async () => {
+    const controller = new AbortController();
+    const operation = vi.fn(async () => 1);
+    const result = new GenerationQueue().run(operation, controller.signal);
+    controller.abort();
+    await expect(result).rejects.toThrow();
+    expect(operation).not.toHaveBeenCalled();
+  });
+  it("shares identical work while each caller retains separate cancellation", async () => {
+    const shared = new SharedWork<number>();
+    const pending = deferred<number>();
+    let sharedSignal!: AbortSignal;
+    const operation = vi.fn((signal: AbortSignal) => {
+      sharedSignal = signal;
+      return pending.promise;
+    });
+    const controller = new AbortController();
+    const one = shared
+      .run("same", operation, controller.signal)
+      .catch((error) => error);
+    const two = shared.run("same", operation);
+    await Promise.resolve();
+    controller.abort();
+    await one;
+    expect(sharedSignal.aborted).toBe(false);
+    pending.resolve(2);
+    expect(await two).toBe(2);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+  it("cancels shared work when its final caller leaves", async () => {
+    const shared = new SharedWork<number>();
+    const controller = new AbortController();
+    let sharedSignal!: AbortSignal;
+    const pending = deferred<number>();
+    const result = shared
+      .run(
+        "one",
+        (signal) => {
+          sharedSignal = signal;
+          return pending.promise;
+        },
+        controller.signal,
+      )
+      .catch((error) => error);
+    await Promise.resolve();
+    controller.abort();
+    await result;
+    expect(sharedSignal.aborted).toBe(true);
+    pending.resolve(1);
+  });
+  it("never retries malformed output or authentication failures", async () => {
+    const invalid = vi
+      .fn()
+      .mockRejectedValue(
+        new AppError("invalid JSON", 502, { code: "AI_INVALID_JSON" }),
+      );
+    await expect(withRetry(invalid)).rejects.toThrow("invalid JSON");
+    expect(invalid).toHaveBeenCalledTimes(1);
+    const unauthorized = vi.fn().mockRejectedValue({
+      status: 401,
+      message: "quota unavailable for this key",
+    });
+    await expect(withRetry(unauthorized)).rejects.toThrow();
+    expect(unauthorized).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("concurrent quota reservations", () => {
+  it("reconciles and rolls back the correct request when completions arrive out of order", () => {
+    const tracker = new QuotaTracker();
+    const first = tracker.reserve("same", 100);
+    const second = tracker.reserve("same", 200);
+    tracker.reconcile("same", 100, 40, first);
+    expect(tracker.getSnapshot().models.same.tpm).toBe(240);
+    tracker.rollback("same", second);
+    expect(tracker.getSnapshot().models.same).toEqual({
+      tpm: 40,
+      rpm: 1,
+      rpd: 1,
+    });
+    tracker.rollback("same", second);
+    expect(tracker.getSnapshot().models.same.rpd).toBe(1);
+  });
+  it.each([
+    ["2026-09-09T06:59:00Z", "2026-09-09T07:01:00Z"],
+    ["2026-12-09T07:59:00Z", "2026-12-09T08:01:00Z"],
+  ])("resets daily quotas at Pacific midnight from %s", (before, after) => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(before));
+      const tracker = new QuotaTracker(2);
+      tracker.reserve("same", 100);
+      tracker.reserveGrounding();
+      vi.setSystemTime(new Date(after));
+      const snapshot = tracker.getSnapshot();
+      expect(snapshot.models.same).toEqual({ rpm: 0, tpm: 0, rpd: 0 });
+      expect(snapshot.grounding.remaining).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+  it("keeps the quota at UTC midnight and preserves new-day usage after an old rejection", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-09-08T23:59:00Z"));
+      const tracker = new QuotaTracker(2);
+      const oldRequest = tracker.reserve("same", 100);
+      const oldGroundingDate = tracker.reserveGrounding();
+      vi.setSystemTime(new Date("2026-09-09T00:01:00Z"));
+      expect(tracker.getSnapshot().models.same.rpd).toBe(1);
+      expect(tracker.getSnapshot().grounding.rpd).toBe(1);
+      vi.setSystemTime(new Date("2026-09-09T07:01:00Z"));
+      tracker.reserve("same", 50);
+      tracker.reserveGrounding();
+      tracker.rollback("same", oldRequest);
+      tracker.rollbackGrounding(oldGroundingDate);
+      expect(tracker.getSnapshot().models.same.rpd).toBe(1);
+      expect(tracker.getSnapshot().grounding.rpd).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/frontend.aiSearch.test.ts
+++ b/tests/unit/frontend.aiSearch.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import {
+  useAISearchStream,
+  useAISearchStatusPoll,
+} from "../../src/api/aiSearch";
+import { ApiError } from "../../src/api/client";
+
+let source: {
+  onmessage?: (event: { data: string }) => void;
+  onerror?: () => void;
+  close: ReturnType<typeof vi.fn>;
+};
+const batch = {
+  id: "one",
+  strategy: "two-pass",
+  createdAt: "2026-09-09",
+  status: "processing",
+  totalTokens: 0,
+  jobs: [
+    {
+      id: "job",
+      contactId: "contact",
+      contactName: "Test",
+      status: "searching",
+      fieldsUpdated: 0,
+    },
+  ],
+};
+function setup() {
+  vi.stubGlobal(
+    "EventSource",
+    class {
+      constructor() {
+        source = { close: vi.fn() };
+        return source;
+      }
+    },
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+  return { client, wrapper };
+}
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("research progress recovery", () => {
+  it("continues polling after an initial connection failure", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("offline")));
+    const { client, wrapper } = setup();
+    const { result } = renderHook(() => useAISearchStatusPoll("one"), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    const query = client
+      .getQueryCache()
+      .find({ queryKey: ["ai-search-status", "one"] })!;
+    const interval = (
+      query.options as { refetchInterval: (q: typeof query) => unknown }
+    ).refetchInterval;
+    expect(interval(query)).toBe(5000);
+  });
+  it("stops polling for a missing batch", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            JSON.stringify({ error: { message: "Batch missing" } }),
+            { status: 404 },
+          ),
+        ),
+    );
+    const { client, wrapper } = setup();
+    const { result } = renderHook(() => useAISearchStatusPoll("one"), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(ApiError));
+    const query = client
+      .getQueryCache()
+      .find({ queryKey: ["ai-search-status", "one"] })!;
+    const interval = (
+      query.options as { refetchInterval: (q: typeof query) => unknown }
+    ).refetchInterval;
+    expect(interval(query)).toBe(false);
+  });
+  it("ignores events for a different batch and closes the stream on unmount", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(JSON.stringify(batch))),
+    );
+    const { client, wrapper } = setup();
+    const update = vi.fn();
+    const hook = renderHook(() => useAISearchStream("one", update), {
+      wrapper,
+    });
+    await waitFor(() => expect(update).toHaveBeenCalled());
+    await act(async () =>
+      source.onmessage?.({ data: JSON.stringify({ ...batch, id: "other" }) }),
+    );
+    expect(client.getQueryData(["ai-search-status", "one"])).toMatchObject({
+      id: "one",
+    });
+    expect(source.close).toHaveBeenCalled();
+    hook.unmount();
+    expect(source.close).toHaveBeenCalledTimes(2);
+  });
+  it("invalidates contact views once when a job succeeds", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(JSON.stringify(batch))),
+    );
+    const { client, wrapper } = setup();
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    renderHook(() => useAISearchStream("one", vi.fn()), { wrapper });
+    await waitFor(() =>
+      expect(client.getQueryData(["ai-search-status", "one"])).toBeDefined(),
+    );
+    const done = {
+      ...batch,
+      status: "complete",
+      jobs: [{ ...batch.jobs[0], status: "success", fieldsUpdated: 2 }],
+    };
+    await act(async () => source.onmessage?.({ data: JSON.stringify(done) }));
+    await waitFor(() => expect(invalidate).toHaveBeenCalled());
+    const calls = invalidate.mock.calls.length;
+    expect(calls).toBeGreaterThan(0);
+    await act(async () => source.onmessage?.({ data: JSON.stringify(done) }));
+    expect(invalidate.mock.calls).toHaveLength(calls);
+  });
+});

--- a/tests/unit/frontend.dossier.test.tsx
+++ b/tests/unit/frontend.dossier.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { afterEach, describe, it, expect } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { DossierTab } from "../../src/views/contact-detail/components/DossierTab";
+import type { Contact } from "../../src/types";
+afterEach(cleanup);
+describe("research notes", () => {
+  it("shows research-only dossiers and opens sources without replacing the app", () => {
+    render(
+      <DossierTab
+        contact={
+          {
+            id: "test",
+            name: "Test",
+            aiBackground:
+              "Research notes.\n\n[Source](https://example.com/research)",
+          } as Contact
+        }
+      />,
+    );
+    expect(screen.getByText("Research notes and sources")).toBeTruthy();
+    const source = screen.getByRole("link", { name: "Source", hidden: true });
+    expect(source.getAttribute("href")).toBe("https://example.com/research");
+    expect(source.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(source.getAttribute("target")).toBe("_blank");
+  });
+  it("blocks embedded HTML, remote images, and unsafe source schemes", () => {
+    const { container } = render(
+      <DossierTab
+        contact={
+          {
+            id: "test",
+            name: "Test",
+            aiBackground:
+              "<script>alert(1)</script>\n\n![tracking](https://example.com/image)\n\n[Unsafe](javascript:alert(1))",
+          } as Contact
+        }
+      />,
+    );
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector('a[href^="javascript:"]')).toBeNull();
+  });
+});

--- a/tests/unit/gemini.budget.test.ts
+++ b/tests/unit/gemini.budget.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+const sdk = vi.hoisted(() => ({
+  generate: vi.fn(),
+  configs: [] as Record<string, unknown>[],
+}));
+vi.mock("@google/genai", () => ({
+  GoogleGenAI: class {
+    constructor(config: Record<string, unknown>) {
+      sdk.configs.push(config);
+    }
+    models = { generateContent: sdk.generate };
+  },
+  Type: {
+    OBJECT: "OBJECT",
+    ARRAY: "ARRAY",
+    STRING: "STRING",
+    NUMBER: "NUMBER",
+    INTEGER: "INTEGER",
+    BOOLEAN: "BOOLEAN",
+  },
+}));
+import { GeminiAdapter } from "../../server/ai/adapters/gemini.ts";
+beforeEach(() => {
+  sdk.generate.mockReset();
+  sdk.configs.length = 0;
+});
+describe("Gemini call budget", () => {
+  it("disables nested SDK retries and counts explicit-model grounding calls", async () => {
+    sdk.generate.mockResolvedValue({
+      text: "Research",
+      usageMetadata: { totalTokenCount: 12 },
+      candidates: [
+        {
+          groundingMetadata: {
+            groundingChunks: [
+              { web: { title: "Source", uri: "https://example.com/source" } },
+            ],
+          },
+        },
+      ],
+    });
+    const adapter = new GeminiAdapter("test-only-key");
+    const result = await adapter.generate({
+      prompt: "test",
+      model: "test-model",
+      responseFormat: "text",
+      enableSearchGrounding: true,
+      maxOutputTokens: 100,
+    });
+    expect(sdk.configs[0]).toMatchObject({
+      httpOptions: { retryOptions: { attempts: 1 } },
+    });
+    expect(sdk.generate.mock.calls[0][0].config).toMatchObject({
+      maxOutputTokens: 100,
+      abortSignal: expect.any(AbortSignal),
+    });
+    expect(result.citations).toEqual([
+      { title: "Source", uri: "https://example.com/source" },
+    ]);
+    expect(adapter.getQuotaSnapshot().grounding.rpd).toBe(1);
+    expect(adapter.getQuotaSnapshot().models["test-model"].tpm).toBe(12);
+  });
+  it("does not repeat an accepted generation that returns malformed JSON", async () => {
+    sdk.generate.mockResolvedValue({ text: "bad output" });
+    await expect(
+      new GeminiAdapter("test-only-key").generate({
+        prompt: "test",
+        model: "test-model",
+        responseFormat: "json",
+      }),
+    ).rejects.toMatchObject({ code: "AI_INVALID_JSON" });
+    expect(sdk.generate).toHaveBeenCalledTimes(1);
+  });
+  it("does not start or reserve work for an already cancelled caller", async () => {
+    const adapter = new GeminiAdapter("test-only-key");
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      adapter.generate({
+        prompt: "test",
+        model: "test-model",
+        responseFormat: "text",
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+    expect(sdk.generate).not.toHaveBeenCalled();
+    expect(adapter.getQuotaSnapshot().models).toEqual({});
+  });
+});

--- a/tests/unit/resilience.test.ts
+++ b/tests/unit/resilience.test.ts
@@ -194,7 +194,7 @@ describe("withRetry", () => {
       .mockRejectedValueOnce({ status: 503, message: "Service Unavailable" })
       .mockResolvedValueOnce("third-try");
 
-    const promise = withRetry(op);
+    const promise = withRetry(op, { maxAttempts: 3 });
     // Advance past all backoff windows (500ms + 1000ms ≈ 1500ms + jitter).
     await vi.advanceTimersByTimeAsync(5_000);
 
@@ -218,7 +218,7 @@ describe("withRetry", () => {
       .mockRejectedValueOnce({ status: 503 })
       .mockResolvedValueOnce("done");
 
-    const promise = withRetry(op, { onRetry });
+    const promise = withRetry(op, { onRetry, maxAttempts: 3 });
     await vi.advanceTimersByTimeAsync(5_000);
     await promise;
 
@@ -372,7 +372,7 @@ describe("parseAIJson", () => {
 describe("AI_DEFAULTS", () => {
   it("exposes the published timeout, retry, and backoff numbers", () => {
     expect(AI_DEFAULTS.perAttemptTimeoutMs).toBe(60_000);
-    expect(AI_DEFAULTS.maxAttempts).toBe(3);
+    expect(AI_DEFAULTS.maxAttempts).toBe(2);
     expect(AI_DEFAULTS.baseBackoffMs).toBe(500);
     expect(AI_DEFAULTS.jitterMs).toBe(250);
   });


### PR DESCRIPTION
This PR bounds AI work and protects contact edits so enrichment stays responsive and avoids repeated paid requests.

This is PR 5 of 5 in the hardening stack. It targets #21. Merge after #18, #19, #20, and #21.

## Contact enrichment and progress

- Validate research output before one additive database transaction.
  - Reject concurrent research and results that follow contact edits, deletion, archival, or merging.
  - Deduplicate new child records and preserve existing interests, attributes, and scalar values.
  - **Two-pass research requires provider source links.** Missing sources stop extraction and leave the contact unchanged.
- Share the batch response schema between the API and frontend.
  - Validate input before creating a batch and validate stream events before rendering progress.
  - Keep polling after transient stream failures. Refresh contact data once per successful job.
  - Add cancellation, visible errors, a recoverable minimized state, and scrolling for short screens.
- Show research notes and safe source links in the dossier, including profiles with no other dossier fields.

## Request limits and cache freshness

- Allow two concurrent generations and 16 waiting generations. Remove cancelled requests before they start.
- Apply a total deadline and output cap. Disable nested SDK retries and allow at most one application retry for transient failures.
- Remove repeated enrichment workflows after empty, invalid, or failed provider output.
- Reconcile Gemini quotas by reservation ID. Include explicit model pins and grounding requests. Reset daily usage at midnight Pacific.
- Key briefings by actual contact facts, interaction content, and model. Share identical active requests and reject stale results after edits.
- Invalidate AI caches after settings changes. Validate insights, mentions, and parsed contacts before use.
- Return configuration errors instead of demonstration summaries. Prevent late mention extraction from creating contacts after the source note disappears.

## Local resources and dependencies

- Limit local embedding inference to two CPU threads. Skip startup model loading and backfills when background jobs are disabled.
- Remove the vulnerable DiceBear initials package and reuse the escaped monogram renderer.
- Use patched Sharp in both uploads and embeddings. Update the ONNX archive dependency.
- **Remaining limitation:** batch progress lives in memory. A restart loses unfinished work, while completed contact updates remain saved.
- **Remaining advisory:** the production audit reports three moderate entries for the unresolved adm-zip symlink advisory and its dependency parents. It reports no high or critical entries.

## Testing

- `npm test -- --maxWorkers=2`: **679 tests pass across 53 files**.
- `npm run lint`: pass, including TypeScript checks.
- `npm run format:check`: pass.
- `npm run build`: pass.
- `git diff --check`: pass.
- `CONTRACT_GEMINI_MODEL=gemini-3.5-flash-lite npm run test:contract -- -t 'Gemini.*returns schema-conformant JSON'`: **1 passes, 11 skip** with the local credential file.
- Local model smoke check: a normalized 384-dimensional vector with two CPU threads and no provider calls.
- Browser checks: public-contact batch progress, minimize and reopen, contact refresh, and a scrollable dossier at 390 × 480. The production browser starts without runtime errors.
- Live research completed in 6.3 seconds but omitted provider sources. This exposed the new source requirement. Regression tests verify both rejection without extraction and successful persistence with source links.
- `npm audit --omit=dev --json`: **3 moderate, 0 high, 0 critical**.

The complete stack used six small Flash Lite generations. All ordinary regression tests use mocked providers.
