### PR TITLE
feat(tenancy): phase 0, run CI on v2.0 and track the plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "v2.0"]
     tags: ["v*"]
   pull_request:
-    branches: ["main", "arvind/harden-*"]
+    branches: ["main", "v2.0", "arvind/harden-*"]
   # Manual re-run, and an escape hatch when GitHub's hosted pool is congested
   # or degraded — pick the hppc self-hosted runner instead of waiting in queue.
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,3 @@ docs/designs/
 docs/explorations/
 docs/plans/
 docs/recommendations/
-
-# Multi-tenant implementation plan — working design docs, not shipped
-docs/multi-tenant-plan/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# Multi-tenant implementation plan. These are working design documents that
+# are tracked on v2.0 so reviewers can follow the references in each PR. They
+# are not shipped source, and reformatting them would rewrite the hand-aligned
+# tables the plan depends on.
+docs/multi-tenant-plan/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Phase 0.** CI now runs for the `v2.0` integration branch. Pull requests
+  into `v2.0`, and pushes to it, run the `build-and-test` job. The container
+  image job and the release job still run only for `main` and for version
+  tags, so `v2.0` publishes nothing.
+- **Phase 0.** The multi-tenant plan in `docs/multi-tenant-plan/` is now
+  tracked on `v2.0`. A reviewer can follow the references that each 2.0 pull
+  request makes. Prettier and ESLint skip that folder, so the design
+  documents and their benchmark scripts stay exactly as written.
+
 ## [1.5.5] — 2026-08-09
 
 Corrections from an independent review of the v1.5.4 release, run with fresh

--- a/docs/multi-tenant-plan/01-current-state.md
+++ b/docs/multi-tenant-plan/01-current-state.md
@@ -1,0 +1,156 @@
+# 01. Current State (v1.5.5)
+
+This document describes what exists today and what is missing. It is the
+baseline every phase starts from. The raw inventory with line numbers is in
+[appendix-a-query-inventory.md](appendix-a-query-inventory.md).
+
+---
+
+## 1. What already exists
+
+The identity layer is real and well built. It was written with multi-tenancy
+in mind and says so in its comments.
+
+| Piece | Where | State |
+| ----- | ----- | ----- |
+| `users` table with `role` (`admin` or `member`) | `server/db.ts` §2z, `src/db/schema.ts` | Done. The first account is always `admin`. |
+| `sessions` table, hashed secrets, expiry, sweep on boot | `server/db.ts` §2z, `server/services/authService.ts` | Done. |
+| scrypt password hashing with self-describing parameters | `server/services/passwords.ts` | Done. |
+| `Principal` on every request (`anonymous`, `user`, `service`) | `server/middleware/auth.ts` | Done. Only `server/routes/auth.ts` reads it. |
+| `requireAuth` gate on `/api` and `/uploads`, `requireUser` for account endpoints | `server/middleware/auth.ts`, `server/app.ts` | Done. |
+| First-run setup that closes itself, sign-in, sign-out, profile, password change, session list and revoke, session TTL policy | `server/routes/auth.ts`, `src/components/auth/*`, `src/views/settings/AccountSettings.tsx` | Done. |
+| `ownerId` column on `contacts`, `lists`, `ai_invocations`, `dedupe_merge_log`, each with a single-column index | `server/db.ts` §9i | Done. `NULL` means unowned. |
+| `claimUnownedData` on first account creation and `reconcileOwnership` on boot when exactly one account exists | `server/services/authService.ts` | Done. |
+| `existingContacts` count on the setup screen | `server/routes/auth.ts`, `src/components/auth/SetupWizard.tsx` | Done. |
+| Rate limits on sign-in and setup, per IP | `server/routes/auth.ts` | Done. |
+| Integration tests for setup, sign-in, gating, tokens, sessions, ownership claim | `tests/integration/api.auth.test.ts` | 49 tests. |
+
+The `.agent/PHILOSOPHY.md` file says "no multi-user sync" under "What This Is
+NOT". This plan changes that statement for the local instance only. Nothing
+leaves the machine.
+
+---
+
+## 2. What is missing
+
+### 2.1 Nothing filters by owner
+
+Every read of every owned table is unscoped. The inventory counts 33 prepared
+statements in `contactService`, 59 in `dedupe/merging.ts`, 24 in
+`dedupe/suggestions.ts`, 15 in `dashboardService`, and so on, none of which
+mention `ownerId`. `GET /api/contacts` returns every contact on the instance.
+
+### 2.2 Nothing stamps ownership on create
+
+The comment in `server/middleware/auth.ts` says "stamping ownership on new
+rows already uses it". It does not. `contactService.createContact` builds its
+insert from `buildInsertValues`, which has no owner field. The same is true for
+`lists`, `ai_invocations`, and `dedupe_merge_log`. New rows are `NULL`-owned
+until the next boot, when `reconcileOwnership` claims them for the single
+account. With two accounts, `reconcileOwnership` does nothing and the rows
+stay unowned forever.
+
+### 2.3 Auth-off mode has no owner at all
+
+With `AUTH_REQUIRED=false` and no account, every row is `NULL`-owned by
+design. That model cannot support a second account because there is no answer
+to "which owner is the anonymous caller".
+
+### 2.4 The `service` principal has no owner
+
+`API_TOKEN` produces `{ kind: "service" }`. There is no user behind it, so
+there is nothing to scope a query to. MCP clients use this path.
+
+### 2.5 Shared in-process state
+
+Full list in appendix A, section C. The ones that would leak data, not just
+degrade fairness:
+
+- `dedupeQueue` holds scan results with contact snapshots in a map keyed only by scan id. `GET /api/dedupe/active` returns whichever scan is running.
+- `jobQueue` (AI Search) holds batch results keyed only by batch id.
+- `aiCache` tier `dailyInsight` is keyed by the literal string `"singleton"`. The tiers `rerank`, `synthesis`, and `mentions` are keyed by query text or content hash. A cached answer for one owner would be served to another owner who asks the same question.
+
+### 2.6 Shared filesystem
+
+All avatars and attachments live in flat directories with timestamp-based
+names. `express.static` serves the whole tree to any authenticated principal.
+
+### 2.7 Settings, exports, backups, stats are instance-wide
+
+`app_settings` holds AI provider keys. Any signed-in member can read the
+redacted view and write new keys. `GET /api/export/json` dumps six tables
+unfiltered. `GET /api/ai/stats/feed` lists every AI call on the instance.
+
+### 2.8 No admin surface
+
+`role` is written once and never read. There is no endpoint to create a second
+user. The frontend never reads `user.role`.
+
+### 2.9 No cross-tenant tests
+
+There is no test that creates two accounts, because no path creates a second
+account.
+
+### 2.10 The FTS triggers scan the index on every contact update
+
+Not a tenancy gap, but a cost the migration and the purge would inherit.
+Every FTS trigger in `server/db.ts` (`contacts_au`, `fts_emails_ad`, and the
+rest) starts with `DELETE FROM contacts_fts WHERE contactId = old.id`. The
+`contactId` column is `UNINDEXED`, so FTS5 cannot use its index and SQLite
+scans every row of the virtual table. Measured at 40,000 contacts: about 4 ms
+per firing, and each contact update or child-row change fires it once. A
+bulk ownership claim over 5,000 contacts took 27 s and a 5,000-contact purge
+took 77 s in the review benchmark. FTS v2 fixes this with an indexed
+contact-id token (data model document, section 5). Evidence in
+[bench/review-2026-09-08/](bench/review-2026-09-08/README.md).
+
+### 2.11 One MCP route is unreachable
+
+`GET /api/contacts/action-items` (`server/routes/mcp.ts:34`) is shadowed by
+`GET /api/contacts/:id` because `contactsRouter` mounts before `mcpRouter`
+(`server/app.ts:202` and `:204`). The request reaches the contact handler
+with `id = "action-items"` and returns `404`. Phase 0 fixes the mount order.
+
+---
+
+## 3. What is good and stays
+
+- **Prepared statements compiled once** (`stmts` objects in the repository and services). Adding one bound parameter keeps that pattern.
+- **The versioned FTS rebuild gate** (`FTS_SCHEMA_VERSION` and `user_version`). The plan bumps the version and gets a clean re-index for free.
+- **`vec0` rebuild helpers** for dimension changes. The plan extends them for the partition key.
+- **`hydrate` and `hydrateMany`** read child tables by contact id after the parent row is loaded. That is exactly the "derived table" pattern the plan relies on. They do not change.
+- **`resolveUploadPath`** containment. Unchanged.
+- **Integration test harness** with a real database per file and `createApp()`. 41 files, 575 tests, 15.5 s on a laptop. The two-user tests build on it.
+- **`AppError` codes and the central error handler.** New codes slot in.
+- **`asyncHandler` on every route.** Scope resolution throws through it cleanly.
+
+---
+
+## 4. Sizing the work
+
+Counts from appendix A, used to size Phase 2. "Owned" counts statements that
+name one of the eight owned tables (`FROM`, `UPDATE`, `DELETE FROM`,
+`INSERT INTO`, and Drizzle chains). "All" counts every prepared statement and
+Drizzle chain in the domain, which is the number of places a reviewer reads.
+
+| Domain | Files | Owned-table statements | All statements |
+| ------ | ----- | ---------------------- | -------------- |
+| Contacts (service, repository, routes) | 3 | 42 | 69 |
+| Interactions and action items | 3 | 38 | 37 |
+| Lists | 2 | 15 | 17 |
+| Search (FTS, hybrid, local embeddings) | 3 | 8 | 21 |
+| Dashboard and zero-state | 2 | 25 | 20 |
+| Dedupe (engine, passes, blocking, normalization, suggestions, merging, embeddings, context, clustering) | 9 | 53 | 130 |
+| AI Search (job queue, merge engine, strategies) | 3 | 2 plus queue state | 2 |
+| AI stats | 1 | 6 plus 25 `recordInvocation` call sites | 6 |
+| Export, trash, backups | 2 | 6 | 7 |
+| MCP | 2 | 5 | 6 |
+| Relationship scoring | 1 | 7 (mostly unchanged) | 7 |
+| Geocoding | 3 | 4 (unchanged) | 6 |
+| Boot backfills in `server/db.ts` and the claim in `authService` | 2 | 26 | 39 |
+
+About 240 statements over owned tables, inside about 375 statements in all.
+Most changes are one added predicate and one added bound parameter. The
+dedupe domain is the largest and the one with the most cross-contact logic,
+which is why it gets its own sub-phase. Appendix A section A2 lists the
+sites the review added to the inventory.

--- a/docs/multi-tenant-plan/02-research.md
+++ b/docs/multi-tenant-plan/02-research.md
@@ -1,0 +1,228 @@
+# 02. Research: How Self-Hosted Apps Do Multi-User
+
+This document records what was researched online before the architecture was
+chosen, and what was taken from each source. Sources are listed at the end.
+Claims that could not be verified online are marked as such.
+
+---
+
+## 1. Tenancy models
+
+Microsoft's Azure Architecture Center describes a spectrum from "fully
+isolated (shared nothing)" to "fully shared (shared everything)". The key
+sentence for this plan: "When multiple tenants share a single deployment (a
+set of infrastructure), you typically rely on your application code and a
+tenant identifier that's in a database to keep each tenant's data separate."
+The stated risks of the fully shared model are data leakage between tenants,
+noisy neighbors, and scale limits of one shared database. The stated benefit
+is cost, and that moving a user between tenants is a key update, not a data
+migration. [1]
+
+The Azure SaaS patterns page adds that a shared multitenant database "must
+have one or more tenant identifier columns so that the data from any given
+tenant can be selectively retrieved", and that row-level security is the
+mitigation for lost isolation where the database supports it. [2]
+
+SQLite does not support row-level security. Its `ATTACH DATABASE` limit is 10
+by default and 125 at compile time, and it can only be lowered at runtime, so
+a database-per-user design would also need a connection-per-user design in
+the process. [3]
+
+**Taken for this plan:** shared schema with an `ownerId` discriminator column
+(D1). Isolation moves into the application layer and needs structural guards,
+not just discipline (section 3).
+
+---
+
+## 2. How well-known self-hosted apps model users and admins
+
+| App | First user | Registration | Admin creates or invites | Per-user API credential | Data model | Proxy auth |
+| --- | ---------- | ------------ | ------------------------ | ----------------------- | ---------- | ---------- |
+| **Gitea** | Web installer creates the first admin. `INSTALL_LOCK` then closes the installer. | `DISABLE_REGISTRATION` (default `false`): "Disable registration, after which only admin can create accounts." | Admin panel or `gitea admin user create --random-password`. | Personal access tokens per user. | Per-user and per-org ownership with explicit sharing. | `ENABLE_REVERSE_PROXY_AUTHENTICATION` with `REVERSE_PROXY_AUTHENTICATION_USER = X-WEBAUTH-USER` and `REVERSE_PROXY_TRUSTED_PROXIES = 127.0.0.0/8,::1/128`. [4] |
+| **Miniflux** | `CREATE_ADMIN=1` with `ADMIN_USERNAME` and `ADMIN_PASSWORD` bootstraps the admin from env. | No open registration. Admin creates users through the UI or `POST /v1/users` (admin only). | Admin creates with username, password, `is_admin`. | "Settings > API Keys > Create a new API key", sent as `X-Auth-Token`. | Strictly per-user. No sharing. | `AUTH_PROXY_HEADER` with `TRUSTED_REVERSE_PROXY_NETWORKS` required. `AUTH_PROXY_USER_CREATION=1` to auto-create. `DISABLE_LOCAL_AUTH` hides the password form. Sessions swept after `CLEANUP_REMOVE_SESSIONS_DAYS` (30). [5] |
+| **Vaultwarden** | First registered user. | `SIGNUPS_ALLOWED=false` hides the create-account link. `SIGNUPS_DOMAINS_WHITELIST` overrides it for listed domains. `INVITATIONS_ALLOWED` controls org invites separately. | Admin page "Users" section creates users shown as "Invited", which works "regardless of any of the restrictions above". | Bitwarden client tokens. | Per-user vaults, orgs for sharing. | Not applicable. [6] |
+| **Immich** | "The first user to register will be the admin user." | Closed after the first user. | Admin creates users. "Reset Password" sets "a random password and they have to change it next time they sign in." Delete: "The user account will immediately become disabled and their library and all associated data will be removed after 7 days by default", with an option for immediate deletion. Per-user storage quota. | Per-user API keys. | Per-user libraries with explicit sharing. | OAuth. [7] |
+| **Grafana** | `admin`/`admin` default. | Configurable. | Server admin creates users and orgs. | Per-user and service-account tokens. | Organizations as tenants, users belong to orgs with roles. | `[auth.proxy]` with `header_name = X-WEBAUTH-USER`, `auto_sign_up = true`, and `whitelist` "to prevent users spoofing the X-WEBAUTH-USER header". [8] |
+| **Paperless-ngx** | `PAPERLESS_ADMIN_USER` env or `createsuperuser`. | Closed. | Admin creates users and groups. | Per-user API tokens. | Every object has an owner plus view and edit grants. Superusers see everything. Documents consumed from the folder have no owner and are visible to all. | Remote-user header support. [9] |
+| **Monica** (personal CRM) | First registration creates the account. | `APP_DISABLE_SIGNUP` closes it (documented in the project's `.env.example`, not on the user-management page). | Administrator enters an email, picks a permission level, and "the invited person receives a link to create their account." | Per-user tokens. | Accounts contain users and vaults. Administrators manage users, billing, and settings. Regular users manage their own vaults. | Not applicable. [10] |
+| **Mealie** | Default admin from env, must be changed. | Configurable. | "You can add new users with sign-up links or simply create a new user in the admin panel." Invite links are listed in a table where the admin can delete or copy them. | Per-user tokens. | Groups and households. | OIDC. [11] |
+| **Navidrome** | "Create your first user, which will be your admin user." | Closed after the first user. | Admin UI and CLI. | Subsonic tokens per user. | Shared library, per-user playlists and state. | Reverse-proxy header auth. [12] |
+| **Audiobookshelf** | The first account is "Root", which admins cannot edit. | Closed. | Admins create users. | Per-user tokens. | Shared libraries with per-user permissions. | OIDC. [13] |
+
+Patterns that appear in almost every app:
+
+1. **The first user is the admin and the door closes behind them.** Contrack already does this (`countUsers() === 0` makes the first account an admin, then `/setup` returns 409).
+2. **Open registration is a flag that defaults to closed.** Gitea, Vaultwarden, Monica, Miniflux, Immich all default closed on a fresh install. This plan adds `auth.registrationOpen`, default `false`.
+3. **Admins create users through two paths:** a temporary password with a forced change on first sign-in (Immich, Gitea's `--random-password`), or an invitation link the admin copies (Mealie, Monica, Vaultwarden). A self-hosted app has no mail server, so the link must be shown to the admin, not emailed. This plan supports both.
+4. **API credentials are per user, created in account settings.** Gitea, Miniflux, Immich, Paperless. A shared instance token is not a pattern any of them use.
+5. **Delete is two-step.** Immich disables first and purges after seven days. Paperless and Gitea refuse to delete an owner that still holds objects unless the admin decides what happens to them. This plan requires an explicit data decision (`purge` or `export-then-purge`) and keeps `ON DELETE RESTRICT` as the safety rail.
+6. **Reverse-proxy header auth is the common "SSO for self-hosters" path**, and every app that offers it pairs it with a trusted-proxy IP list because the header is trivially spoofable otherwise. This is deferred to [11-future.md](11-future.md) with that constraint recorded.
+7. **Personal-data apps do not let the admin browse member data.** Miniflux and Monica keep user data private to the user. Paperless is the counterexample, and its own discussions list superuser visibility as a surprise for new operators. This plan chooses privacy (D10).
+
+---
+
+## 3. Data isolation enforcement in application code
+
+The OWASP IDOR prevention cheat sheet states: "implement access control checks
+for each object that users try to access" and "Verify the user's permission
+every time an access attempt is made." On random identifiers it says to "use
+complex identifiers as a defense-in-depth measure, but remember that access
+control is crucial even with these identifiers." Its Rails example scopes the
+query to "projects related to the current user rather than all projects". The
+sheet does not prescribe a status code for a denied object. [14]
+
+Contrack already uses UUIDs for every id. That is the defense-in-depth layer.
+It is not the control. The control is the scoped query.
+
+The Postgres row-level-security literature is the gold standard for
+"impossible to forget". Crunchy Data's pattern sets a session variable per
+request and lets a `CREATE POLICY ... USING (org_id = current_setting(...))`
+filter every query automatically: "any queries executed within the request
+will automatically be filtered based on the current tenant ID". [15]
+
+SQLite has no policies. The closest equivalents in application code are:
+
+- A repository boundary whose functions require the scope as a parameter, so the type checker rejects a call that forgets it. This is what the existing schema comment in `src/db/schema.ts` already asks for.
+- A request-scoped context that carries the principal to code that is too deep to thread a parameter through. Node's `AsyncLocalStorage` is stable since 16.4 and is O(1) to read. One published HTTP benchmark measured about 10 percent lower throughput with it enabled on Node 22 and about 7 percent on Node 24, where the `AsyncContextFrame` implementation is the default. [16] [22] The cost per request is microseconds. This app spends its request time in SQLite and in AI calls, so the Phase 0 baseline is the number that matters. The Node documentation also states that an `EventEmitter` listener runs in the context of the code that emits, not the code that subscribed, unless bound with `AsyncResource.bind()`. [16] This is why the plan captures the scope in a closure for every SSE handler.
+- Tests that try cross-tenant access for every route, and a lint that fails on a statement over a tenant table without the tenant predicate.
+
+**Taken for this plan:** explicit `Scope` at the repository and service boundary as the control, `AsyncLocalStorage` for attribution, and the three structural guards in [03-architecture.md](03-architecture.md) section 5.3.
+
+**On 404 versus 403:** OWASP does not prescribe it. The plan chooses `404` for cross-owner ids because a `403` confirms that the id exists, which is exactly the enumeration signal the cheat sheet warns about. GitHub, for example, returns `404` for private repositories the caller cannot see.
+
+---
+
+## 4. Indexes, FTS5, and sqlite-vec
+
+**Composite indexes.** The multi-tenant Postgres guidance is uniform:
+"Every table with an RLS policy needs `tenant_id` as the leading column in
+its primary access indexes", with shapes like `(tenant_id, created_at DESC)`
+and `(tenant_id, status, updated_at)`. One write-up measured two orders of
+magnitude difference when the leading column was missing. [17] SQLite's
+planner works the same way for a B-tree: the leading column must be an
+equality predicate for the index to narrow the scan. Section 8 of
+[03-architecture.md](03-architecture.md) applies this to every owned table.
+
+**FTS5.** From the SQLite FTS5 documentation: columns marked `UNINDEXED` "are
+not added to the FTS index", so they cannot be used in `MATCH`. Column
+filters use the syntax `colname : phrase`, filters can wrap arbitrary
+expressions such as `(b : "hello") AND ({a b} : "world")`, and `AND` binds
+tighter than `OR`. `bm25(ft, w1, w2, ...)` assigns weights left to right,
+**counting every column including `UNINDEXED` ones**, and a weight of `0.0`
+removes that column from the score. The `unicode61` tokenizer treats Unicode
+letters and numbers as token characters and everything else, including `-`
+and `_`, as separators. [18]
+
+Two facts from the FTS5 source that the documentation does not state. First,
+`xBestIndex` consumes only `MATCH`, `rowid`, and `rank` constraints, so an
+`=` predicate on any regular column, indexed or not, is evaluated by the
+SQLite core after the virtual table returns each row. This applies to the
+`DELETE FROM contacts_fts WHERE contactId = ?` in today's triggers, which
+scans the whole table because `contactId` is `UNINDEXED`. Second, an `AND`
+node advances the child with the smaller rowid to the larger one (a leapfrog
+intersection), not a full read of both doclists, so an `AND` with a very
+common term costs about the rarer side plus seeks. [18] The review measured
+both (section 2 of the risks document).
+
+Consequences for the design in section 6 of the architecture document: an
+`UNINDEXED` owner column would be filtered by the SQLite core after the
+virtual table returns rows, which is a post-filter. An indexed owner token
+column lets FTS5 intersect posting lists. A raw UUID would split into five
+tokens on the hyphens, so the token is the UUID with hyphens removed and a
+letter prefix. A weight of `0.0` on that column removes it from ranking. The
+same technique, applied to the contact id, turns the trigger delete from a
+table scan into an index probe. There is no documented "tenant token"
+precedent for FTS5; the approach is justified by the leapfrog evaluation and
+by measurement.
+
+**sqlite-vec.** The `vec0` documentation shows partition keys declared as
+`user_id integer partition key`, with `TEXT` also shown as a supported type,
+and a KNN query filtered as `where contents_embedding match :query and k = 20
+and user_id = 123`. "Any `=` constraint in a `WHERE` clause on a partition key
+column will restrict the search to that clause." Limits: at most 4 partition
+keys per table (with a caution above 1), at most 16 metadata columns.
+Performance guidance: "every unique partition key value has ~100s of vectors"
+to avoid over-sharding. [19] Partition keys, metadata columns, and auxiliary
+columns shipped in v0.1.6, and "partition key columns can only be `TEXT` or
+`INTEGER` values". [20] The installed package is 0.1.9, which is the latest
+stable release. [24]
+
+Limits verified on 0.1.9 during the review, from the issue tracker and by
+test: `UPDATE` of a partition key column is refused ("not supported yet"),
+and an `UPDATE` of another column whose `WHERE` uses `EXISTS` trips the same
+error (issue #261). `partitionCol IN (...)` is not supported (issue #142).
+`k` has a maximum of 4096 (issue #157). Before 0.1.7, `DELETE` did not
+reclaim space. `ALTER TABLE ... RENAME` on a `vec0` table returns OK on 0.1.9
+but leaves the shadow tables under the old name, so the table is broken
+afterward; rename support arrives in 0.1.10, which is a pre-release. An
+`INSERT` that omits the partition column succeeds with a `NULL` partition.
+`DELETE`, `SELECT`, and `COUNT(*)` with `WHERE partitionCol = ?` work. [24]
+
+---
+
+## 5. Admin user management conventions
+
+Collected from the apps above:
+
+| Concern | Convention | Source |
+| ------- | ---------- | ------ |
+| Create user | Admin sets a temporary password and the user must change it on first sign-in | Immich [7], Gitea `--random-password` [4] |
+| Invite user | Admin generates a link with an expiry, copies it, and can revoke it from a list | Mealie [11], Monica [10], Vaultwarden [6] |
+| Reset password | Admin resets to a random value and forces a change | Immich [7] |
+| Disable vs delete | Disable is immediate and reversible. Delete waits or requires an explicit choice about data | Immich [7] |
+| Last admin | Gitea refuses to delete or demote the last admin (`auth.last_admin`) and refuses self-deletion. Grafana refuses with "cannot remove last grafana admin". Immich and Keycloak do not protect the last admin; Immich blocks self-deletion only. The plan follows Gitea and Grafana, and adds the self-target guard all three apply. | [25] |
+| Roles | Two roles (admin, user) is the norm for personal-data apps. Grafana and Gitea add org-level roles only because they have sharing. | [5], [7], [8] |
+| Registration | Flag, default closed | [4], [6], [10] |
+| Audit | Grafana and Gitea keep admin audit trails. Miniflux logs to stdout. | [4], [8] |
+
+---
+
+## 6. Auth details
+
+- **Sessions over JWT.** Contrack already stores sessions server-side so revocation works. Miniflux does the same and sweeps sessions after 30 days. [5] No change.
+- **Token format.** GitHub moved to prefixed tokens such as `ghp_` so that secret scanners can identify them. The old 40-hex format was "indistinguishable from other encoded data like SHA hashes". [21] GitHub's audit log identifies tokens by their SHA-256, which is how the stored form is known to be a hash. [23] This plan uses `ctk_` and stores a SHA-256. Since the token is 32 random bytes, a fast hash is correct, the same reasoning the existing `sessions` table applies.
+- **Reverse-proxy auth.** Gitea, Miniflux, and Grafana all support a trusted header from an authenticating proxy, and all three require an allowlist of proxy addresses. [4], [5], [8] Deferred, with the allowlist requirement recorded.
+
+---
+
+## 7. Background jobs and caches
+
+No primary source gives a recipe for single-process, single-writer job
+fairness. The reasoning in this plan is first-principles:
+
+- SQLite has one writer at a time. Two owners' scans cannot run in parallel on one connection anyway, so a global run lock is not a regression. Per-owner **state** is what prevents information leaks and wrong 429s.
+- Provider rate limits are per API key. With instance-level keys, a global concurrency cap is the correct model for the AI Search batch queue.
+- Caches keyed by content that depends on the owner's data must include the owner in the key. Caches keyed by a pure function of the input (query parse, HyDE) can be shared and sharing saves paid calls.
+
+---
+
+## Sources
+
+1. Tenancy models for a multitenant solution, Azure Architecture Center. https://learn.microsoft.com/en-us/azure/architecture/guide/multitenant/considerations/tenancy-models
+2. Multitenant SaaS patterns, Azure SQL Database. https://learn.microsoft.com/en-us/azure/azure-sql/database/saas-tenancy-app-design-patterns
+3. Implementation limits for SQLite (`SQLITE_MAX_ATTACHED`). https://sqlite.org/limits.html
+4. Gitea configuration cheat sheet. https://docs.gitea.com/administration/config-cheat-sheet/ and command line reference https://docs.gitea.com/administration/command-line/
+5. Miniflux configuration parameters. https://miniflux.app/docs/configuration.html and API reference https://miniflux.app/docs/api.html
+6. Vaultwarden wiki, disable registration of new users. https://github.com/dani-garcia/vaultwarden/wiki/Disable-registration-of-new-users and disable invitations https://github.com/dani-garcia/vaultwarden/wiki/Disable-invitations
+7. Immich user management. https://docs.immich.app/administration/user-management/ and post-install steps https://docs.immich.app/install/post-install/
+8. Grafana, configure auth proxy authentication. https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/auth-proxy/
+9. Paperless-ngx usage and permissions. https://docs.paperless-ngx.com/usage/ and multi-user discussion https://github.com/paperless-ngx/paperless-ngx/discussions/5878
+10. Monica, manage users. https://docs.monicahq.com/user-and-account-settings/manage-users
+11. Mealie user management (invite links). https://docs.mealie.io/ (User Management section)
+12. Navidrome getting started. https://www.navidrome.org/docs/getting-started/
+13. Audiobookshelf user management. https://audiobookshelf.org/docs/documentation/server-management/user-management/
+14. OWASP Insecure Direct Object Reference Prevention Cheat Sheet. https://cheatsheetseries.owasp.org/cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.html
+15. Row Level Security for tenants in Postgres, Crunchy Data. https://www.crunchydata.com/blog/row-level-security-for-tenants-in-postgres
+16. Node.js asynchronous context tracking. https://nodejs.org/api/async_context.html and a production guide https://www.hirenodejs.com/blog/nodejs-async-local-storage-2026
+17. Postgres RLS multi-tenant patterns and index guidance. https://queryplane.com/blog/postgres-row-level-security-in-practice/ and https://patotski.com/blog/postgres-row-level-security-multi-tenant/
+18. SQLite FTS5 extension. https://www.sqlite.org/fts5.html
+19. sqlite-vec `vec0` documentation, partition keys and metadata. https://alexgarcia.xyz/sqlite-vec/features/vec0.html
+20. sqlite-vec metadata release post (v0.1.6). https://alexgarcia.xyz/blog/2024/sqlite-vec-metadata-release/index.html
+21. Behind GitHub's new authentication token formats. https://github.blog/engineering/platform-security/behind-githubs-new-authentication-token-formats/
+22. The hidden cost of context (AsyncLocalStorage HTTP benchmark on Node 22 and 24), Platformatic. https://blog.platformatic.dev/the-hidden-cost-of-context
+23. Identifying audit log events performed by an access token (`hashed_token` is the SHA-256), GitHub Docs. https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/identifying-audit-log-events-performed-by-an-access-token
+24. sqlite-vec releases and issues. https://github.com/asg017/sqlite-vec/releases, https://github.com/asg017/sqlite-vec/issues/261, https://github.com/asg017/sqlite-vec/issues/142, https://github.com/asg017/sqlite-vec/issues/157. Virtual table rename rule: https://www.sqlite.org/vtab.html section 2.19.
+25. Last-admin protection in Gitea (`routers/web/admin/users.go`, `IsErrDeleteLastAdminUser`) https://github.com/go-gitea/gitea/blob/main/routers/web/admin/users.go and Grafana (`ErrLastGrafanaAdmin`) https://github.com/grafana/grafana/blob/main/pkg/services/user/error.go. Immich `user-admin.service.ts` blocks self-delete only. Keycloak issue #20662 closed as not planned.
+26. Express 5 migration guide (`app.router` returns) https://expressjs.com/en/guide/migrating-5.html and the mount-path discussion https://github.com/expressjs/express/discussions/5961. `express-route-parser` records mount paths by patching `Router.prototype.use` https://github.com/nklisch/express-route-parser.
+27. multer issue #1111, AsyncLocalStorage lost after the multer middleware when the multipart body carries text fields. https://github.com/expressjs/multer/issues/1111
+28. SQLite `ALTER TABLE` restrictions https://www.sqlite.org/lang_altertable.html, `VACUUM INTO` https://www.sqlite.org/lang_vacuum.html, triggers https://www.sqlite.org/lang_createtrigger.html, foreign key actions https://www.sqlite.org/foreignkeys.html.

--- a/docs/multi-tenant-plan/03-architecture.md
+++ b/docs/multi-tenant-plan/03-architecture.md
@@ -1,0 +1,557 @@
+# 03. Target Architecture
+
+This document states the architecture decisions for multi-tenant Contrack. Every
+phase document refers back to the names and rules defined here. Read this
+document before any phase document.
+
+The plan uses the word **owner** for the tenant. One owner is one row in the
+`users` table. One owner has one private CRM. Nothing is shared between owners
+in this plan. See [11-future.md](11-future.md) for shared workspaces.
+
+---
+
+## 1. Decision summary
+
+| # | Decision | Choice | Why |
+| - | -------- | ------ | --- |
+| D1 | Tenancy model | Shared database, shared schema, `ownerId` discriminator column | One SQLite file. No cross-database joins. The `ownerId` column already exists on four tables. |
+| D2 | Tenant unit | `ownerId` = `users.id` (one owner per user) | Simplest model. Upgradable to workspaces later without a data migration (see section 12). |
+| D3 | Always an owner | Every row has a non-null `ownerId`. Auth-off mode uses an implicit **local owner account** | Removes `ownerId IS NULL` from every query. One query shape, one index shape. |
+| D4 | Enforcement | Explicit `Scope` parameter at the repository and service boundary, plus an `AsyncLocalStorage` request context for attribution | A forgotten `WHERE ownerId = ?` must be a compile error or a failing test, never a silent leak. |
+| D5 | Denormalization | Add `ownerId` to `interactions`, `action_items`, `dedupe_suggestions`, `dedupe_exclusions`. Keep the ten `contact_*` child tables derived. | Those four tables are queried without starting from a contact. The ten child tables are only read through a contact id. |
+| D6 | Full-text search | Add two indexed token columns to `contacts_fts`, `ownerTok` and `cidTok`, both with BM25 weight 0. Query with `ownerTok:<token> AND (<query>)`. Triggers delete with `cidTok:<token>` | FTS5 intersects posting lists in the index. No post-filter, no JOIN. The contact token turns the trigger delete from a table scan into an index probe (measured 400 times faster). |
+| D7 | Vector search | Rebuild both `vec0` tables with `ownerId TEXT PARTITION KEY` | KNN scans only the owner's partition. Correct top-k for small owners. |
+| D8 | Indexes | Composite indexes that lead with `ownerId` on every owned table | The owner column is the most selective predicate on a multi-owner instance. |
+| D9 | Cross-owner access | Return `404 NOT_FOUND`, never `403` | A `403` confirms the row exists. `404` gives no information. |
+| D10 | Admin data visibility | An admin manages accounts. An admin cannot read a member's contacts. | Personal CRM. Privacy is a core belief in `.agent/PHILOSOPHY.md`. |
+| D11 | Machine credentials | Per-user API tokens, hashed at rest. The env `API_TOKEN` maps to the primary admin and is deprecated. | A shared secret has no owner, so it cannot scope a query. |
+| D12 | Settings | `app_settings` stays instance-level and admin-only for writes. New `user_settings` table for per-user values. | AI provider keys are paid by the operator. Preferences belong to the person. |
+| D13 | Background work | One process, one writer. Global concurrency locks stay. Job **state** becomes per-owner. | SQLite has one writer. Provider rate limits are per API key, which is instance-level. |
+| D14 | Uploads | Per-owner directory `uploads/u/<ownerId>/`. An ownership guard runs before `express.static`. | Static serving stays fast. The guard is a string compare with no database read. |
+| D15 | Version | Ship as `2.0.0` | The `API_TOKEN` principal changes meaning. That is a breaking change for scripts. |
+
+---
+
+## 2. Why shared schema with a discriminator column
+
+Three models exist for multi-tenancy:
+
+1. **Database per tenant.** Each owner gets a SQLite file. Isolation is perfect. Cost: N open connections, N sets of prepared statements, N FTS indexes, N vector stores, N embedding backfills, N backup files, and no cross-owner admin queries. The background jobs in `server.ts` would loop over N databases. `better-sqlite3` is synchronous, so N databases means N times the boot work on one thread.
+2. **Schema per tenant.** SQLite has no schemas. `ATTACH DATABASE` is limited to 10 databases by default and 125 at compile time. This model does not fit.
+3. **Shared schema with a discriminator column.** One file, one connection, one set of prepared statements. Isolation is enforced in application code. This is the model the codebase already started with `ownerId`.
+
+The user asked for one database. Model 3 is the only model that keeps one file and stays fast on one thread. The cost of model 3 is discipline. Section 5 turns that discipline into structure.
+
+---
+
+## 3. Data model at a glance
+
+```mermaid
+erDiagram
+    users ||--o{ sessions : "userId"
+    users ||--o{ api_tokens : "userId"
+    users ||--o{ user_settings : "userId"
+    users ||--o{ invitations : "invitedBy"
+    users ||--o{ audit_log : "actorUserId"
+    users ||--o{ contacts : "ownerId"
+    users ||--o{ lists : "ownerId"
+    users ||--o{ interactions : "ownerId (denormalized)"
+    users ||--o{ action_items : "ownerId (denormalized)"
+    users ||--o{ dedupe_suggestions : "ownerId (denormalized)"
+    users ||--o{ dedupe_exclusions : "ownerId (denormalized)"
+    users ||--o{ dedupe_merge_log : "ownerId"
+    users ||--o{ ai_invocations : "ownerId"
+    contacts ||--o{ contact_emails : "contactId (derived owner)"
+    contacts ||--o{ contact_phones : "contactId (derived owner)"
+    contacts ||--o{ interactions : "contactId"
+    contacts ||--o{ action_items : "contactId"
+    contacts ||--o{ list_members : "contactId (derived owner)"
+    lists ||--o{ list_members : "listId"
+    contacts ||--|| contacts_fts : "contactId + ownerTok"
+    contacts ||--|| search_embeddings : "contactId, ownerId partition"
+    contacts ||--|| contact_embeddings : "contactId, ownerId partition"
+```
+
+### 3.1 Table classes
+
+| Class | Tables | Rule |
+| ----- | ------ | ---- |
+| **Owned** (carry `ownerId`) | `contacts`, `lists`, `interactions`, `action_items`, `dedupe_suggestions`, `dedupe_exclusions`, `dedupe_merge_log`, `ai_invocations` | Every read filters on `ownerId`. Every insert sets `ownerId`. |
+| **Derived** (owner through a parent) | `contact_emails`, `contact_phones`, `contact_addresses`, `contact_social_links`, `contact_education`, `contact_experience`, `contact_sources`, `contact_tags`, `contact_interests`, `contact_attributes`, `interaction_mentions`, `list_members`, `dedupe_embedding_meta` | Read only through a parent id that was already owner-checked. Never queried by a user-supplied id alone. |
+| **Virtual** | `contacts_fts` (`ownerTok` column), `search_embeddings` and `contact_embeddings` (`ownerId PARTITION KEY`) | Filter inside the virtual table, not after it. |
+| **Identity** | `users`, `sessions`, `api_tokens`, `invitations`, `user_settings`, `audit_log` | Keyed by `userId`. Admin endpoints read across users. |
+| **Instance** | `app_settings`, `__drizzle_migrations`, geocode cache | No owner. Admin writes. |
+
+The complete DDL is in [04-data-model-and-migration.md](04-data-model-and-migration.md).
+
+### 3.2 Why `interactions` and `action_items` get their own `ownerId`
+
+The current schema comment argues that a child table should derive its owner
+through the foreign key. That argument holds for the ten `contact_*` tables.
+Every read of those tables starts from a contact id that the caller already
+loaded. See `contactRepository.hydrate` and `hydrateMany`.
+
+It does not hold for these four tables. Each of them has queries that start
+from the table itself:
+
+| Table | Queries that do not start from a contact |
+| ----- | ---------------------------------------- |
+| `interactions` | `mcpService.getGlobalTimeline`, `mcpService.searchInteractions`, dashboard interaction velocity and recent activity (`dashboardService.ts:80`, `:168-178`), the mention graph in `loadNegativeConstraints` |
+| `action_items` | `actionItemService.getAllPending`, `getRecentlyCompleted`, `getUrgentCount`, the Pulse swimlane |
+| `dedupe_suggestions` | `getPendingSuggestions`, `getPendingCount`, `getPendingClusterCount`, the sidebar badge |
+| `dedupe_exclusions` | `loadNegativeConstraints` loads the full table into a `Set` for every scan |
+
+Without a column, each of those queries needs `JOIN contacts c ON c.id = x.contactId WHERE c.ownerId = ?`. The join is cheap per row, but the planner then has two paths and neither path has a covering index. With the column, each query is `WHERE ownerId = ? AND ...` on a composite index. The column costs 36 bytes per row. Drift is prevented by triggers (section 4 of the data model document).
+
+---
+
+## 4. Identity and principals
+
+### 4.1 The principal
+
+Every request that passes `requireAuth` carries a user. The `anonymous` and
+`service` principal kinds are removed.
+
+```ts
+// server/middleware/auth.ts
+export type Principal =
+  | { kind: "user"; user: User; via: "session"; sessionId: string }
+  | { kind: "user"; user: User; via: "token"; tokenId: string }
+  | { kind: "user"; user: User; via: "implicit" }
+  | { kind: "user"; user: User; via: "legacy-env-token" };
+```
+
+| `via` | Source | Can change password or manage sessions | Notes |
+| ----- | ------ | -------------------------------------- | ----- |
+| `session` | Cookie `contrack_session` | Yes | Unchanged behavior. |
+| `token` | `Authorization: Bearer ctk_...` | No (`403 SESSION_REQUIRED`) | Per-user token from the `api_tokens` table. |
+| `implicit` | Auth is off | No | The local owner account. See 4.2. |
+| `legacy-env-token` | `Authorization: Bearer <API_TOKEN>` | No | Maps to the primary admin. Deprecated. Logged once at boot. |
+
+Three gates replace the current two:
+
+| Gate | Passes when | Failure |
+| ---- | ----------- | ------- |
+| `requireAuth` | `req.principal` is set | `401 UNAUTHORIZED` |
+| `requireSession` (renamed from `requireUser`) | `via === "session"` | `403 SESSION_REQUIRED` (was `USER_REQUIRED`, a documented breaking change; seven call sites in `server/routes/auth.ts`) |
+| `requireAdmin` (new) | `user.role === "admin"` | `403 ADMIN_REQUIRED` |
+
+A disabled account (`users.status = 'disabled'`) fails at sign-in with `403 ACCOUNT_DISABLED`. `resolveSession` and token lookup also reject a disabled user, so disabling an account ends its live sessions on the next request.
+
+### 4.2 The local owner account (auth off)
+
+Today, auth-off mode has zero users and every row has `ownerId = NULL`. The
+boot reconcile claims those rows only when exactly one account exists. That
+model cannot survive a second user.
+
+The plan replaces `NULL` with an implicit account:
+
+- On boot, if `users` is empty, the server inserts one row: `username = 'local'`, `email = 'local@contrack.local'`, `role = 'admin'`, `credentialState = 'none'`, `passwordHash = 'none$'`. The hash never verifies because `parseHash` rejects the algorithm. Nobody can sign in as this account.
+- The boot reconcile assigns every `NULL` owner row to this account. It runs on every boot. It is idempotent.
+- With `AUTH_REQUIRED=false`, `attachPrincipal` sets `{ kind: "user", user: localOwner, via: "implicit" }` for a request with no credential.
+- The first-run setup screen becomes "secure this instance". `POST /api/auth/setup` **converts** the local owner account: it sets email, username, password, and `credentialState = 'password'`. Ownership does not move. `existingContacts` still counts what the account owns.
+- Rule: **auth-off mode is valid only while the local owner is the only account.** If `AUTH_REQUIRED=false` and a second account exists, the server logs an error at boot and behaves as if `AUTH_REQUIRED=true`. This removes the ambiguity of "who is the anonymous caller".
+
+Result: every row has an owner at all times. Every query is `WHERE ownerId = ?`. No query has an `IS NULL` branch.
+
+### 4.3 Roles
+
+Two roles: `admin` and `member`. This is enough for a self-hosted personal CRM.
+The `role` column already exists.
+
+| Capability | member | admin |
+| ---------- | ------ | ----- |
+| Own contacts, lists, interactions, search, dedupe, AI features | Yes | Yes |
+| Own profile, password, sessions, API tokens, per-user settings | Yes | Yes |
+| Own AI usage stats | Yes | Yes (plus instance totals) |
+| Export own data | Yes | Yes |
+| Read another user's contacts | No | **No** (D10) |
+| Create, invite, disable, delete users. Change roles. Reset passwords. | No | Yes |
+| Instance settings: AI providers, capabilities, custom endpoints, SearXNG, session policy, registration | No | Yes |
+| Backups (list, create) | No | Yes |
+| Audit log | No | Yes |
+| Export another user's data (as a file, for offboarding) | No | Yes, logged in the audit log |
+
+Last-admin protection: the server refuses to demote, disable, or delete the last active admin. `409 LAST_ADMIN`.
+
+### 4.4 Per-user API tokens
+
+```
+ctk_<43 chars base64url>         format shown once at creation
+api_tokens.tokenHash = sha256(token)   stored
+api_tokens.tokenPrefix = first 12 chars  shown in lists for identification
+```
+
+- `attachPrincipal` checks `Bearer ctk_` first. It hashes the presented token and looks it up by `tokenHash` (unique index, one probe). It rejects revoked, expired, or disabled-user tokens.
+- A token acts as its user for every scoped endpoint. It cannot call `requireSession` endpoints.
+- `lastUsedAt` is updated at most once per hour, same pattern as `sessions.lastSeenAt`.
+- Endpoints: `GET /api/auth/tokens`, `POST /api/auth/tokens`, `DELETE /api/auth/tokens/:id`. All need `requireSession`.
+- The env `API_TOKEN` keeps working. It resolves to the **primary admin** (the admin with the earliest `createdAt`). A warning is logged once at boot: "API_TOKEN is deprecated. Create a personal token in Settings → Account → API tokens." It is removed in a later major version.
+
+---
+
+## 5. Scope: how isolation is enforced
+
+### 5.1 The `Scope` type
+
+```ts
+// server/tenancy/scope.ts
+declare const ownerIdBrand: unique symbol;
+export type OwnerId = string & { readonly [ownerIdBrand]: true };
+
+export interface Scope {
+  readonly ownerId: OwnerId;
+}
+
+/** The only constructors. Nothing else may build a Scope. */
+export function scopeOf(req: Request): Scope;          // throws 401 when no principal
+export function scopeForUser(user: User): Scope;
+export function scopeForOwnerId(id: string): Scope;    // background jobs only
+```
+
+Rules:
+
+1. Every repository function that reads or writes an owned table takes `scope: Scope` as its **first** parameter. The type system rejects a call without it.
+2. Every service function that a route calls takes `scope: Scope` first. Routes call `scopeOf(req)` once and pass it down.
+3. A function that receives a user-supplied id **and** a scope must put both in the same SQL statement: `WHERE id = ? AND ownerId = ?`. It must not select by id and compare in JavaScript. One statement is one index probe. Two statements are two probes and a race.
+4. Derived tables are read only through a parent id that came from a scoped statement in the same call. This is the only place a query without `ownerId` is allowed on user data.
+5. A repository never accepts a raw `ownerId: string`. It accepts a `Scope`. The brand prevents passing a contact id or a session id by mistake.
+
+### 5.2 Request context (`AsyncLocalStorage`)
+
+Some code is too deep to thread a `Scope` through. The 25 `recordInvocation`
+call sites in the AI layer are the clearest case. The cache key builders in
+`aiCache` are another.
+
+```ts
+// server/tenancy/requestContext.ts
+export interface RequestContext {
+  requestId: string;
+  principal: Principal | null;
+  scope: Scope | null;
+}
+export function runWithContext<T>(ctx: RequestContext, fn: () => T): T;
+export function getContext(): RequestContext | null;
+export function currentScope(): Scope;   // throws AppError 500 NO_SCOPE when absent
+```
+
+- Middleware `attachRequestContext` runs directly after `attachPrincipal` in `server/app.ts`. It wraps `next()` in `runWithContext`.
+- Background jobs call `runWithContext({ scope: scopeForOwnerId(id), principal: null, requestId: "job-..." }, fn)` per owner.
+- The context is for **attribution and defaults**: AI invocation logging, cache key prefixes, log lines, per-user rate limits. It is **not** the primary isolation mechanism. The explicit `Scope` parameter is. A repository must not read the context to find its owner. This keeps repositories testable and keeps the leak surface visible in signatures.
+
+The overhead of `AsyncLocalStorage` is microseconds per request. One published HTTP benchmark puts the throughput cost at 7 to 10 percent for a router-bound workload; this app is bound by SQLite and AI calls, and the Phase 0 baseline measures the real number.
+
+One rule that the review verified by test: an `EventEmitter` listener runs in the context of the code that calls `emit`, not the code that subscribed. The dedupe and AI Search SSE handlers subscribe to a queue that emits from a background job, so inside those listeners `currentScope()` returns the job's scope or `null`. Every SSE and NDJSON handler captures `const scope = scopeOf(req)` in its closure before it subscribes and never reads the context inside a listener.
+
+### 5.3 Three structural guards
+
+Discipline fails at scale. The plan adds three guards that fail a build or a
+test run, not a code review.
+
+1. **Tenant lint** (`scripts/tenant-lint.mjs`, wired into `npm run lint`). It scans every template literal and string in `server/**` that contains `FROM <owned table>`, `UPDATE <owned table>`, or `DELETE FROM <owned table>`. It fails when the same statement does not contain `ownerId`. An allowlist comment `// tenant-lint: allow <reason>` on the line above permits an exception. Exceptions are for: boot migrations in `server/db.ts`, the claim routine, admin cross-user reports, and derived-table reads by parent id.
+2. **Route manifest test** (`tests/integration/tenancy.routeManifest.test.ts`). The test lists every `method + path` the app registers. Each entry must appear in `server/tenancy/routeManifest.ts` with a class: `scoped`, `admin`, `session-self`, `public`, or `instance-read`. A new route that is not classified fails the test. The manifest is the single list a reviewer reads. Express 5's router does not store mount path strings (see Phase 0 task 0.3), so the test records mount paths by wrapping `use` while `createApp()` runs, then walks `app.router.stack`.
+3. **Cross-owner matrix test** (`tests/integration/tenancy.isolation.test.ts`). Two users, each with seeded contacts, lists, interactions, action items, suggestions, and uploads. For every `scoped` route in the manifest, user B calls it with user A's ids and expects `404`. Every list endpoint is asserted to contain zero rows of user A. Search, vector search, dedupe scan, dashboard, zero-state, export, and MCP are asserted the same way.
+
+Together these three make a leak a red CI run.
+
+### 5.4 Error semantics
+
+| Situation | Status | `code` |
+| --------- | ------ | ------ |
+| Row belongs to another owner, or does not exist | 404 | `NOT_FOUND` |
+| Endpoint needs admin | 403 | `ADMIN_REQUIRED` |
+| Endpoint needs a browser session, caller used a token | 403 | `SESSION_REQUIRED` |
+| Account is disabled | 403 | `ACCOUNT_DISABLED` |
+| Last active admin would be removed | 409 | `LAST_ADMIN` |
+| Delete a user who still owns data without a data decision | 409 | `USER_HAS_DATA` |
+| Programmer error: scoped code ran with no scope | 500 | `NO_SCOPE` |
+
+`404` for cross-owner access is deliberate. See D9.
+
+---
+
+## 6. Search: FTS5 with an owner token
+
+### 6.1 Design
+
+`contacts_fts` gains two more **indexed** columns, `ownerTok` and `cidTok`,
+placed last.
+
+```sql
+CREATE VIRTUAL TABLE contacts_fts USING fts5(
+  contactId UNINDEXED,
+  name, company, role, headline, location, about, industry, extras, searchExpansion,
+  ownerTok, cidTok
+);
+```
+
+`ownerTok` is `'o' || replace(ownerId, '-', '')` and `cidTok` is
+`'c' || replace(id, '-', '')`. The default `unicode61` tokenizer splits on
+`-`, so a raw UUID becomes five tokens. Removing the hyphens and adding a
+letter prefix produces one alphanumeric token, for example
+`o3f2c1d0e9a84b7c8d6e5f4a3b2c1d0e9`. Verified with `fts5vocab`: the
+33-character token is stored as one term.
+
+Every FTS query becomes:
+
+```
+ownerTok:o3f2c1d0... AND ("original query" strategy)
+```
+
+Every trigger delete becomes:
+
+```sql
+DELETE FROM contacts_fts WHERE contacts_fts MATCH 'cidTok:c' || replace(old.id, '-', '');
+```
+
+BM25 weights are positional and count every column, including `contactId
+UNINDEXED` at position 0. The v2 table has twelve columns, so the string has
+twelve values, the last two `0.0`. The exact string, and the decision about
+the offset in today's nine-value string, are in the data model document,
+section 5.4, and in the risks document, Q13. Ranking is unchanged by the two
+token columns.
+
+### 6.2 Why not an `UNINDEXED` column or a JOIN
+
+FTS5's `xBestIndex` pushes down only `MATCH`, `rowid`, and `rank` constraints. A
+`WHERE ownerId = ?` on an `UNINDEXED` column is evaluated by the SQLite core
+after the virtual table returns each row. A `JOIN contacts` is the same cost
+plus an index probe per row. Both are post-filters. For a common token across
+50,000 contacts, both touch every match.
+
+With an indexed token, FTS5 intersects the posting list for `o3f2c1d0...` with
+the posting lists of the query tokens inside the index. Only the owner's
+matches are produced. FTS5 evaluates `AND` as a leapfrog intersection, so
+the cost is driven by the rarer side plus seeks into the owner's list. It
+also keeps the three retry strategies in `hybridRetrieval.ftsRetrieval`
+unchanged, because the owner clause wraps the strategy expression.
+
+Measured in the review at 50,000 contacts, one owner of 5,000, `LIMIT 50`:
+the indexed token answered in 1.0 to 2.7 ms p50, the `UNINDEXED` post-filter
+in 5.0 to 11.3 ms, and a `JOIN contacts` in 10.7 to 22.2 ms. Today's
+unfiltered query takes 3.3 to 8.4 ms, so the scoped query is faster than the
+current one.
+
+**Why `cidTok`.** The same `xBestIndex` rule applies to the trigger delete.
+`DELETE FROM contacts_fts WHERE contactId = ?` on an `UNINDEXED` column
+scans the whole virtual table: 4 ms per firing at 40,000 rows. Every contact
+update and every child-row insert or delete fires it once. That is a latent
+cost in 1.5.5 that made the bulk ownership claim and the owner purge take
+minutes in the benchmark. With `MATCH 'cidTok:...'` the same delete is an
+index probe at 0.011 ms.
+
+### 6.3 What changes
+
+- All eleven FTS triggers in `server/db.ts` (`contacts_ai`, `contacts_au`, `contacts_ad`, and the eight child-table triggers) write `ownerTok` and `cidTok`, and delete by `cidTok`. The bulk purge in Phase 3 can also delete an owner's index rows in one statement with `MATCH 'ownerTok:...'` (17 ms per 5,000 rows measured).
+- `FTS_SCHEMA_VERSION` becomes `2`. The existing versioned rebuild gate drops and re-indexes on the first boot after upgrade.
+- `searchService`, `hybridRetrieval.ftsRetrieval`, and the command palette instant search server handover pass the owner token.
+- Helpers `ownerToken(scope)` and `contactToken(id)` in `server/tenancy/scope.ts` build the tokens. The FTS trigger SQL and the helpers must agree. A unit test pins both against SQLite's `replace()`.
+
+---
+
+## 7. Vector search: `vec0` partition keys
+
+sqlite-vec `0.1.9` is installed. The binary in `node_modules` contains the
+partition-key and metadata-column code paths. Partition keys were introduced
+in sqlite-vec 0.1.6.
+
+```sql
+CREATE VIRTUAL TABLE search_embeddings USING vec0(
+  contactId TEXT PRIMARY KEY,
+  ownerId   TEXT PARTITION KEY,
+  embedding FLOAT[384]
+);
+
+SELECT contactId, distance
+FROM search_embeddings
+WHERE embedding MATCH ? AND k = ? AND ownerId = ?
+ORDER BY distance;
+```
+
+A partition key stores vectors in separate chunks per key. A KNN query with
+`ownerId = ?` reads only that owner's chunks. This fixes two problems at once:
+
+- **Correctness.** Today `findSearchNeighbors` fetches the global top `k` and then filters by `preFilterIds` in JavaScript. An owner with 200 contacts on an instance with 40,000 contacts would rarely appear in the global top 100. Their vector channel would return nothing.
+- **Performance.** Brute-force KNN cost is linear in the rows scanned. Partitioning makes it linear in the owner's rows.
+
+`contact_embeddings` (dedupe) gets the same shape. Both `upsert` transactions
+insert `ownerId`. Both rebuild helpers (`rebuildSearchEmbeddingTable`,
+`rebuildDedupeEmbeddingTable`) include the partition key. The migration copies
+existing vectors instead of re-embedding, so no provider API calls are spent on
+upgrade. See the data model document, section 6.
+
+Verification at the start of Phase 1: `SELECT vec_version()` must be `>= 0.1.6`,
+and a smoke test must create a partitioned table, insert two owners, and assert
+a KNN with `ownerId = ?` returns only that owner's rows. The review ran that
+smoke test on 0.1.9 (`bench/review-2026-09-08/01-vec-fts-smoke.cjs`) and it
+passes. Measured at 50,000 vectors: partitioned KNN 1.0 ms p50, flat KNN
+10.4 ms, and today's `k = 500` then JavaScript filter 23.5 ms. Of the global
+top 100, only 4 rows belonged to the queried owner of 5,000, which is the
+correctness problem above in numbers.
+
+Rules that sqlite-vec 0.1.9 imposes on a partitioned table, all verified:
+
+- `UPDATE` of the partition key column is refused. Owner reassignment of a vector is `DELETE` then `INSERT`. The `contacts_owner_propagate` trigger cannot touch `vec0`; a future reassign feature re-inserts the two vector rows in code.
+- An `UPDATE` of any column whose `WHERE` contains `EXISTS` trips the same error (issue #261). Every upsert is `DELETE` then `INSERT`, which the search store already does.
+- `ownerId IN (...)` is not supported. Query one owner per statement.
+- `k` has a maximum of 4096.
+- An `INSERT` that omits `ownerId` succeeds with a `NULL` partition and no error. The verification script counts `NULL` partitions.
+- `ALTER TABLE ... RENAME` returns OK and breaks the table. Never rename a `vec0` table.
+- The rebuild helpers `rebuildSearchEmbeddingTable` and `rebuildDedupeEmbeddingTable` emit the partition key from Phase 1 on, so a later model change keeps it.
+
+---
+
+## 8. Indexes
+
+Every owned table gets composite indexes that lead with `ownerId`. The
+single-column `idx_<table>_owner` indexes become redundant prefixes and are
+dropped after `EXPLAIN QUERY PLAN` confirms the composites are used.
+
+| Index | Serves |
+| ----- | ------ |
+| `contacts(ownerId, isGhost, isArchived, canonicalId)` | slim list, map, archived, dedupe corpus, hard-filter corpus |
+| `contacts(ownerId, deletedAt)` | trash list, active gate |
+| `contacts(ownerId, lastContactedAt)` | dashboard at-risk, temporal filters, MCP action items |
+| `contacts(ownerId, addedAt)` | network growth, MCP default order |
+| `contacts(ownerId, relationshipScore)` | health distribution |
+| `contacts(ownerId, phoneticHash)` | dedupe phonetic blocking |
+| `contacts(ownerId, canonicalId)` | soft-merge lookups |
+| `interactions(ownerId, date)` | global timeline, velocity, MCP search |
+| `action_items(ownerId, dueAt) WHERE completedAt IS NULL` | pending swimlane, urgent count |
+| `action_items(ownerId, completedAt)` | recently completed |
+| `lists(ownerId, sortOrder)` | list panel |
+| `dedupe_suggestions(ownerId, status)` | pending list and counts |
+| `dedupe_suggestions(ownerId, confidence DESC)` | ranked review queue |
+| `dedupe_exclusions(ownerId)` | negative constraints per scan |
+| `dedupe_merge_log(ownerId, mergedAt DESC)` | merge history |
+| `ai_invocations(ownerId, createdAt DESC)` | AI stats feed |
+| `api_tokens(tokenHash)` UNIQUE, `api_tokens(userId)` | bearer lookup, token list |
+| `invitations(tokenHash)` UNIQUE | accept flow |
+| `audit_log(createdAt DESC)`, `audit_log(actorUserId, createdAt DESC)` | admin views |
+
+Existing per-contact indexes (`idx_contact_emails_contact` and the rest) stay.
+Hydration by `contactId` does not need an owner column.
+
+---
+
+## 9. Shared in-process state
+
+The server is one process. Several modules hold state in module scope. Each one
+is classified below.
+
+| State | File | Today | Plan |
+| ----- | ---- | ----- | ---- |
+| `aiCache` tiers `rerank`, `synthesis`, `dailyInsight`, `briefing` | `server/utils/aiCache.ts` | Keyed by query text or contact id. The `rerank` key is built in `aiCache.getCachedSearch` and `setCachedSearch`, called from seven sites in `searchService.ts`, not in `searchIntel.ts`. | Key prefix `${ownerId}::`. `dailyInsight` `maxEntries` 1 → 100. `invalidateForOwner(tier, ownerId)` uses the existing prefix match. `mergeEngine.invalidateSearchCache()` (`aiSearch/mergeEngine.ts:298`), which flushes the whole `rerank` tier today, becomes an owner-prefix invalidation. |
+| `aiCache` tiers `queryParse`, `hyde`, `mentions` | same | Keyed by query text or a content hash of the note text | Unchanged. Pure functions of the input. Sharing is safe and saves AI calls. `mentions` stays shared on the condition in the risks document, Q14. |
+| `dedupeQueue` | `server/services/dedupe/jobQueue.ts` | One global `processing` flag, one active scan | `Map<ownerId, scanId>` for active scans. A global run lock keeps one scan executing at a time. Others queue FIFO. Status and SSE are per owner. Scan ids are checked against the owner. |
+| AI Search `jobQueue` | `server/services/aiSearch/jobQueue.ts` | One global lock, one global 5-minute cooldown | Per-owner cooldown. Global lock stays (provider rate limits are per API key). Batches carry `ownerId`. `getActiveBatches(ownerId)`. |
+| Geocode cache and queue | `server/services/geocoding/` | Address → coordinates | Unchanged. An address is not user data. Sharing helps. |
+| `settingsService` cache | `server/services/settingsService.ts` | Instance key → value | Unchanged for `app_settings`. A second cache for `user_settings` keyed `${userId}::${key}`. |
+| `QuotaTracker`, `ParallelQueue` | `server/ai/routing/` | Per provider model | Unchanged. Keys are instance-level, so limits are instance-level. |
+| Rate limiters | `server/middleware/rateLimit.ts` | Per IP. `aiEndpointRateLimit` mounts at `server/app.ts:142`, before `attachPrincipal` at `:170` and before `req.requestId` at `:145`. | Per IP stays for pre-auth routes. New per-user limiter on AI-cost routes keyed by `principal.user.id`, mounted after `attachPrincipal`. The request id moves above the AI limiter so a `429` carries one. |
+| `_dedupeTimers` | `server/services/contactService.ts` | Per contact id | Unchanged. Contact ids are globally unique. |
+| `relationshipService.recomputeAll` | `server/services/relationshipService.ts` | All contacts | Unchanged. Uniform work per row. No owner needed. |
+
+---
+
+## 10. Uploads
+
+```
+DATA_DIR/uploads/
+  logos/                      shared, domain-keyed cache (unchanged)
+  u/<ownerId>/avatars/        contact avatars
+  u/<ownerId>/files/          interaction attachments
+```
+
+- `server/utils/paths.ts` adds `ownerUploadDir(scope, "avatars" | "files")`.
+- Multer `destination` callbacks in `server/routes/contacts.ts` and `server/routes/interactions.ts` use the owner directory from `scopeOf(req)`.
+- Stored URLs become `/uploads/u/<ownerId>/avatars/<file>` and `/uploads/u/<ownerId>/files/<file>`.
+- A guard middleware runs on `/uploads` before `express.static`. For a path under `/uploads/u/<id>/`, it compares `<id>` with `principal.user.id` and returns `404` on mismatch. No database read. For `/uploads/logos/`, any authenticated principal passes. For any other `/uploads/` path, `404`.
+- `resolveUploadPath` stays the containment check for every filesystem read and unlink. It is unchanged.
+- The migration moves existing flat files into the owner directory of the contact that references them, and rewrites `avatarUrl` and `fileUrl`. See the data model document, section 7.
+
+---
+
+## 11. Settings
+
+| Setting | Level | Who writes |
+| ------- | ----- | ---------- |
+| `ai.providerKeys`, `ai.customEndpoints`, `ai.capabilities`, `ai.modelCache`, `ai.searxng`, `ai.embeddingsState`, `ai.embeddingsState.dedupe` | instance (`app_settings`) | admin |
+| `auth.sessionTtlDays` | instance | admin |
+| `auth.registrationOpen` (new, default `false`) | instance | admin |
+| Weather unit, list density, dedupe threshold preset | browser `localStorage` today | unchanged in this plan |
+| Future per-user server settings | `user_settings` | the user |
+
+`GET /api/settings/ai` stays readable by members so the UI can show which AI
+capabilities are available. Provider keys are already redacted in that view.
+Every write under `/api/settings/ai` requires `requireAdmin`.
+
+---
+
+## 12. Upgrade path to shared workspaces
+
+This plan does not build sharing. It keeps the door open at zero cost:
+
+- Later, add `workspaces(id, name)` and `workspace_members(workspaceId, userId, role)`.
+- Create one personal workspace per user with `workspaces.id = users.id`.
+- `ownerId` now means "workspace id". Every existing row already points at a valid workspace id without a data migration.
+- `Scope` becomes `{ ownerId, actorUserId }`. Repositories do not change. Access checks move into `scopeOf(req)`, which resolves the workspace from the URL or a header.
+
+This is why `Scope` is an object and not a bare string, and why nothing else is added now.
+
+---
+
+## 13. Request flow after the change
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant P as attachPrincipal
+    participant X as attachRequestContext
+    participant G as requireAuth / requireAdmin
+    participant R as Route
+    participant S as Service
+    participant Q as Repository
+    participant D as SQLite
+
+    C->>P: request (cookie | Bearer ctk_ | none)
+    P->>P: resolve session / token / implicit / legacy
+    P->>X: req.principal
+    X->>X: runWithContext({requestId, principal, scope})
+    X->>G: next()
+    G->>R: next()
+    R->>R: const scope = scopeOf(req)
+    R->>S: service.fn(scope, ...validated body)
+    S->>Q: repo.fn(scope, id)
+    Q->>D: WHERE id = ? AND ownerId = ?
+    D-->>Q: row | undefined
+    Q-->>S: row | null
+    S-->>R: result | NotFoundError
+    R-->>C: 200 | 404
+```
+
+---
+
+## 14. Canonical names
+
+Phase documents use these names exactly.
+
+| Name | Kind | Location |
+| ---- | ---- | -------- |
+| `Scope`, `OwnerId`, `scopeOf`, `scopeForUser`, `scopeForOwnerId`, `ownerToken`, `contactToken` | types and functions | `server/tenancy/scope.ts` |
+| `RequestContext`, `runWithContext`, `getContext`, `currentScope` | functions | `server/tenancy/requestContext.ts` |
+| `attachRequestContext` | middleware | `server/tenancy/requestContext.ts` |
+| `requireAdmin`, `requireSession` | middleware | `server/middleware/auth.ts` |
+| `ROUTE_MANIFEST` | const | `server/tenancy/routeManifest.ts` |
+| `OWNED_TABLES` (extended) | const | `server/db.ts` |
+| `ensureLocalOwner`, `primaryAdminId`, `claimUnownedData` | functions, raw SQL, exported | `server/db.ts` (not `authService`: `authService` imports from `db.ts`, so the reverse import is a cycle) |
+| `reconcileOwnership` (rewritten), `convertLocalOwner` | functions | `server/services/authService.ts` |
+| `adminService` | service | `server/services/adminService.ts` |
+| `apiTokenService` | service | `server/services/apiTokenService.ts` |
+| `invitationService` | service | `server/services/invitationService.ts` |
+| `auditService` | service | `server/services/auditService.ts` |
+| `userSettingsService` | service | `server/services/userSettingsService.ts` |
+| `ownerUploadDir`, `guardUploads` | function, middleware | `server/utils/paths.ts`, `server/middleware/uploads.ts` |
+| `tenant-lint` | script | `scripts/tenant-lint.mjs` |
+| `bench-tenancy` | script | `scripts/bench-tenancy.ts` |
+| `TENANCY_SCHEMA_VERSION` | const | `server/db.ts` (stored in `app_settings` under `schema.tenancy`; `PRAGMA user_version` belongs to the FTS gate, see data model doc §1.1) |

--- a/docs/multi-tenant-plan/04-data-model-and-migration.md
+++ b/docs/multi-tenant-plan/04-data-model-and-migration.md
@@ -1,0 +1,851 @@
+# 04. Data Model and Migration
+
+This document is the exact schema change set and the boot-time migration that
+applies it. Phase 1 implements this document. Phase 2 depends on every column
+and index named here.
+
+Conventions:
+
+- DDL lives in `server/db.ts` as idempotent numbered sections, following the
+  precedent set by `users`, `sessions`, `app_settings`, and the dedupe tables.
+  Every new table and column is mirrored in `src/db/schema.ts` so Drizzle
+  types stay correct. No `drizzle-kit generate` migration is produced for
+  these changes. The reason is in section 9.
+- Every statement below is safe to run twice. The migration runs on every
+  boot and does nothing after the first successful run.
+- `ownerId` is `TEXT REFERENCES users(id) ON DELETE RESTRICT` everywhere. The
+  `RESTRICT` choice is unchanged from today: deleting an account that still
+  owns data must fail, and the admin delete flow in Phase 3 decides what to
+  do with the data first.
+- Every number marked "measured" comes from
+  [bench/review-2026-09-08/](bench/review-2026-09-08/README.md), run on
+  SQLite 3.53.2 and sqlite-vec 0.1.9.
+- The tenancy helpers (`ensureLocalOwner`, `primaryAdminId`,
+  `claimUnownedData`) are written in `server/db.ts` as raw SQL and exported.
+  `server/services/authService.ts` imports `sqlite` and `OWNED_TABLES` from
+  `db.ts` and runs `sqlite.prepare` at module top level, so `db.ts` cannot
+  import `authService` without an import cycle that throws at boot.
+
+---
+
+## 1. Migration versioning and safety
+
+### 1.1 Version slot
+
+`PRAGMA user_version` already holds `FTS_SCHEMA_VERSION`. A second integer
+cannot share that slot (it is one 32-bit field at offset 60 of the header).
+The tenancy migration stores its version in `app_settings` under the key
+`schema.tenancy`, read and written with raw SQL inside `server/db.ts` (the
+settings service cannot be imported there without a cycle). `app_settings`
+is created today at §9g2, which runs after the point where the tenancy block
+now sits (section 10). The tenancy block therefore runs the same
+`CREATE TABLE IF NOT EXISTS app_settings (...)` statement first, and §9g2
+becomes a no-op.
+
+```ts
+// server/db.ts
+export const TENANCY_SCHEMA_VERSION = 1;
+
+function readTenancyVersion(): number {
+  const row = sqlite
+    .prepare(`SELECT value FROM app_settings WHERE key = 'schema.tenancy'`)
+    .get() as { value: string } | undefined;
+  return row ? Number(JSON.parse(row.value)) : 0;
+}
+```
+
+### 1.2 Backup before the first run
+
+When `readTenancyVersion() < TENANCY_SCHEMA_VERSION` and the `contacts` table
+has at least one row, the migration first writes a full copy of the database:
+
+```sql
+VACUUM INTO '<DATA_DIR>/backups/pre-tenancy-<ISO stamp>.db';
+```
+
+`VACUUM INTO` is synchronous, works in WAL mode, and produces a consistent
+single-file copy of the committed state. It is used instead of
+`sqlite.backup()` because that API is asynchronous and `server/db.ts` runs at
+import time. The file is not subject to the normal rotation in
+`backupService` because its name does not start with `curator-`. The log line
+names the file. The docs tell the operator to delete it once they trust the
+upgrade.
+
+Rules, all verified:
+
+- `VACUUM INTO` fails with "cannot VACUUM from within a transaction". It runs before `sqlite.transaction()` opens, never inside it.
+- The target file must not exist. The ISO stamp in the name makes a collision impossible on one boot; the code still checks and appends a counter if the file exists.
+- Free space needed is about one compacted copy of the database, not two. The code reads `fs.statfsSync(DATA_DIR)` and skips the backup with an `error` log when free space is below 1.5 × the database file size. It never fails the boot for a missing backup, because the operator can restore from the rotating `curator-*.db` snapshots.
+- `PRAGMA synchronous` must not be `OFF` for the copy to be fsynced. The app sets `NORMAL`.
+
+### 1.3 Transaction boundary
+
+The order is fixed by three constraints found in the review: the FTS block
+references `contacts.ownerId`, so the column must exist first; the claim
+`UPDATE` fires every trigger on `contacts`, so the expensive triggers must be
+absent while it runs; and `VACUUM INTO` cannot run inside a transaction.
+
+1. **Backup.** `VACUUM INTO`, outside any transaction, only when the version is behind and `contacts` has rows.
+2. **Transaction A, the tenancy block.** `app_settings` if missing. `users` columns. Identity tables. The three dedupe tables if missing (identical DDL to §9c to 9e). `ownerId` on all eight owned tables. `DROP TRIGGER IF EXISTS` for the eleven FTS triggers, the three `_auto_updated_at` triggers, and the three `action_items_sync_*` triggers. `ensureLocalOwner`. `claimUnownedData`. Child backfill. Invariant triggers. Composite indexes. Write `schema.tenancy`. One `sqlite.transaction`, measured under 1 s per 50,000 contacts once the triggers are gone.
+3. **FTS v2.** The existing `user_version` gate drops and recreates `contacts_fts` with its eleven triggers and runs the bulk backfill (233 ms per 50,000 rows measured). Its own `exec`, as today.
+4. **Sections 4, 5, 6 of `server/db.ts`** recreate the `_auto_updated_at` and `action_items_sync_*` triggers. Each already begins with `DROP TRIGGER IF EXISTS`, so no change is needed there.
+5. **`vec0` rebuild.** One transaction per table (0.9 s per 50,000 × 384-dim rows measured).
+6. **Uploads relocation.** Last, outside any transaction, because it touches the filesystem.
+
+If the process dies mid-way, the next boot re-runs from the top. Every step
+checks its own precondition, so partial progress is not a problem. A crash
+between steps 2 and 4 leaves the six dropped triggers absent until the next
+boot recreates them; the window is one process lifetime and the next boot
+always closes it, because steps 3 and 4 are unconditional `DROP` + `CREATE`.
+
+---
+
+## 2. Identity tables
+
+### 2.1 `users` additions
+
+```sql
+ALTER TABLE users ADD COLUMN status TEXT NOT NULL DEFAULT 'active';          -- 'active' | 'disabled'
+ALTER TABLE users ADD COLUMN credentialState TEXT NOT NULL DEFAULT 'password'; -- 'password' | 'none'
+ALTER TABLE users ADD COLUMN mustChangePassword INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN passwordChangedAt TEXT;
+ALTER TABLE users ADD COLUMN disabledAt TEXT;
+ALTER TABLE users ADD COLUMN createdBy TEXT REFERENCES users(id) ON DELETE SET NULL;
+```
+
+Each `ALTER` is guarded by `PRAGMA table_info(users)` the same way §9i guards
+`ownerId` today. `NOT NULL DEFAULT '...'` on `ADD COLUMN` is legal; a
+`REFERENCES` clause with a non-`NULL` default is not (SQLite raises the error
+only when the table has rows, so an empty test database would not catch it).
+`createdBy` has a `NULL` default and is fine.
+
+Four places in `server/services/authService.ts` enumerate user columns by
+hand and must gain the new ones: `USER_COLUMNS` (`:178-179`), the `User`
+type (`:89-98`), `stripHash` (`:249-260`), and `publicUser` (`:116-126`).
+Until they do, `resolveSession` and `attachPrincipal` cannot see `status`,
+`credentialState`, or `mustChangePassword`.
+
+| Column | Meaning |
+| ------ | ------- |
+| `status` | `disabled` refuses sign-in, token use, and existing sessions. |
+| `credentialState` | `none` marks the local owner account (section 3). Sign-in is impossible until setup converts it. |
+| `mustChangePassword` | Set by admin create-with-temporary-password and by admin reset. Cleared by `POST /api/auth/change-password`. |
+| `passwordChangedAt` | Shown in the admin user list. |
+| `disabledAt` | Audit convenience. |
+| `createdBy` | Which admin created or invited this account. `NULL` for the first account and the local owner. |
+
+### 2.2 `api_tokens`
+
+```sql
+CREATE TABLE IF NOT EXISTS api_tokens (
+  id          TEXT PRIMARY KEY,
+  userId      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name        TEXT NOT NULL,
+  tokenHash   TEXT NOT NULL UNIQUE,     -- sha256 hex of the full token
+  tokenPrefix TEXT NOT NULL,            -- first 12 chars, for display
+  createdAt   TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  lastUsedAt  TEXT,
+  expiresAt   TEXT,                     -- NULL = never
+  revokedAt   TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(userId);
+```
+
+Cascade is correct here. A token without an account is meaningless, like a
+session.
+
+### 2.3 `invitations`
+
+```sql
+CREATE TABLE IF NOT EXISTS invitations (
+  id         TEXT PRIMARY KEY,
+  email      TEXT,                      -- optional hint, not enforced on accept
+  role       TEXT NOT NULL DEFAULT 'member',
+  tokenHash  TEXT NOT NULL UNIQUE,
+  invitedBy  TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  createdAt  TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  expiresAt  TEXT NOT NULL,
+  acceptedAt TEXT,
+  acceptedBy TEXT REFERENCES users(id) ON DELETE SET NULL,
+  revokedAt  TEXT
+);
+```
+
+The invitation link is `<origin>/join?token=<secret>`. The database holds only
+the hash. Default expiry is 7 days. An accepted or revoked invitation cannot
+be used again.
+
+### 2.4 `user_settings`
+
+```sql
+CREATE TABLE IF NOT EXISTS user_settings (
+  userId    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  key       TEXT NOT NULL,
+  value     TEXT NOT NULL,              -- JSON
+  updatedAt TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  PRIMARY KEY (userId, key)
+);
+```
+
+Empty at the end of this plan. It exists so that Phase 4 and later features
+have a home for per-user server-side preferences without another migration.
+
+### 2.5 `audit_log`
+
+```sql
+CREATE TABLE IF NOT EXISTS audit_log (
+  id          TEXT PRIMARY KEY,
+  actorUserId TEXT REFERENCES users(id) ON DELETE SET NULL,
+  action      TEXT NOT NULL,            -- 'user.create', 'user.disable', 'auth.login.failed', ...
+  targetType  TEXT,                     -- 'user' | 'token' | 'invitation' | 'setting' | 'backup'
+  targetId    TEXT,
+  details     TEXT,                     -- JSON, never contains secrets
+  ip          TEXT,
+  createdAt   TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+);
+CREATE INDEX IF NOT EXISTS idx_audit_created ON audit_log(createdAt DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_actor   ON audit_log(actorUserId, createdAt DESC);
+```
+
+Retention: 90 days. There is no daily sweep to attach to today:
+`cleanupOldInvocations` runs once at boot with no interval
+(`server.ts:170-174`) and the session sweep is boot-only
+(`server/db.ts:193-198`). Phase 3 adds one daily maintenance interval in
+`server.ts`, gated by `DISABLE_BACKGROUND_JOBS`, that sweeps `audit_log`,
+expired `sessions`, expired `api_tokens`, expired `invitations`, and old
+`ai_invocations`.
+
+---
+
+## 3. The local owner account
+
+Runs after section 2 and before section 4, because section 4 needs a valid
+owner id to backfill into. The code lives in `server/db.ts` and is exported;
+`countUsers()` and `primaryAdminId()` below are local raw-SQL helpers in the
+same file, not imports from `authService`.
+
+```ts
+export function ensureLocalOwner(): string {
+  const existing = sqlite
+    .prepare(`SELECT id FROM users WHERE credentialState = 'none' LIMIT 1`)
+    .get() as { id: string } | undefined;
+  if (existing) return existing.id;
+  if (countUsers() > 0) return primaryAdminId();   // an account already exists; nothing to create
+  const id = crypto.randomUUID();
+  sqlite.prepare(`
+    INSERT INTO users (id, email, username, displayName, passwordHash, role, credentialState)
+    VALUES (?, 'local@contrack.local', 'local', 'This device', 'none$', 'admin', 'none')
+  `).run(id);
+  return id;
+}
+```
+
+- `passwordHash = 'none$'` never verifies. `parseHash` (`server/services/passwords.ts:151-156`) splits on `$` and returns `null` when the part count is not six, before it looks at the algorithm. `verifyPassword` returns `false`. `needsRehash` returns `true`, which is harmless because nothing can sign in to rehash.
+- The account is an admin because in auth-off mode the person at the keyboard is the operator.
+- `primaryAdminId()` is `SELECT id FROM users WHERE role = 'admin' AND status = 'active' ORDER BY createdAt ASC LIMIT 1`.
+
+Immediately after: `claimUnownedData(ownerId)` for every table in the extended
+`OWNED_TABLES` list. On an instance upgraded from 1.x with one real account,
+this claims nothing new. On an auth-off instance it claims everything for the
+new local owner.
+
+---
+
+## 4. Ownership columns on the four child tables
+
+```sql
+ALTER TABLE interactions        ADD COLUMN ownerId TEXT REFERENCES users(id) ON DELETE RESTRICT;
+ALTER TABLE action_items        ADD COLUMN ownerId TEXT REFERENCES users(id) ON DELETE RESTRICT;
+ALTER TABLE dedupe_suggestions  ADD COLUMN ownerId TEXT REFERENCES users(id) ON DELETE RESTRICT;
+ALTER TABLE dedupe_exclusions   ADD COLUMN ownerId TEXT REFERENCES users(id) ON DELETE RESTRICT;
+```
+
+Backfill from the parent contact:
+
+```sql
+UPDATE interactions       SET ownerId = (SELECT ownerId FROM contacts WHERE id = interactions.contactId)      WHERE ownerId IS NULL;
+UPDATE action_items       SET ownerId = (SELECT ownerId FROM contacts WHERE id = action_items.contactId)      WHERE ownerId IS NULL;
+UPDATE dedupe_suggestions SET ownerId = (SELECT ownerId FROM contacts WHERE id = dedupe_suggestions.contactIdA) WHERE ownerId IS NULL;
+UPDATE dedupe_exclusions  SET ownerId = (SELECT ownerId FROM contacts WHERE id = dedupe_exclusions.contactIdA)  WHERE ownerId IS NULL;
+```
+
+`OWNED_TABLES` becomes:
+
+```ts
+export const OWNED_TABLES = [
+  "contacts", "lists", "interactions", "action_items",
+  "dedupe_suggestions", "dedupe_exclusions", "dedupe_merge_log", "ai_invocations",
+] as const;
+```
+
+`claimUnownedData` loops this list unchanged.
+
+### 4.1 Invariant triggers
+
+The invariant: every owned row has a non-null `ownerId`, and a child row's
+`ownerId` equals its parent contact's `ownerId`.
+
+**Required on insert (all eight owned tables).** SQLite cannot add `NOT NULL`
+to an existing column. A trigger gives the same guarantee.
+
+```sql
+CREATE TRIGGER IF NOT EXISTS contacts_owner_required BEFORE INSERT ON contacts
+WHEN NEW.ownerId IS NULL
+BEGIN SELECT RAISE(ABORT, 'contacts.ownerId is required'); END;
+```
+
+Repeated for `lists`, `dedupe_merge_log`, `ai_invocations`. For the four child
+tables, the required-trigger is replaced by a fill-trigger so callers that
+insert through a parent id still work:
+
+**Fill from parent (child tables).**
+
+```sql
+CREATE TRIGGER IF NOT EXISTS interactions_owner_fill AFTER INSERT ON interactions
+WHEN NEW.ownerId IS NULL
+BEGIN
+  UPDATE interactions
+     SET ownerId = (SELECT ownerId FROM contacts WHERE id = NEW.contactId)
+   WHERE id = NEW.id;
+END;
+```
+
+Same shape for `action_items` (by `contactId`) and `dedupe_suggestions` (by
+`contactIdA`). `dedupe_exclusions` has no `id` column; its primary key is
+`(contactIdA, contactIdB)`, so its fill trigger ends with
+`WHERE contactIdA = NEW.contactIdA AND contactIdB = NEW.contactIdB`. Services
+still pass `ownerId` explicitly. The trigger is a safety net, not the primary
+path.
+
+The fill `UPDATE` fires the table's own `AFTER UPDATE` triggers (verified):
+`interactions_auto_updated_at` stamps `updatedAt`, and on `action_items` the
+`action_items_sync_update` trigger updates `contacts.nextFollowUpAt`, which
+fires `contacts_au` and `contacts_auto_updated_at`. This is acceptable for
+the rare insert that omits `ownerId`. It is not acceptable for the bulk
+backfill, which is why the migration drops those triggers first (section
+1.3).
+
+**Mismatch check (child tables).**
+
+```sql
+CREATE TRIGGER IF NOT EXISTS interactions_owner_check
+BEFORE INSERT ON interactions
+WHEN NEW.ownerId IS NOT NULL
+ AND NEW.ownerId != (SELECT ownerId FROM contacts WHERE id = NEW.contactId)
+BEGIN SELECT RAISE(ABORT, 'interactions.ownerId does not match contact owner'); END;
+```
+
+For `dedupe_suggestions` and `dedupe_exclusions` the check compares against
+both `contactIdA` and `contactIdB`. A cross-owner suggestion is a bug and
+must fail loudly.
+
+When the parent contact's `ownerId` is `NULL`, `NEW.ownerId != NULL` is
+`NULL` and the check does not fire. That state cannot exist after the claim,
+and the triggers are installed after the claim, so the gap is closed by
+ordering. Verification query 1 in section 11 guards it.
+
+**Propagate owner change (contacts).** The only supported owner change is the
+one-time claim from `NULL`. This trigger keeps children consistent if a future
+admin "reassign data" feature is built.
+
+```sql
+CREATE TRIGGER IF NOT EXISTS contacts_owner_propagate AFTER UPDATE OF ownerId ON contacts
+WHEN NEW.ownerId IS NOT OLD.ownerId
+BEGIN
+  UPDATE interactions       SET ownerId = NEW.ownerId WHERE contactId = NEW.id;
+  UPDATE action_items       SET ownerId = NEW.ownerId WHERE contactId = NEW.id;
+  UPDATE dedupe_suggestions SET ownerId = NEW.ownerId WHERE contactIdA = NEW.id OR contactIdB = NEW.id;
+  UPDATE dedupe_exclusions  SET ownerId = NEW.ownerId WHERE contactIdA = NEW.id OR contactIdB = NEW.id;
+END;
+```
+
+Trigger install order matters: the `_owner_required` triggers are installed
+**after** the claim in section 3 and the backfill in section 4. Before that,
+rows with `NULL` still exist.
+
+The propagate trigger cannot touch the `vec0` tables: sqlite-vec 0.1.9
+refuses `UPDATE` on a partition key column. A future reassign feature deletes
+and re-inserts the two vector rows in code after the contact update.
+
+Cost: one indexed sub-select per insert on four tables. Interactions are
+written a few times a minute at most. Negligible.
+
+### 4.2 Triggers dropped around the claim
+
+The claim `UPDATE contacts SET ownerId = ? WHERE ownerId IS NULL` and the
+child backfill fire every `AFTER UPDATE` trigger on those tables, once per
+row. Two of them are expensive or harmful:
+
+- `contacts_au` deletes and re-inserts the FTS row. With today's trigger body that is a full FTS scan per row (section 5.5): 5.4 ms per contact, 27 s for 5,000 contacts measured.
+- `contacts_auto_updated_at` and `interactions_auto_updated_at` stamp `updatedAt`. `findStaleEmbeddings` (`server/services/dedupe/embeddings.ts:298-313`) compares `contacts.updatedAt` with `dedupe_embedding_meta.embeddedAt`, so a stamped corpus is re-embedded through the paid provider on the next deep scan. That breaks the promise in section 6.3.
+
+The tenancy block therefore runs, before the claim:
+
+```sql
+DROP TRIGGER IF EXISTS contacts_ai;  DROP TRIGGER IF EXISTS contacts_au;  DROP TRIGGER IF EXISTS contacts_ad;
+DROP TRIGGER IF EXISTS fts_tags_ai;  DROP TRIGGER IF EXISTS fts_tags_ad;
+DROP TRIGGER IF EXISTS fts_interests_ai;  DROP TRIGGER IF EXISTS fts_interests_ad;
+DROP TRIGGER IF EXISTS fts_emails_ai;  DROP TRIGGER IF EXISTS fts_emails_ad;
+DROP TRIGGER IF EXISTS fts_phones_ai;  DROP TRIGGER IF EXISTS fts_phones_ad;
+DROP TRIGGER IF EXISTS contacts_auto_updated_at;
+DROP TRIGGER IF EXISTS interactions_auto_updated_at;
+DROP TRIGGER IF EXISTS action_items_auto_updated_at;
+DROP TRIGGER IF EXISTS action_items_sync_insert;
+DROP TRIGGER IF EXISTS action_items_sync_update;
+DROP TRIGGER IF EXISTS action_items_sync_delete;
+```
+
+The FTS block (§3) and sections 4, 5, and 6 of `server/db.ts` recreate all
+seventeen on the same boot. Each of those sections already starts with
+`DROP TRIGGER IF EXISTS`, so no code there changes. The migration test
+asserts that `updatedAt` on every contact and interaction is byte-identical
+before and after the migration, and that the seventeen triggers exist
+afterward.
+
+---
+
+## 5. FTS5 rebuild with `ownerTok`
+
+### 5.1 Table
+
+```sql
+CREATE VIRTUAL TABLE IF NOT EXISTS contacts_fts USING fts5(
+  contactId UNINDEXED,
+  name, company, role, headline, location, about, industry, extras, searchExpansion,
+  ownerTok, cidTok
+);
+```
+
+No `tokenize=` option, as today (default `unicode61`). `FTS_SCHEMA_VERSION`
+becomes `2`. The existing gate (`server/db.ts` §3) drops and recreates the
+table when the stored `user_version` differs, so the first boot after upgrade
+performs a full re-index. The bulk backfill took 233 ms for 50,000 contacts
+(measured), so 10,000 contacts index in well under one second.
+
+`cidTok` is new in the review. Section 5.5 explains why it exists.
+
+### 5.2 Token expressions
+
+Everywhere the triggers and the backfill build a row, the two tokens are:
+
+```sql
+'o' || replace(c.ownerId, '-', '')   -- ownerTok
+'c' || replace(c.id, '-', '')        -- cidTok
+```
+
+The JavaScript helpers `ownerToken(scope)` and `contactToken(id)` in
+`server/tenancy/scope.ts` must produce the identical strings. A unit test
+compares each with SQLite's `replace()` for a fixed UUID. Verified with
+`fts5vocab`: a 33-character token is stored as one term under `unicode61`.
+
+### 5.3 Triggers
+
+All eleven triggers (`contacts_ai`, `contacts_au`, `contacts_ad`,
+`fts_tags_ai/ad`, `fts_interests_ai/ad`, `fts_emails_ai/ad`,
+`fts_phones_ai/ad`) and the backfill `INSERT ... SELECT` gain the `ownerTok`
+and `cidTok` columns. Three more changes to every trigger body:
+
+1. Every `DELETE FROM contacts_fts WHERE contactId = X` becomes
+   `DELETE FROM contacts_fts WHERE contacts_fts MATCH 'cidTok:c' || replace(X, '-', '')`.
+   This is the section 5.5 fix.
+2. `contacts_ai` gains `WHERE new.deletedAt IS NULL`, which it lacks today
+   (`server/db.ts:395-406`). Every other trigger already has the guard.
+3. `contacts_au` is `AFTER UPDATE ON contacts` with no column list, so it
+   fires on every update. It stays that way. During the migration it is
+   dropped (section 4.2), so the claim does not fire it; the bulk backfill
+   indexes the claimed rows instead.
+
+The trigger SQL is generated from one template string in `server/db.ts`
+instead of eleven hand-copied blocks. This is a refactor of existing code
+that Phase 1 does while it is touching every trigger anyway. The generated
+SQL is snapshot-tested.
+
+### 5.4 Queries
+
+```sql
+-- hybridRetrieval.ftsRetrieval
+SELECT contactId, bm25(contacts_fts, 0.0, 10.0, 5.0, 3.0, 2.0, 2.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0) AS score
+FROM contacts_fts
+WHERE contacts_fts MATCH ?
+ORDER BY score
+LIMIT ?;
+-- bound value: 'ownerTok:o3f2c1d0... AND ("original query")'
+```
+
+**The weight string has twelve values, one per column, including
+`contactId UNINDEXED` at position 0.** `bm25()` assigns weights by column
+position and does not skip `UNINDEXED` columns (verified: a weight on
+position 0 has no effect, a weight on position 1 boosts `name`). Today's
+constant `BM25_WEIGHTS` in `server/services/search/hybridRetrieval.ts:113`
+has nine values for a ten-column table, so every weight sits one column to
+the left of its intended target: `name` gets 5.0, not 10.0, and
+`searchExpansion` gets the default 1.0. The string above fixes the offset.
+The alternative that preserves today's effective ranking is
+`0.0, 5.0, 3.0, 2.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0`. The decision
+is Q13 in the risks document; the recommendation is to fix the offset in
+Phase 0 as its own PR so the ranking change is isolated from tenancy.
+
+`searchService.searchFts` (`server/services/searchService.ts:193-208`) runs
+one `"<q>"*` query with `ORDER BY rank` and no weights. It gets the owner
+wrapper only. The three-strategy list lives in `hybridRetrieval.ftsRetrieval`
+(`:286-290`). These two functions and `server/db.ts` are the only code that
+names `contacts_fts`. The column-filter syntax `ownerTok : term` and the
+`AND` with parentheses are standard FTS5 query syntax; all three strategy
+shapes were verified inside the wrapper.
+
+### 5.5 Why `cidTok`, with numbers
+
+Every FTS trigger today starts with `DELETE FROM contacts_fts WHERE contactId
+= old.id`. FTS5's `xBestIndex` accepts only `MATCH`, `rowid`, and `rank`
+constraints, so an `=` on the `UNINDEXED` `contactId` column is evaluated by
+the SQLite core after a full scan of the virtual table. Measured at 40,000
+rows: 4.06 ms per delete. With an indexed `cidTok` column and
+`MATCH 'cidTok:...'`: 0.011 ms.
+
+Consequences, measured on 50,000 contacts with two emails each:
+
+| Operation | Today's triggers | `cidTok` triggers |
+| --------- | ---------------- | ----------------- |
+| `UPDATE contacts SET ownerId` on 5,000 rows (the claim, if the triggers were left in place) | 27.1 s | 0.23 s |
+| Purge one owner: `DELETE FROM contacts WHERE ownerId = ?`, 5,000 contacts plus 10,000 cascaded emails | 77.1 s | 0.20 s |
+| One contact update (any column) | about 5 ms of FTS work | about 0.05 ms |
+| `DELETE FROM contacts_fts WHERE contacts_fts MATCH 'ownerTok:...'`, 5,000 rows | n/a | 17 ms |
+
+The purge cost is dominated by the child-table triggers: an FK cascade fires
+`fts_emails_ad` and its siblings once per cascaded row (verified), and each
+firing pays the scan. This is a latent 1.5.5 cost, not something the plan
+introduces. FTS v2 is the moment to fix it because every trigger is rewritten
+anyway. Scripts 04 and 05 in `bench/review-2026-09-08/` reproduce the table.
+
+---
+
+## 6. `vec0` rebuild with partition keys
+
+### 6.1 Target shape
+
+```sql
+CREATE VIRTUAL TABLE search_embeddings USING vec0(
+  contactId TEXT PRIMARY KEY,
+  ownerId   TEXT PARTITION KEY,
+  embedding FLOAT[<dim>]
+);
+CREATE VIRTUAL TABLE contact_embeddings USING vec0(
+  contactId TEXT PRIMARY KEY,
+  ownerId   TEXT PARTITION KEY,
+  embedding FLOAT[<dim>]
+);
+```
+
+`<dim>` is read from the existing table's DDL with `vecTableWidth()` so the
+rebuild preserves whatever model the instance uses.
+
+### 6.2 Precondition check
+
+```sql
+SELECT vec_version();
+```
+
+Must be `>= 0.1.6`. Partition keys and metadata columns were introduced in
+sqlite-vec 0.1.6. The installed package is 0.1.9, which is the latest stable
+release. If the check fails the server logs an error and refuses to start,
+because every vector query in Phase 2 depends on the partition key. The
+returned string has a leading `v` and may carry a pre-release suffix
+(`v0.1.10-alpha.4`), so the check parses the three numbers and compares them;
+it does not compare strings. `server/db.ts:132-135` already calls
+`vec_version()` for the boot log.
+
+### 6.3 Idempotent rebuild by copy
+
+Detect: `SELECT sql FROM sqlite_master WHERE name = 'search_embeddings'`
+contains `PARTITION KEY` (case-insensitive). If yes, skip.
+
+Otherwise, per table, inside one transaction:
+
+1. `SELECT e.contactId, c.ownerId, e.embedding FROM search_embeddings e JOIN contacts c ON c.id = e.contactId` in chunks of 1,000 rows into memory. Rows whose contact no longer exists are dropped (they are orphans already).
+2. `DROP TABLE search_embeddings`.
+3. `CREATE VIRTUAL TABLE search_embeddings USING vec0(...)` with the partition key and the preserved dimension.
+4. Reinsert every row with `INSERT INTO search_embeddings (contactId, ownerId, embedding) VALUES (?, ?, ?)`.
+
+Verified: a `DROP` and `CREATE VIRTUAL TABLE ... vec0` inside one
+`sqlite.transaction` works, and the copy of 50,000 × 384-dim rows took 0.9 s.
+
+Memory: 10,000 × 384 floats × 4 bytes is 15 MB for search embeddings and 31 MB
+for 768-dim dedupe embeddings. Both fit. On a 50,000-contact instance, chunk
+the read and write in one transaction per 5,000 rows.
+
+Rules for this step:
+
+- **Never `ALTER TABLE ... RENAME` a `vec0` table.** On 0.1.9 the statement returns OK, the shadow tables keep the old name, and the next read fails with `no such table: main.<new>_rowids`. Copy and drop, as above.
+- `vecTableWidth()` (`server/db.ts:810-815`) is module-private and returns a string with an `"unknown"` fallback. The rebuild parses it to a number and throws with a clear message when the DDL does not match, instead of creating a table with a wrong dimension.
+- `rebuildDedupeEmbeddingTable` (`server/services/dedupe/embeddings.ts:48`) is not exported and lives in a module that imports `db.ts`. The rebuild in `db.ts` uses its own DDL string; the two helpers in the services and the string in `db.ts` are pinned equal by a unit test.
+- An `INSERT` that omits `ownerId` succeeds with a `NULL` partition and no error. Verification query 9 counts them.
+
+No embedding is recomputed. No provider API call is made. The stored
+`ai.embeddingsState` signature and dimension are unchanged, so
+`ensureEmbeddingStore` and `ensureDedupeEmbeddingStore` see no change on the
+next boot and do not trigger a re-embed.
+
+### 6.4 Code changes that follow
+
+- `rebuildSearchEmbeddingTable(dimension)` and `rebuildDedupeEmbeddingTable(dimension)` include the partition key from now on. Without this, the next embedding-model change would recreate the tables without the partition column.
+- Every `INSERT INTO search_embeddings` and `INSERT INTO contact_embeddings` supplies `ownerId`. The upsert transactions look it up from `contacts` by id in the same transaction.
+- Every upsert is `DELETE` then `INSERT`. The search store already does this (`localEmbeddings.ts:203-212`). The dedupe store uses `INSERT OR REPLACE` (`dedupe/embeddings.ts:188`); sqlite-vec lists `INSERT OR REPLACE` support as new in 0.1.10, so the Phase 1 smoke test runs it against a partitioned table on 0.1.9 and the code switches to `DELETE` + `INSERT` if it fails (risks document T24). sqlite-vec also refuses `UPDATE` of a partition key and mis-reports an `UPDATE ... WHERE EXISTS (...)` on any column as the same error (issue #261).
+- `ownerId IN (...)` is not supported on a partition key (issue #142). One owner per statement.
+- `k` has a maximum of 4096 (issue #157). `findSearchNeighbors` already caps at 500.
+- KNN statements gain `AND ownerId = ?` (Phase 2).
+
+### 6.5 Partition size note
+
+sqlite-vec's guidance is that each partition key value should hold on the
+order of hundreds of vectors. An owner with 30 contacts has a tiny partition,
+which is fine: KNN over 30 rows is instant. The guidance warns against
+thousands of distinct keys with a handful of rows each, which does not
+describe this deployment.
+
+---
+
+## 7. Uploads relocation
+
+Target layout: `DATA_DIR/uploads/u/<ownerId>/avatars/` and
+`DATA_DIR/uploads/u/<ownerId>/files/`. `logos/` stays where it is.
+
+Procedure, run once per boot after the database migration, idempotent:
+
+1. `SELECT id, ownerId, avatarUrl FROM contacts WHERE avatarUrl LIKE '/uploads/avatars/%'`. For each row: move `<UPLOADS_DIR>/avatars/<file>` to `<UPLOADS_DIR>/u/<ownerId>/avatars/<file>`, then `UPDATE contacts SET avatarUrl = '/uploads/u/<ownerId>/avatars/<file>' WHERE id = ?`. If the source file is missing, only rewrite the URL. The `contacts_au` FTS trigger fires, which is harmless.
+2. `SELECT i.id, i.ownerId, i.fileUrl FROM interactions i WHERE fileUrl LIKE '/uploads/%' AND fileUrl NOT LIKE '/uploads/u/%' AND fileUrl NOT LIKE '/uploads/logos/%'`. Same move and rewrite into `files/`.
+3. `avatarUrl` values pointing at `/api/avatar/...` (generated) or external `https://` hosts are untouched.
+4. A file left in the flat directories that no row references is an orphan. It is moved to `<UPLOADS_DIR>/orphaned/` and logged. Nothing is deleted.
+
+`resolveUploadPath` is unchanged. The new paths are still inside `UPLOADS_DIR`.
+
+---
+
+## 8. Indexes
+
+Installed after all columns exist. All `IF NOT EXISTS`.
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_status   ON contacts(ownerId, isGhost, isArchived, canonicalId);
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_deleted  ON contacts(ownerId, deletedAt);
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_lastc    ON contacts(ownerId, lastContactedAt);
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_added    ON contacts(ownerId, addedAt);
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_score    ON contacts(ownerId, relationshipScore);
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_phonetic ON contacts(ownerId, phoneticHash);
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_canon    ON contacts(ownerId, canonicalId);
+
+CREATE INDEX IF NOT EXISTS idx_interactions_owner_date ON interactions(ownerId, date);
+CREATE INDEX IF NOT EXISTS idx_action_items_owner_due  ON action_items(ownerId, dueAt) WHERE completedAt IS NULL;
+CREATE INDEX IF NOT EXISTS idx_action_items_owner_done ON action_items(ownerId, completedAt);
+CREATE INDEX IF NOT EXISTS idx_lists_owner_sort        ON lists(ownerId, sortOrder);
+CREATE INDEX IF NOT EXISTS idx_dedupe_sugg_owner_status ON dedupe_suggestions(ownerId, status);
+CREATE INDEX IF NOT EXISTS idx_dedupe_sugg_owner_conf  ON dedupe_suggestions(ownerId, confidence DESC);
+CREATE INDEX IF NOT EXISTS idx_dedupe_excl_owner       ON dedupe_exclusions(ownerId);
+CREATE INDEX IF NOT EXISTS idx_merge_log_owner_at      ON dedupe_merge_log(ownerId, mergedAt DESC);
+CREATE INDEX IF NOT EXISTS idx_ai_inv_owner_created    ON ai_invocations(ownerId, createdAt DESC);
+```
+
+Drop after Phase 2 confirms plans (each is a prefix of a composite above):
+
+```sql
+DROP INDEX IF EXISTS idx_contacts_owner;
+DROP INDEX IF EXISTS idx_lists_owner;
+DROP INDEX IF EXISTS idx_ai_invocations_owner;
+DROP INDEX IF EXISTS idx_dedupe_merge_log_owner;
+```
+
+Keep `idx_contacts_status`, `idx_contacts_last_contacted`, `idx_contacts_added`,
+`idx_contacts_score`, `idx_contacts_phonetic`, `idx_contacts_canonical`,
+`idx_contacts_deleted`, `idx_action_items_due`, `idx_dedupe_status`,
+`idx_dedupe_confidence`, and `idx_ai_invocations_created` through Phase 2.
+The background sweeps (`recomputeAll`, trash purge, geocoding backfill,
+invocation cleanup) still run across all owners and use them. Revisit in
+Phase 5 with `EXPLAIN QUERY PLAN` evidence.
+
+Then `ANALYZE` once (new; nothing runs `ANALYZE` today), and `PRAGMA optimize`
+as today (`server/db.ts:932`, daily in `server.ts:198`, and on shutdown).
+
+---
+
+## 9. Why not a Drizzle migration file
+
+The repository has two Drizzle migrations (`0000`, `0001`) and a large body of
+idempotent DDL in `server/db.ts` (`users`, `sessions`, the dedupe tables,
+`app_settings`, `dedupe_embedding_meta`, every virtual table, every trigger,
+every `ownerId` column). `action_items` is defined in both places (Drizzle
+`0000` and `server/db.ts` §6 with `IF NOT EXISTS`). `geocode_cache` is
+created by `server/services/geocoding/cache.ts` at import time, outside
+`db.ts`. The `users` table itself was added the `db.ts` way.
+
+Generating a Drizzle migration for the new tables would produce a migration
+that recreates `users` and `sessions`, because the snapshot in
+`drizzle/meta/0001_snapshot.json` does not know about them. Reconciling the
+snapshot is a separate cleanup with its own risk. This plan follows the
+existing precedent and keeps the `src/db/schema.ts` mirror current so types
+stay right. A follow-up task in [11-future.md](11-future.md) proposes moving
+all of `server/db.ts` DDL into numbered migrations.
+
+---
+
+## 10. Boot sequence in `server/db.ts` after Phase 1
+
+Section numbers continue the file's existing scheme. Today's file has two
+sections labelled `2a` (`server/db.ts:201` and `:268`); Phase 1 renames the
+second to `2b` while it is editing the file. The tenancy block must run
+**before** the FTS block, because the FTS backfill `INSERT ... SELECT`
+references `contacts.ownerId` and fails at prepare time on a fresh database
+if the column does not exist yet (verified: `no such column`, even with zero
+rows). On a fresh database `contacts` comes from Drizzle `0000` without
+`ownerId`. The FTS block also must not exist while the claim runs (§4.2).
+The three dedupe tables move up with it because `OWNED_TABLES` names them.
+
+| § | Step | Idempotency check |
+| - | ---- | ----------------- |
+| 2 | Drizzle migrations (unchanged). After this, `contacts`, `lists`, `interactions`, `action_items`, `ai_invocations` and the child tables exist | Drizzle journal |
+| 2z | `users`, `sessions` (unchanged) | `IF NOT EXISTS` |
+| **2z-1** | `users` column additions (§2.1) | `table_info` |
+| **2z-2** | `api_tokens`, `invitations`, `user_settings`, `audit_log` (§2.2 to 2.5); `app_settings` moved up from §9g2 (§1.1) | `IF NOT EXISTS` |
+| **2z-3** | `dedupe_suggestions`, `dedupe_exclusions`, `dedupe_merge_log` moved up from §9c to 9e (identical DDL; those sections become no-ops) | `IF NOT EXISTS` |
+| **2z-4** | `TENANCY` block: read `schema.tenancy`; `VACUUM INTO` backup if behind and `contacts` has rows (outside the transaction, §1.2); then one transaction: `ownerId` on all eight `OWNED_TABLES` (§4, replaces §9i), drop the seventeen triggers (§4.2), `ensureLocalOwner` (§3), `claimUnownedData`, child backfill (§4), invariant triggers (§4.1), composite indexes (§8), write version | `schema.tenancy` |
+| 2a, 2b | avatar URL migration, data cleanup (unchanged) | |
+| 3 | FTS table with `ownerTok` and `cidTok`, `FTS_SCHEMA_VERSION = 2`, eleven triggers, bulk backfill (§5) | `user_version` gate |
+| 4, 5, 6 | `_auto_updated_at` and `action_items_sync_*` triggers recreated (unchanged code, each starts with `DROP TRIGGER IF EXISTS`) | |
+| 7, 8 | unchanged. The §8 legacy follow-up backfill inserts `action_items` without `ownerId`; the `action_items_owner_fill` trigger from 2z-4 fills it from the contact | |
+| 9a, 9b | soft-merge column, phonetic index (unchanged) | |
+| 9c to 9e | now no-ops (moved to 2z-3) | |
+| 9f, 9f-b | `vec0` tables. The `CREATE VIRTUAL TABLE IF NOT EXISTS` DDL gains the partition key, so a fresh database gets it directly | `IF NOT EXISTS` |
+| **9k** | `vec0` partition rebuild by copy for tables created before 2.0 (§6) | `sqlite_master.sql` contains `PARTITION KEY` |
+| 9g | `dedupe_embedding_meta` (unchanged) | |
+| 9g2 | `app_settings` (now a no-op) | |
+| 9i | now a no-op (moved to 2z-4). The section stays as a guard that throws if any owned table lacks `ownerId` | `table_info` |
+| 9h | hot-path indexes (unchanged) | |
+| 10 | phonetic backfill (unchanged) | |
+| **11** | uploads relocation (§7) | no rows match the legacy `LIKE` patterns |
+
+`reconcileOwnership()` in `server/app.ts` is rewritten: it calls
+`ensureLocalOwner()` and `claimUnownedData()` unconditionally. With every row
+already owned, it is a no-op after the first boot. The old "only when exactly
+one user" guard is deleted.
+
+`FTS_SCHEMA_VERSION` must be bumped in the same release as the `ownerId`
+columns, because the FTS triggers reference `contacts.ownerId` and the
+`ownerTok` column. On a fresh 2.0 database the order above guarantees the
+column exists when §3 runs. The integration suite exercises exactly that path
+on every test file, so a wrong order fails the whole suite immediately.
+
+---
+
+## 11. Verification queries
+
+These run in the Phase 1 integration test and are printed by
+`npm run tenancy:verify` (a small script added in Phase 1) so an operator can
+check an upgraded instance.
+
+```sql
+-- 1. No unowned rows anywhere. Expect 0 for each.
+SELECT 'contacts', COUNT(*) FROM contacts WHERE ownerId IS NULL
+UNION ALL SELECT 'lists', COUNT(*) FROM lists WHERE ownerId IS NULL
+UNION ALL SELECT 'interactions', COUNT(*) FROM interactions WHERE ownerId IS NULL
+UNION ALL SELECT 'action_items', COUNT(*) FROM action_items WHERE ownerId IS NULL
+UNION ALL SELECT 'dedupe_suggestions', COUNT(*) FROM dedupe_suggestions WHERE ownerId IS NULL
+UNION ALL SELECT 'dedupe_exclusions', COUNT(*) FROM dedupe_exclusions WHERE ownerId IS NULL
+UNION ALL SELECT 'dedupe_merge_log', COUNT(*) FROM dedupe_merge_log WHERE ownerId IS NULL
+UNION ALL SELECT 'ai_invocations', COUNT(*) FROM ai_invocations WHERE ownerId IS NULL;
+
+-- 2. Child owner equals parent owner. Expect 0.
+SELECT COUNT(*) FROM interactions i JOIN contacts c ON c.id = i.contactId WHERE i.ownerId != c.ownerId;
+SELECT COUNT(*) FROM action_items a JOIN contacts c ON c.id = a.contactId WHERE a.ownerId != c.ownerId;
+SELECT COUNT(*) FROM dedupe_suggestions s JOIN contacts a ON a.id = s.contactIdA JOIN contacts b ON b.id = s.contactIdB
+ WHERE s.ownerId != a.ownerId OR s.ownerId != b.ownerId;
+
+-- 3. FTS row count equals active contact count.
+SELECT (SELECT COUNT(*) FROM contacts_fts) = (SELECT COUNT(*) FROM contacts WHERE deletedAt IS NULL);
+
+-- 4. Every FTS row carries the right owner token.
+SELECT COUNT(*) FROM contacts_fts f JOIN contacts c ON c.id = f.contactId
+ WHERE f.ownerTok != 'o' || replace(c.ownerId, '-', '');
+
+-- 5. Vector stores have partition keys and preserved counts.
+SELECT sql LIKE '%PARTITION KEY%' FROM sqlite_master WHERE name IN ('search_embeddings', 'contact_embeddings');
+
+-- 6. No legacy flat upload URLs remain.
+SELECT COUNT(*) FROM contacts WHERE avatarUrl LIKE '/uploads/avatars/%';
+SELECT COUNT(*) FROM interactions WHERE fileUrl LIKE '/uploads/%' AND fileUrl NOT LIKE '/uploads/u/%';
+
+-- 7. Exactly one local owner at most.
+SELECT COUNT(*) <= 1 FROM users WHERE credentialState = 'none';
+
+-- 8. No FTS row with a missing owner or contact token. Expect 0 for each.
+SELECT COUNT(*) FROM contacts_fts WHERE ownerTok IS NULL OR ownerTok = 'o';
+SELECT COUNT(*) FROM contacts_fts f JOIN contacts c ON c.id = f.contactId
+ WHERE f.cidTok != 'c' || replace(c.id, '-', '');
+
+-- 9. No vector row with a NULL partition. Expect 0 for each.
+SELECT COUNT(*) FROM search_embeddings WHERE ownerId IS NULL;
+SELECT COUNT(*) FROM contact_embeddings WHERE ownerId IS NULL;
+
+-- 10. Every vector row belongs to an existing contact of the same owner. Expect 0 for each.
+SELECT COUNT(*) FROM search_embeddings e LEFT JOIN contacts c ON c.id = e.contactId
+ WHERE c.id IS NULL OR c.ownerId != e.ownerId;
+SELECT COUNT(*) FROM contact_embeddings e LEFT JOIN contacts c ON c.id = e.contactId
+ WHERE c.id IS NULL OR c.ownerId != e.ownerId;
+
+-- 11. The seventeen triggers exist again after the migration. Expect 17.
+SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name IN (
+  'contacts_ai','contacts_au','contacts_ad',
+  'fts_tags_ai','fts_tags_ad','fts_interests_ai','fts_interests_ad',
+  'fts_emails_ai','fts_emails_ad','fts_phones_ai','fts_phones_ad',
+  'contacts_auto_updated_at','interactions_auto_updated_at','action_items_auto_updated_at',
+  'action_items_sync_insert','action_items_sync_update','action_items_sync_delete');
+```
+
+Two checks are tests rather than queries, because they need a before-image:
+`updatedAt` on every contact and interaction is unchanged by the migration,
+and `embedBatch` is never called during boot.
+
+---
+
+## 12. Rollback
+
+1. Stop the server.
+2. Replace `DATA_DIR/curator.db` (and remove `curator.db-wal` and `curator.db-shm`) with `DATA_DIR/backups/pre-tenancy-<stamp>.db`.
+3. Move files from `uploads/u/<ownerId>/avatars/` back to `uploads/avatars/` and from `uploads/u/<ownerId>/files/` back to `uploads/`. The 1.x database still holds the old URLs, so the files must be at the old paths. A script `scripts/tenancy-rollback-uploads.mjs` does this.
+4. Start the 1.x image.
+
+The FTS index and the vector tables rebuild themselves on the 1.x boot from
+the restored database, because the restored file predates the rebuild.
+
+Do not attempt a rollback by renaming `vec0` tables. Renaming breaks them on
+sqlite-vec 0.1.9 (section 6.3). The restore of the backup file is the only
+supported path.
+
+---
+
+## 13. `src/db/schema.ts` mirror
+
+Additions, all typed with Drizzle:
+
+- `users`: `status`, `credentialState`, `mustChangePassword`, `passwordChangedAt`, `disabledAt`, `createdBy`.
+- New tables: `apiTokens`, `invitations`, `userSettings`, `auditLog`, with relations to `users`.
+- `ownerId` on `interactions`, `actionItems`, `dedupeSuggestions`, `dedupeExclusions`, with `owner` relations.
+- The OWNERSHIP comment block is rewritten. It must state the new invariant: `ownerId` is never `NULL` after boot, the four child tables carry a denormalized copy kept consistent by triggers, and the local owner account is what makes auth-off mode work. It currently says "eleven contact_* child tables" (`src/db/schema.ts:144`); ten exist.
+
+---
+
+## 14. Measured migration costs
+
+All numbers from `bench/review-2026-09-08/`, laptop, SQLite 3.53.2, sqlite-vec
+0.1.9. Use them to size the boot log expectations and the acceptance criteria.
+
+| Step | Data | Measured |
+| ---- | ---- | -------- |
+| FTS bulk backfill (`INSERT ... SELECT` with the email subselect) | 50,000 contacts | 233 ms |
+| `vec0` copy-rebuild | 50,000 × 384-dim | 923 ms |
+| Claim `UPDATE contacts SET ownerId` with all triggers dropped | 5,000 rows | under 50 ms (the 230 ms figure in the bench includes the `cidTok` FTS re-index, which the migration does not run) |
+| Claim with today's FTS triggers still installed (what happens if §4.2 is skipped) | 5,000 rows | 27.1 s |
+| Owner purge with `cidTok` triggers (Phase 3) | 5,000 contacts, 10,000 emails | 198 ms |
+| Owner purge with today's triggers | same | 77.1 s |
+| `VACUUM INTO` | proportional to file size, sequential write | not benchmarked; typical NAS disks write 100 MB in about 1 s |
+
+A 10,000-contact instance should complete the whole migration in under five
+seconds plus the backup copy time. The boot log prints each step with its
+duration so a slow step is visible.

--- a/docs/multi-tenant-plan/05-phase-0-foundations.md
+++ b/docs/multi-tenant-plan/05-phase-0-foundations.md
@@ -1,0 +1,511 @@
+# 05. Phase 0: Foundations and Safety Net
+
+**Goal:** put the isolation scaffolding in place with **no user-visible
+change**, fix the ownership-stamping gap, and fix three small defects the
+review found in `v1.5.5`. Everything in this phase is additive. A
+single-account instance behaves exactly as before.
+
+**Lands on:** the `v2.0` integration branch (section 0). It has no
+user-visible change, so it is safe to cherry-pick to `main` as `1.6.0` if a
+release is wanted before 2.0. That is optional.
+
+**Size:** M (about 5 to 7 engineering days).
+
+**Depends on:** nothing.
+
+This document is written so that an implementer can work from it alone.
+Section 0 gives the repository facts, the branch workflow, and the
+conventions. Section 8 restates every plan name and rule this phase uses.
+The wider design is in [03-architecture.md](03-architecture.md) and the
+review evidence is in [bench/review-2026-09-08/](bench/review-2026-09-08/README.md).
+
+---
+
+## 0. Context for the implementer
+
+### 0.1 The repository
+
+Contrack is a local-first personal CRM: Express 5.2.1 API in `server/`,
+React 19 SPA in `src/`, one SQLite file through `better-sqlite3` 12.11
+(SQLite 3.53.2) with the `sqlite-vec` 0.1.9 extension and FTS5. Drizzle ORM
+0.45 supplies the types in `src/db/schema.ts` and two early migrations in
+`drizzle/`; most DDL is idempotent raw SQL in `server/db.ts`, which runs at
+import time. TypeScript 6 in strict mode. Vitest 4 with three projects:
+`unit` (mocked database), `integration` (a real database in a temp
+`DATA_DIR` per test file, `createApp()` under supertest), and `contract`
+(real provider calls, not part of `npm test`). Node 22 is the runtime and the
+Docker base image.
+
+| Command | What it does |
+| ------- | ------------ |
+| `npm run dev` | Starts the API with `tsx server.ts` (Vite serves the SPA in dev) |
+| `npm test` | Runs the `unit` and `integration` projects. Today: 41 files, 575 tests, about 16 s |
+| `npx vitest run --project integration tests/integration/<file>` | One integration file |
+| `npm run lint` | ESLint plus `tsc --noEmit`. Must pass before a PR |
+| `npm run format:check` | Prettier. CI runs it |
+| `npm run build` | Production build. CI runs it |
+| `npm run test:coverage` | What CI runs instead of `npm test` |
+
+Key files for this phase:
+
+| Path | Role |
+| ---- | ---- |
+| `server/app.ts` | `createApp()`: middleware order and router mounts. Line references below are to `v1.5.5` |
+| `server/middleware/auth.ts` | `Principal`, `attachPrincipal`, `requireAuth`, `requireUser`, `currentUser`, `isAuthRequired` |
+| `server/middleware/rateLimit.ts` | `createRateLimiter`, `aiEndpointRateLimit`, `AI_COST_PATTERNS` |
+| `server/services/authService.ts` | `createUser`, `claimUnownedData`, `reconcileOwnership`, `countUsers` |
+| `server/db.ts` | All DDL, `OWNED_TABLES`, FTS triggers, `vec0` tables |
+| `server/services/search/hybridRetrieval.ts` | `BM25_WEIGHTS` at `:113`, `ftsRetrieval` at `:276` |
+| `tests/integration/helpers.ts`, `tests/integration-setup.ts` | `makeTestApp()`, the per-file temp `DATA_DIR`, mock AI, `AUTH_REQUIRED=""` by default |
+| `tests/integration/api.auth.test.ts` | The 49 existing auth tests |
+| `.agent/ARCHITECTURE.md`, `.agent/TESTING.md`, `.agent/STYLE.md` | House rules. `TESTING.md` §3: paste the raw vitest summary into every PR |
+
+### 0.2 Branch, PR, and release workflow (applies to every phase)
+
+- All multi-tenant work lands on one integration branch, **`v2.0`**, created from `main` at the start of this phase:
+
+  ```bash
+  git checkout main && git pull
+  git checkout -b v2.0 && git push -u origin v2.0
+  ```
+
+- **The first PR on the branch is task 0.0 below**, which makes CI run for the branch. Until it merges, pull requests into `v2.0` run no tests, because `.github/workflows/ci.yml` lists only `main` under `pull_request.branches`.
+- Each phase is one PR from a feature branch into `v2.0`. Phase 2 is nine PRs, one per sub-phase. Branch names: `v2.0/phase-0-foundations`, `v2.0/phase-2a-contacts`, and so on. PRs are **squash-merged** into `v2.0`, which is the repository's habit (every commit on `main` has one parent and a `(#N)` suffix).
+- PR title: `feat(tenancy): phase 0, foundations and safety net`. Commit messages use the `type(area): subject` form from `CONTRIBUTING.md`. No AI attribution trailers or footers anywhere.
+- PR description: one plain sentence saying what the PR adds and why, then short sections in this order: what users or the API see, how it works, operational behavior, guarantees. Nested bullets for reviewer context. A **Testing** section with the exact commands and the raw vitest summary line, for example `Test Files  44 passed (44) / Tests  612 passed (612)`. No semicolons, no em-dashes.
+- Keep `v2.0` current with `main`: run `git merge origin/main` into `v2.0` at every phase boundary and before the final release PR. Merge, do not rebase, because the branch is shared.
+- `package.json` stays at `1.5.5` on the branch until Phase 5 sets `2.0.0`. Each phase adds its entry under `## [Unreleased]` in `CHANGELOG.md`, prefixed with the phase, for example `- **Phase 0.** ...`.
+- Nothing is released from `v2.0`. Phase 5 merges `v2.0` into `main` with a merge commit, tags `v2.0.0`, and publishes. See [10-phase-5-hardening-release.md](10-phase-5-hardening-release.md) section 4.
+- Never push to `main` directly. Never force-push `v2.0`.
+
+### 0.3 Facts about `v1.5.5` that this phase depends on
+
+- `req.principal` is `{kind:"anonymous"} | {kind:"user"; user; sessionId} | {kind:"service"}` (`server/middleware/auth.ts:46-52`). Only `server/routes/auth.ts` reads it.
+- Nothing stamps `ownerId` on insert. `createContact` builds its values in `buildInsertValues` (`server/services/contactService.ts:94-114`) with no owner field. `INSERT INTO lists` at `listService.ts:37`, `INSERT INTO ai_invocations` at `aiStatsService.ts:88-91`, and `INSERT INTO dedupe_merge_log` at `dedupe/suggestions.ts:127-131` omit it. The ghost insert at `interactionService.ts:70-80` and the dev seed at `dedupe/engine.ts:584-585` omit it too.
+- Ownership is assigned only in bulk: `claimUnownedData` on first account creation (`authService.ts:323`) and `reconcileOwnership()` at `server/app.ts:113`, which does nothing unless exactly one user exists.
+- The AI rate limiter mounts at `server/app.ts:141-143`, **before** `req.requestId` is assigned at `:145-148` and before `attachPrincipal` at `:170`. A limiter `429` therefore has no request id.
+- `contactsRouter` mounts at `server/app.ts:202` and `mcpRouter` at `:204`. `GET /contacts/:id` (`routes/contacts.ts:122`) captures `GET /api/contacts/action-items` (`routes/mcp.ts:34`) with `id = "action-items"` and returns `404`. The MCP route is unreachable today.
+- `BM25_WEIGHTS` (`hybridRetrieval.ts:113`) has nine values for a ten-column FTS table. `bm25()` weights are positional and include `contactId UNINDEXED` at position 0, so `name` receives 5.0 instead of the intended 10.0 and every other column is shifted one to the left.
+- Express 5's router does not store mount path strings. `app.router` is a lazy getter, `app._router` is undefined, layers have no `regexp`, and `layer.path` is set only after `layer.match(url)`. A naive walk of `app.router.stack` yields `/`, `/reorder`, `/contacts/:id/timeline` without their prefixes.
+- `AsyncLocalStorage` context survives multer's `destination` and `filename` callbacks, `await`, `setTimeout`, and `Promise.all` (verified with multer 2.2.0). An `EventEmitter` listener runs in the context of the code that calls `emit`. multer issue #1111 reports context loss in the handler after `upload.single()` when the multipart body also has text fields.
+
+---
+
+## 1. Deliverables
+
+| # | Deliverable | Files |
+| - | ----------- | ----- |
+| 0.0 | `v2.0` branch exists and CI runs for it | `.github/workflows/ci.yml` |
+| 0.1 | `Scope` type, constructors, `ownerToken`, `contactToken` | `server/tenancy/scope.ts` (new) |
+| 0.2 | Request context on `AsyncLocalStorage`; request id moved above the AI limiter | `server/tenancy/requestContext.ts` (new), `server/app.ts` |
+| 0.3 | Route manifest, route recorder, coverage test | `server/tenancy/routeManifest.ts` (new), `tests/integration/tenancy/listRoutes.ts` (new), `tests/integration/tenancy.routeManifest.test.ts` (new) |
+| 0.4 | Tenant lint in report mode | `scripts/tenant-lint.mjs` (new), `package.json` |
+| 0.5 | Ownership stamping on every insert into an owned table | `server/services/contactService.ts`, `listService.ts`, `aiStatsService.ts`, `dedupe/suggestions.ts`, `interactionService.ts`, `dedupe/engine.ts` |
+| 0.6 | Two-user integration test harness | `tests/integration/tenancy/helpers.ts` (new) |
+| 0.7 | Isolation matrix skeleton (`it.todo` per route) | `tests/integration/tenancy.isolation.test.ts` (new) |
+| 0.8 | Benchmark script and baseline numbers | `scripts/bench-tenancy.ts` (new), `docs/multi-tenant-plan/bench/baseline-phase-0.md` |
+| 0.9 | Comment and doc corrections | `server/middleware/auth.ts`, `src/db/schema.ts`, `server/db.ts`, `.agent/ARCHITECTURE.md`, `.agent/TESTING.md`, `.agent/STATUS.md` |
+| 0.10 | BM25 weight offset fix, its own PR | `server/services/search/hybridRetrieval.ts`, `tests/unit/search.test.ts` |
+| 0.11 | Router mount order fix so the MCP action-items route is reachable | `server/app.ts`, `tests/integration/api.compatEndpoint.test.ts` or a new MCP test |
+| 0.12 | `CHANGELOG.md` entry under Unreleased | `CHANGELOG.md` |
+
+---
+
+## 2. Tasks
+
+### 0.0 Branch, CI, and the plan itself
+
+1. Create `v2.0` from `main` as in section 0.2.
+2. On a feature branch, edit `.github/workflows/ci.yml`: add `"v2.0"` to `on.pull_request.branches` and to `on.push.branches`. Do not touch the `if:` conditions on `build-image` (`github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')`) or `release` (`startsWith(github.ref, 'refs/tags/v')`). A push to `v2.0` then runs tests and publishes nothing.
+3. **Commit the plan on the branch.** `docs/multi-tenant-plan/` is listed in `.gitignore` (line 58), so a fresh clone has none of these documents and no reviewer or implementer can follow the references in the PRs. Remove that line on the branch and commit the whole folder, including `bench/`. The folder stays tracked for the life of `v2.0`; Phase 5 decides where it goes at release (see [10-phase-5-hardening-release.md](10-phase-5-hardening-release.md) section 4.5). Do not commit the two scratch databases `bench/review-2026-09-08/` may have produced under `/tmp`; only the `.cjs` scripts and the README belong in the folder.
+4. Open the PR into `v2.0`, confirm the `build-and-test` job runs on it, merge.
+
+From this point on, each phase PR ticks its own acceptance boxes in its
+phase document and records measured numbers under `bench/`, so the plan
+stays a live record of what shipped.
+
+### 0.1 `server/tenancy/scope.ts`
+
+```ts
+import type { Request } from "express";
+import { AppError } from "../utils/AppError.ts";
+import type { User } from "../services/authService.ts";
+
+declare const ownerIdBrand: unique symbol;
+export type OwnerId = string & { readonly [ownerIdBrand]: true };
+export interface Scope { readonly ownerId: OwnerId }
+
+export function scopeForUser(user: Pick<User, "id">): Scope {
+  return Object.freeze({ ownerId: user.id as OwnerId });
+}
+
+/** Background jobs only. Never called from a route. */
+export function scopeForOwnerId(id: string): Scope {
+  return Object.freeze({ ownerId: id as OwnerId });
+}
+
+export function scopeOf(req: Request): Scope {
+  const p = req.principal;
+  if (p?.kind === "user") return scopeForUser(p.user);
+  // Phase 0: anonymous and service principals have no owner yet. Phase 1
+  // removes both kinds. Until then, callers that need a scope get a 401.
+  throw new AppError("Authentication required", 401, { code: "UNAUTHORIZED" });
+}
+
+/** FTS5 owner token. Must equal  'o' || replace(ownerId, '-', '')  in server/db.ts. */
+export function ownerToken(scope: Scope): string {
+  return "o" + scope.ownerId.replace(/-/g, "");
+}
+
+/** FTS5 contact token. Must equal  'c' || replace(id, '-', '')  in server/db.ts. */
+export function contactToken(contactId: string): string {
+  return "c" + contactId.replace(/-/g, "");
+}
+```
+
+In Phase 0 nothing calls `scopeOf` on the data path yet. The function exists
+so Phase 2 has one place to change when Phase 1 makes every principal a user.
+`contactToken` is unused until Phase 1 writes the FTS triggers; it lives here
+from the start so the unit test below pins both tokens together.
+
+Unit test (`tests/unit/tenancy.scope.test.ts`): for a fixed UUID, assert
+`ownerToken` equals `SELECT 'o' || replace(?, '-', '')` and `contactToken`
+equals `SELECT 'c' || replace(?, '-', '')` computed by an in-memory
+better-sqlite3 database in the same test. Assert the token is one FTS5 term
+by creating a one-column `fts5` table, inserting the token, and matching it
+with `MATCH 'col:<token>'`.
+
+### 0.2 `server/tenancy/requestContext.ts`
+
+```ts
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { Request, Response, NextFunction } from "express";
+import { AppError } from "../utils/AppError.ts";
+import type { Principal } from "../middleware/auth.ts";
+import { scopeForUser, type Scope } from "./scope.ts";
+
+export interface RequestContext {
+  requestId: string;
+  principal: Principal | null;
+  scope: Scope | null;
+}
+
+const als = new AsyncLocalStorage<RequestContext>();
+
+export function runWithContext<T>(ctx: RequestContext, fn: () => T): T {
+  return als.run(ctx, fn);
+}
+export function getContext(): RequestContext | null {
+  return als.getStore() ?? null;
+}
+export function currentScope(): Scope {
+  const s = getContext()?.scope;
+  if (!s) throw new AppError("No owner scope on this code path", 500, { code: "NO_SCOPE" });
+  return s;
+}
+export function currentScopeOrNull(): Scope | null {
+  return getContext()?.scope ?? null;
+}
+
+export function attachRequestContext(req: Request, _res: Response, next: NextFunction): void {
+  const p = req.principal ?? null;
+  const scope = p?.kind === "user" ? scopeForUser(p.user) : null;
+  runWithContext({ requestId: req.requestId, principal: p, scope }, () => next());
+}
+```
+
+Changes in `server/app.ts`:
+
+1. Move the `req.requestId` assignment (today `:145-148`) **above** `app.use(aiEndpointRateLimit)` (today `:141-143`). A limiter `429` then carries a request id like every other error.
+2. Mount `attachRequestContext` directly after `attachPrincipal` (today `:170`) and before the `/api/auth` router (today `:175`).
+
+Rules the context must follow, and the tests that pin them
+(`tests/unit/tenancy.requestContext.test.ts`):
+
+- The store survives `await`, `setTimeout`, `setImmediate`, `Promise.all`, and a `for await` loop.
+- An `EventEmitter` listener sees the context of the **emitter**, not the subscriber. The test subscribes inside `runWithContext(A)`, emits from inside `runWithContext(B)`, and asserts the listener sees `B`; then emits from outside any context and asserts `null`. This is why every SSE handler in Phase 2 captures `scope` in its closure.
+- `currentScope()` throws an `AppError` with status 500 and code `NO_SCOPE` outside a context.
+- Integration test: a multipart upload with **one text field plus one file** to a test-only route wrapped in `upload.single()` asserts `getContext()` is intact inside `destination`, inside `filename`, and inside the handler after multer. If the handler assertion fails (multer issue #1111), record it in the PR and have the two upload handlers in Phase 1 read the scope from `req.principal` instead of the context.
+
+`recordInvocation` in `server/services/aiStatsService.ts` reads
+`currentScopeOrNull()?.ownerId` and writes it into the existing `ownerId`
+column. Boot-time jobs produce `NULL`, which is correct until Phase 2 wraps
+them in a context.
+
+### 0.3 Route manifest and route recorder
+
+```ts
+// server/tenancy/routeManifest.ts
+export type RouteClass =
+  | "public"         // no credential: /healthz, /api/auth/status, /api/auth/login, ...
+  | "session-self"   // acts on the caller's own account: /api/auth/me, /api/auth/tokens
+  | "scoped"         // reads or writes owned data for the caller's scope
+  | "admin"          // requireAdmin
+  | "instance-read"  // any authenticated caller, no owned data: /api/avatar/:style, /api/logos/:domain
+  | "static";        // the /uploads express.static layer; guarded by middleware, not a route
+
+export interface RouteEntry {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "USE";
+  path: string;            // full path as a client sends it, with the mount prefix
+  class: RouteClass;
+  /** Phase 2 flips this when the isolation test for the route is green. */
+  isolated: boolean;
+  /** Only registered when NODE_ENV !== "production". */
+  devOnly?: boolean;
+}
+
+export const ROUTE_MANIFEST: readonly RouteEntry[] = [ /* every row of appendix B */ ];
+```
+
+Express 5 does not keep mount path strings, so the test cannot rebuild
+`/api/lists/reorder` from the stack alone. Use a **recorder**:
+
+```ts
+// tests/integration/tenancy/listRoutes.ts
+import express from "express";
+export interface RegisteredRoute { method: string; path: string; handlers: string[] }
+
+/** Wraps Router.prototype.use and the app's use while fn runs, records every mount path,
+ *  then walks app.router.stack and joins mount prefixes with route.path. */
+export function listRoutes(build: () => express.Express): RegisteredRoute[] { /* about 40 lines */ }
+```
+
+Implementation notes for the recorder: patch `express.Router.prototype.use`
+and `express.application.use` before calling `createApp()`, record
+`(handle, mountPath)` for every string first argument (an array of strings
+records one entry per string), restore the originals in a `finally`, then
+walk `app.router.stack`: a layer with `layer.route` is a route (`route.path`,
+`Object.keys(route.methods)`, and `route.stack.map(l => l.handle.name)` for
+the handler names); a layer with `layer.name === "router"` is a mount whose
+prefix is the recorded path for `layer.handle`; the `express.static` layer
+has `layer.name === "serveStatic"`. Normalize a trailing `/` so
+`/api/search/` and `/api/search` are one entry.
+
+The test (`tests/integration/tenancy.routeManifest.test.ts`) asserts:
+
+1. Every registered `method + path` has exactly one manifest entry.
+2. Every manifest entry corresponds to a registered route, except rows with `devOnly: true` when `NODE_ENV === "production"`.
+3. The `/uploads` static layer is present and the manifest has one `USE /uploads` row of class `static`.
+
+Two routes need care. `GET /api/debug/cache-stats` is registered in
+`server.ts:97-102`, outside `createApp()`, so a supertest app never has it.
+Move it into `createApp()` behind the same `NODE_ENV !== "production"` guard
+(after the routers, before the error handler) so the manifest can see it;
+mark it `devOnly`. `POST /api/dev/seed-duplicates` is registered only when
+`NODE_ENV !== "production"` at module load (`routes/dedupe/scan.ts:138`);
+mark it `devOnly`.
+
+The test does **not** yet assert `isolated`. Phase 2 adds that assertion when
+the last route flips. The initial classification is in
+[appendix-b-route-manifest.md](appendix-b-route-manifest.md).
+
+### 0.4 Tenant lint (report mode)
+
+`scripts/tenant-lint.mjs`:
+
+- Walks `server/**/*.ts`.
+- Finds every string or template literal that contains `FROM <t>`, `JOIN <t>`, `UPDATE <t>`, `DELETE FROM <t>`, or `INSERT INTO <t>` where `<t>` is an owned table (`contacts`, `lists`, `interactions`, `action_items`, `dedupe_suggestions`, `dedupe_exclusions`, `dedupe_merge_log`, `ai_invocations`) or a virtual table (`contacts_fts`, `search_embeddings`, `contact_embeddings`).
+- Also finds Drizzle builder chains on `schema.contacts`, `schema.lists`, `schema.interactions`, `schema.actionItems` (`db.select().from(...)`, `db.insert(...)`, `db.update(...)`, `db.delete(...)`).
+- Flags any such statement that does not contain the substring `ownerId` (or `ownerTok` for FTS), unless the previous line contains `// tenant-lint: allow <reason>` with one of the reasons listed in section 8.
+- Two modes: `--report` prints a table and exits 0. `--strict <glob>` exits 1 on any flag inside matching files.
+- `npm run lint` runs `tenant-lint --report` in Phase 0. Phase 2 moves files into `--strict` as they are converted, and Phase 2 ends with `--strict "server/**"`.
+
+The report from Phase 0 is committed to
+`docs/multi-tenant-plan/bench/tenant-lint-baseline.txt` so Phase 2 can watch
+the count go to zero. Expect roughly 240 owned-table statements across about
+375 statements in all (current-state document, section 4).
+
+Unit test (`tests/unit/tenantLint.test.ts`): the scanner flags a statement
+without `ownerId`, honors the allow comment, rejects an allow comment with an
+unknown reason, and ignores non-owned tables.
+
+### 0.5 Ownership stamping
+
+For each insert into an owned table, take the owner from
+`currentScopeOrNull()` in Phase 0. This keeps signatures unchanged for one
+phase while closing the gap:
+
+| Insert site | Change |
+| ----------- | ------ |
+| `contactService.createContact`, `bulkCreateContacts` (`buildInsertValues`, `:94-114`) | add `ownerId: currentScopeOrNull()?.ownerId ?? null` |
+| `interactionService` ghost creation inside `runMentionExtraction` (`:70-80`) | same |
+| `dedupe/engine.ts seedDuplicates` (`:584-585`, dev only) | same |
+| `listService.createList` (`:37`) | add `ownerId` column to the `INSERT` |
+| `aiStatsService.recordInvocation` (`:88-91`) | add `ownerId` column to the `INSERT` |
+| `dedupe/suggestions.ts recordMerge` and `recordMergeUnsafe` (`:127-131`) | add `ownerId` from the primary contact's row (`SELECT ownerId FROM contacts WHERE id = ?`), not from context, because merges can run from a background scan |
+| `dedupe/merging.ts` | no `INSERT INTO contacts` exists; merges only `UPDATE` and `DELETE`. Nothing to do here |
+
+Anonymous mode still writes `NULL`, and `reconcileOwnership` still claims on
+boot for a single account. Behavior for today's users is unchanged. For an
+`AUTH_REQUIRED=true` instance, new rows are now owned immediately.
+
+Test (`tests/integration/tenancy.stamping.test.ts`): with auth on, create a
+contact, a list, an interaction with an `@mention` of an unknown name (which
+creates a ghost), and trigger one AI call through the mock; assert every new
+row's `ownerId` equals the signed-in user's id without a restart.
+
+### 0.6 Two-user harness
+
+`tests/integration/tenancy/helpers.ts` exports:
+
+```ts
+export interface Actor { user: AccountUser; cookie: string[]; scope: Scope }
+
+export async function createActor(app, overrides?): Promise<Actor>
+// First call: POST /api/auth/setup (admin). Later calls: authService.createUser (member),
+// then POST /api/auth/login. Returns the cookie and a Scope for direct DB assertions.
+export function asUser(actor: Actor): (req: supertest.Test) => supertest.Test
+export async function seedOwner(app, actor, shape: { contacts: number; interactions?: number; lists?: number; actionItems?: number }): Promise<Seeded>
+// Uses the public API (POST /api/contacts, /api/lists, /api/contacts/:id/interactions,
+// /api/contacts/:id/action-items) so every row is stamped the way production stamps it.
+// Returns every created id grouped by table, plus one uploaded avatar URL and one attachment URL.
+export function rowsOwnedBy(table: string, ownerId: string): number
+export function resetAccounts(): void
+// Phase 0: DELETE FROM sessions; DELETE FROM users after deleting owned rows.
+// Phase 1 changes this to keep or recreate the local owner (see 06, task 1.13).
+```
+
+### 0.7 Isolation matrix skeleton
+
+`tests/integration/tenancy.isolation.test.ts` reads `ROUTE_MANIFEST`, and for
+every `scoped` route creates an `it.todo("<METHOD> <path>: user B cannot reach user A's data")`.
+Phase 2 replaces each `it.todo` with a real test as the route is converted.
+The test file also has a `describe("list endpoints exclude other owners")`
+block with one `it.todo` per list endpoint.
+
+The point of the skeleton is the diff in Phase 2: every PR that converts a
+domain replaces `todo` with a passing test, and the reviewer can see the
+matrix fill in.
+
+### 0.8 Benchmark baseline
+
+`scripts/bench-tenancy.ts`:
+
+- Boots the app against a temp `DATA_DIR` with `DISABLE_BACKGROUND_JOBS=true` and mock AI.
+- Seeds `OWNERS × CONTACTS_PER_OWNER` (defaults `1 × 5000`, then `10 × 2000`, then `25 × 2000`) with realistic names, companies, tags, and 3 interactions per contact, through the service layer with a scope per owner. In Phase 0 the scope is set with `runWithContext` around each owner's inserts, which is what task 0.5 reads.
+- Measures p50 and p95 over 50 iterations for: `GET /api/contacts?view=slim`, `GET /api/contacts/:id`, `GET /api/search?q=`, `POST /api/search/semantic` (mock AI, so this measures FTS plus vector), `GET /api/dashboard`, `GET /api/command-palette/zero-state`, `GET /api/contacts/:id/timeline`, `GET /api/action-items`, `POST /api/dedupe/scan` wall time (mock AI), and one `PATCH /api/contacts/:id` (to record today's FTS trigger cost per update).
+- Prints a markdown table with the machine, Node, SQLite, and sqlite-vec versions in the header.
+
+Phase 0 records the `1 × 5000` and the `10 × 2000` numbers for the current
+code in `bench/baseline-phase-0.md` so Phase 5 has a before. Expect the
+`10 × 2000` run to show the problem: every list endpoint returns 20,000 rows
+to each user. Expect the `PATCH` to cost several milliseconds because of the
+FTS trigger scan described in the current-state document, section 2.10.
+
+### 0.9 Corrections
+
+- `server/middleware/auth.ts:20-22` and `:223-227`: rewrite the comments to say ownership is stamped from the request context as of this phase.
+- `src/db/schema.ts:144`: "eleven contact_* child tables" becomes "ten". Add a line pointing at this plan.
+- `server/db.ts:268`: the second section labelled `2a` becomes `2b`.
+- `.agent/ARCHITECTURE.md` §7 Invariants: add "Every function that reads or writes an owned table takes a `Scope` as its first argument. See `server/tenancy/scope.ts`."
+- `.agent/TESTING.md` §1: "Two vitest projects" becomes three (`unit`, `integration`, `contract`), and the inventory gains the new test files.
+- `.agent/STATUS.md`: the test count line says 316; update it to the real number after this phase.
+
+### 0.10 BM25 weight offset (its own PR)
+
+`BM25_WEIGHTS` in `server/services/search/hybridRetrieval.ts:113` becomes ten
+values for the current ten-column table:
+`"0.0, 10.0, 5.0, 3.0, 2.0, 2.0, 1.0, 1.0, 1.0, 1.0"`. Position 0 is
+`contactId UNINDEXED` and gets `0.0`. This gives every column the weight the
+constant's comment intends. Add a unit test in `tests/unit/search.test.ts`
+that builds a three-column `fts5(id UNINDEXED, a, b)` table and asserts a
+weight in position 1 boosts `a`, so the positional rule is pinned.
+
+This is a ranking change for users. It ships as its own PR with its own
+CHANGELOG line so it can be reverted alone. The decision and the alternative
+(preserve today's effective weights) are Q13 in the risks document. Phase 1
+extends the string to twelve values when it adds `ownerTok` and `cidTok`.
+
+### 0.11 Router mount order
+
+In `server/app.ts`, mount `mcpRouter` before `contactsRouter` (today `:204`
+and `:202`). Add an integration test that `GET /api/contacts/action-items`
+returns `200` with the MCP payload, and that `GET /api/contacts/<uuid>` still
+returns the contact. No client works today with this route, so nothing
+breaks.
+
+### 0.12 CHANGELOG
+
+Under `## [Unreleased]`, add a `Phase 0` block with: ownership stamped on
+insert for `AUTH_REQUIRED=true` instances, the MCP action-items route fixed,
+the request id on rate-limit responses, and the BM25 weight fix (its own
+line, marked as a ranking change).
+
+---
+
+## 3. Tests added in this phase
+
+| File | Asserts |
+| ---- | ------- |
+| `tests/unit/tenancy.scope.test.ts` | Tokens equal SQLite's expressions. A token is one FTS5 term. `scopeOf` throws 401 for a non-user principal. |
+| `tests/unit/tenancy.requestContext.test.ts` | Context survives async boundaries. Emitter rule. `NO_SCOPE` outside a context. |
+| `tests/unit/tenantLint.test.ts` | Flags, allows, rejects unknown reasons, ignores non-owned tables. |
+| `tests/unit/search.test.ts` (extended) | BM25 positional rule. |
+| `tests/integration/tenancy.routeManifest.test.ts` | Every route classified, no stale rows, static layer present. |
+| `tests/integration/tenancy.stamping.test.ts` | Every insert carries the caller's id. |
+| `tests/integration/tenancy.context.upload.test.ts` | Context inside multer callbacks and after multer with a text field. |
+| `tests/integration/tenancy.isolation.test.ts` | Skeleton only, one `it.todo` per scoped route. |
+| MCP route test | `GET /api/contacts/action-items` reachable. |
+
+---
+
+## 4. Acceptance criteria
+
+- [ ] CI runs on pull requests into `v2.0` (task 0.0 merged first).
+- [ ] `npm run lint` passes. `tenant-lint --report` prints the baseline count and exits 0.
+- [ ] `npm test` passes. All 575 existing tests unchanged, plus the new files.
+- [ ] `tenancy.routeManifest.test.ts` passes: every route classified, including `/api/debug/cache-stats` and the `devOnly` rows.
+- [ ] `tenancy.isolation.test.ts` exists with one `it.todo` per scoped route.
+- [ ] Stamping test green for contacts, lists, interactions (ghost), merge log, AI invocations.
+- [ ] Context tests green, including the emitter rule and the multipart-with-text-field case (or the fallback recorded in the PR).
+- [ ] `bench-tenancy` runs and `bench/baseline-phase-0.md` is committed.
+- [ ] `GET /api/contacts/action-items` returns the MCP payload.
+- [ ] A limiter `429` carries a `requestId`.
+- [ ] A single-account instance upgraded from 1.5.5 shows no behavior change. Verified by running the full existing integration suite and by a manual smoke on a copy of a real database.
+- [ ] PR description carries the raw vitest summary line and the lint output.
+
+---
+
+## 5. Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Express router internals change in a minor release and break the recorder | The recorder patches `use` and reads `route.path`, `route.methods`, and `layer.name`, which are stable public-ish fields. Pin the shape in a comment naming `router@2.2.0`. |
+| `AsyncLocalStorage` context lost across a library boundary | The context is attribution-only in this phase. The upload and emitter tests tell Phase 1 and Phase 2 exactly where to pass the scope explicitly. |
+| `recordInvocation` `ownerId` is `NULL` for background jobs | Expected. Phase 2 wraps jobs. The AI stats view groups `NULL` as "system". |
+| The BM25 fix changes search ranking for existing users | Its own PR and CHANGELOG line. Revertable alone. The unit test documents the rule so the twelve-value string in Phase 1 is right. |
+
+---
+
+## 6. Contract this phase delivers to Phase 1
+
+- `server/tenancy/scope.ts` and `requestContext.ts` exist with the names in section 8.
+- `attachRequestContext` is mounted after `attachPrincipal`. `req.requestId` is assigned before any limiter.
+- Every insert into an owned table sets `ownerId` when a scope is present.
+- `ROUTE_MANIFEST` lists every route with a class. The recorder-based `listRoutes` works.
+- The two-user harness can create a second account through `authService.createUser` and sign it in.
+- `bench-tenancy` produces a table; the Phase 0 baseline is committed.
+
+---
+
+## 7. Do not do in this phase
+
+- Do not add `WHERE ownerId = ?` to any read. That is Phase 2.
+- Do not change the `Principal` union or remove `anonymous` and `service`. That is Phase 1.
+- Do not change the database schema. `contactToken` is a helper only.
+- Do not bump `package.json` version.
+
+---
+
+## 8. Names and rules used in this phase
+
+| Name | Meaning |
+| ---- | ------- |
+| Owner | The user who owns a row. `ownerId` is a `users.id`. |
+| `Scope` | `{ readonly ownerId: OwnerId }`, built only by `scopeOf(req)`, `scopeForUser(user)`, `scopeForOwnerId(id)`. |
+| Owned tables | `contacts`, `lists`, `interactions`, `action_items`, `dedupe_suggestions`, `dedupe_exclusions`, `dedupe_merge_log`, `ai_invocations`. In `v1.5.5` only the first two and the last two have the column. |
+| Owner token | `'o' + uuid without hyphens`. Contact token: `'c' + uuid without hyphens`. |
+| Route classes | `public`, `session-self`, `scoped`, `admin`, `instance-read`, `static`. |
+| Allow-comment reasons | `instance sweep`, `owner-checked by caller`, `boot migration`, `admin cross-user`, `derived table`. |
+| `NO_SCOPE` | `AppError` 500 thrown by `currentScope()` outside a context. Programmer error. |
+| Request context | `AsyncLocalStorage<RequestContext>` for attribution only. Never the isolation mechanism. Repositories take an explicit `Scope`. |

--- a/docs/multi-tenant-plan/06-phase-1-storage.md
+++ b/docs/multi-tenant-plan/06-phase-1-storage.md
@@ -1,0 +1,592 @@
+# 06. Phase 1: Storage and Migration
+
+**Goal:** land every schema change from
+[04-data-model-and-migration.md](04-data-model-and-migration.md) with an
+idempotent boot migration, a pre-migration backup, and verification. After
+this phase every row has an owner, the search structures can filter by
+owner, the FTS triggers no longer scan the index on every update, and
+uploads live under per-owner directories. Queries still do not filter (that
+is Phase 2), so a single-account instance behaves as before.
+
+**Lands on:** the `v2.0` branch. Not released alone, because the local owner
+account changes what `/api/auth/status` reports on an auth-off instance and
+the frontend needs Phase 4 to present that well.
+
+**Size:** L (about 7 to 10 engineering days).
+
+**Depends on:** Phase 0.
+
+This document is written so that an implementer can work from it alone. The
+exact DDL is repeated here. The reasoning behind each choice is in the data
+model document. Every number marked "measured" comes from
+[bench/review-2026-09-08/](bench/review-2026-09-08/README.md).
+
+---
+
+## 0. Context for the implementer
+
+### 0.1 Repository, commands, and workflow
+
+Same as Phase 0, section 0.1 and 0.2 of
+[05-phase-0-foundations.md](05-phase-0-foundations.md). In short: Express 5
+API in `server/`, React SPA in `src/`, one SQLite file through better-sqlite3
+(SQLite 3.53.2) with sqlite-vec 0.1.9 and FTS5, raw idempotent DDL in
+`server/db.ts` that runs at import time, three vitest projects. Work on a
+feature branch `v2.0/phase-1-storage`, open the PR into `v2.0`, squash-merge.
+`npm run lint` and `npm test` must pass. Paste the raw vitest summary line
+into the PR. No AI attribution in commits or PRs. `package.json` stays at
+`1.5.5`.
+
+### 0.2 State at the start of this phase (after Phase 0)
+
+- `server/tenancy/scope.ts` exports `Scope`, `OwnerId`, `scopeOf`, `scopeForUser`, `scopeForOwnerId`, `ownerToken`, `contactToken`.
+- `server/tenancy/requestContext.ts` exports `runWithContext`, `getContext`, `currentScope`, `currentScopeOrNull`, `attachRequestContext`, mounted after `attachPrincipal` in `server/app.ts`.
+- Every insert into an owned table sets `ownerId` from the request context when one exists. Background inserts still write `NULL`.
+- `ROUTE_MANIFEST` and the recorder-based route test exist. The two-user harness exists. `bench-tenancy` exists.
+- `BM25_WEIGHTS` has ten values. `mcpRouter` mounts before `contactsRouter`.
+- `req.principal` is still `anonymous | user | service`.
+
+### 0.3 Facts about `server/db.ts` and its neighbors that this phase edits
+
+Line numbers are `v1.5.5`. Section labels are the `// N.` comments in the file.
+
+| Section | Lines | What it does today |
+| ------- | ----- | ------------------ |
+| §1, §1a, §1b | 20-139 | Open the file, PRAGMAs (`journal_mode = WAL`, `foreign_keys = ON`, `busy_timeout = 5000`), load sqlite-vec, log `vec_version()` |
+| §2 | 140-150 | Drizzle migrations `0000` (contacts, ten `contact_*` tables, interactions, interaction_mentions, lists, list_members, action_items) and `0001` (ai_invocations) |
+| §2z | 151-199 | `users`, `sessions`, indexes, expired-session sweep |
+| §2a | 201-262 | Dicebear avatar URL migration (`UPDATE contacts`) |
+| §2a (duplicate label, becomes §2b in Phase 0) | 268-333 | Legacy AI-search cleanup (`UPDATE contact_interests`, `contact_experience`, `contact_education`) |
+| §3 | 335-556 | `FTS_SCHEMA_VERSION = 1`, `user_version` gate, `contacts_fts` with ten columns and no `tokenize` option, eleven triggers, bulk backfill |
+| §4, §5 | 558-605 | `contacts_auto_updated_at`, `interactions_auto_updated_at`, `action_items_auto_updated_at` (each `DROP TRIGGER IF EXISTS` then `CREATE`) |
+| §6 | 607-658 | `action_items` (`IF NOT EXISTS`, also in Drizzle `0000`), `action_items_sync_insert/update/delete` (each `DROP` then `CREATE`) |
+| §7, §8 | 660-705 | `relationshipScore` column guard, legacy `nextFollowUpAt` backfill that inserts `action_items` without `ownerId` |
+| §9a, §9b | 713-731 | `canonicalId`, `phoneticHash` and its index |
+| §9c, §9d, §9e | 733-782 | `dedupe_suggestions`, `dedupe_exclusions` (PK `contactIdA, contactIdB`, no `id`), `dedupe_merge_log` |
+| §9f, §9f-b | 784-800 | `contact_embeddings` `vec0(contactId TEXT PRIMARY KEY, embedding FLOAT[768])`, `search_embeddings` `FLOAT[384]` |
+| `vecTableWidth` | 810-815 | Private. Returns a string, `"unknown"` on no match |
+| §9g, §9g2 | 828-852 | `dedupe_embedding_meta` (no FK), `app_settings` |
+| §9i | 854-903 | `OWNED_TABLES = ["contacts","lists","ai_invocations","dedupe_merge_log"]`, `ownerId` ALTER guarded by `table_info`, `idx_<table>_owner` |
+| §9h | 905-933 | Fifteen hot-path indexes, `PRAGMA optimize` |
+| §10 | 935-965 | Phonetic hash backfill |
+
+Other facts:
+
+- `server/services/authService.ts:18` imports `sqlite, OWNED_TABLES` from `db.ts` and prepares statements at module top level (`:191-201`). `db.ts` cannot import it.
+- `authService.ts` enumerates user columns by hand in `USER_COLUMNS` (`:178-179`), the `User` type (`:89-98`), `stripHash` (`:249-260`), `publicUser` (`:116-126`).
+- `passwords.ts` hashes are `scrypt$N$r$p$salt$hash`. `parseHash` (`:151-156`) returns `null` when the part count is not six.
+- `requireUser` (`server/middleware/auth.ts:278-294`) returns `403 USER_REQUIRED`. Seven routes use it (`routes/auth.ts:193, 199, 217, 234, 241, 257, 268`). `api.auth.test.ts:379` asserts the code.
+- `isAuthRequired()` is `AUTH_REQUIRED === "true" || API_TOKEN is set` (`auth.ts:103-105`). Keep that rule.
+- Every FTS trigger starts with `DELETE FROM contacts_fts WHERE contactId = ...`. `contactId` is `UNINDEXED`, so that is a full scan of the FTS table per firing: 4 ms at 40,000 rows, measured.
+- `contacts_ai` (`:395-406`) lacks the `deletedAt IS NULL` guard the other triggers have.
+- The search upsert is `DELETE` then `INSERT` (`localEmbeddings.ts:203-212`). The dedupe upsert is `INSERT OR REPLACE` (`dedupe/embeddings.ts:188`). `rebuildDedupeEmbeddingTable` (`dedupe/embeddings.ts:48`) is not exported. `rebuildSearchEmbeddingTable` (`localEmbeddings.ts:179`) is.
+- `ai.embeddingsState` (search) and `ai.embeddingsState.dedupe` (dedupe) in `app_settings` hold the model signature and dimension. Both `ensure*Store` functions compare settings, not DDL, so a copy-rebuild does not trigger a re-embed.
+- `findStaleEmbeddings` (`dedupe/embeddings.ts:298-313`) re-embeds any contact whose `updatedAt` is newer than its `embeddedAt`. Anything that stamps `updatedAt` on every contact causes a paid re-embed of the corpus.
+- Multer `destination` callbacks ignore `req` today (`routes/contacts.ts:63-69`, `routes/interactions.ts:34-41`). Avatars go to `UPLOADS_DIR/avatars/`, attachments to `UPLOADS_DIR/`. `resolveUploadPath` (`server/utils/paths.ts:35-43`) is the containment check.
+- `scripts/seed.ts` (`:18`, `:105`) and `scripts/seedMock.ts` (`:385`, `:499`) insert contacts and interactions through Drizzle with no `ownerId`. `npm run seed` and `npm run db:seed` call them.
+- `tests/integration/api.auth.test.ts` inserts `NULL`-owned contacts at `:586`, `:605`, `:752-753`, `:760-761`, and `wipeAccounts()` (`:33`) runs `DELETE FROM sessions; DELETE FROM users;`.
+- `geocode_cache` is created by `server/services/geocoding/cache.ts` at import time.
+
+### 0.4 Verified engine behavior this phase relies on
+
+| Fact | Consequence |
+| ---- | ----------- |
+| `VACUUM INTO` fails inside a transaction | The backup runs before `sqlite.transaction()` opens |
+| `ALTER TABLE ADD COLUMN ... REFERENCES` works with `foreign_keys = ON` when the default is `NULL`; `NOT NULL DEFAULT 'x'` works; `REFERENCES` with a non-`NULL` default fails only on non-empty tables | The `ownerId` and `users` ALTERs below are legal. Never combine `REFERENCES` with a non-`NULL` default |
+| `CREATE TRIGGER` does not validate column names; a `SELECT` in an `exec` does | The FTS backfill fails at prepare time if `contacts.ownerId` is missing, even with zero rows. Order matters |
+| An `AFTER INSERT` trigger that `UPDATE`s its own row fires the table's `AFTER UPDATE` triggers; `recursive_triggers` is off | The fill triggers stamp `updatedAt` on the rare insert without an owner. Acceptable |
+| FK cascades fire the child table's triggers | A contact delete fires `fts_emails_ad` per email. With `cidTok` each firing is cheap |
+| `vec0` `TEXT PARTITION KEY` works; KNN with `ownerId = ?` filters; `DELETE`, `SELECT`, `COUNT` by partition work; `UPDATE` of the partition column fails; `IN` on it is unsupported; `k` max 4096; an `INSERT` without `ownerId` gets a `NULL` partition silently; `ALTER TABLE RENAME` breaks the table | Copy-rebuild only. Upserts are `DELETE` + `INSERT`. Verification counts `NULL` partitions |
+| `DROP TABLE` and `CREATE VIRTUAL TABLE ... vec0` work inside a transaction | The copy-rebuild is one transaction per table |
+| `vec_version()` returns `v0.1.9` (leading `v`, may carry `-alpha.N`) | Parse three integers; do not compare strings |
+
+---
+
+## 1. Deliverables
+
+| # | Deliverable | Spec |
+| - | ----------- | ---- |
+| 1.1 | `users` columns, `api_tokens`, `invitations`, `user_settings`, `audit_log`, `app_settings` moved up | data model §2, §1.1 |
+| 1.2 | `ensureLocalOwner`, `primaryAdminId`, `claimUnownedData` in `db.ts`; rewritten `reconcileOwnership`; `convertLocalOwner` | data model §3 |
+| 1.3 | `ownerId` on four child tables with backfill and invariant triggers, `OWNED_TABLES` extended, triggers dropped around the claim | data model §4 |
+| 1.4 | FTS v2: `ownerTok` and `cidTok`, `MATCH`-based deletes in every trigger, generated trigger template, `FTS_SCHEMA_VERSION = 2`, twelve BM25 weights | data model §5 |
+| 1.5 | `vec0` partition-key rebuild by copy, `vec_version` check, rebuild helpers and upserts updated | data model §6 |
+| 1.6 | Uploads relocation and `ownerUploadDir` | data model §7 |
+| 1.7 | Composite indexes, `ANALYZE` | data model §8 |
+| 1.8 | `TENANCY_SCHEMA_VERSION`, `VACUUM INTO` backup, boot ordering | data model §1 and §10 |
+| 1.9 | `npm run tenancy:verify` script | data model §11 |
+| 1.10 | Rollback script for uploads | data model §12 |
+| 1.11 | Principal rewrite: `implicit` and `legacy-env-token` kinds, removal of `anonymous` and `service`, `requireSession`, `requireAdmin` | architecture §4.1, §4.2 |
+| 1.12 | Upgrade test from a 1.5.5-shaped database | this document §3 |
+| 1.13 | Test harness reset that survives the local owner | this document §2, task 1.13 |
+| 1.14 | Seed scripts stamp the local owner | `scripts/seed.ts`, `scripts/seedMock.ts` |
+| 1.15 | `src/db/schema.ts` mirror | data model §13 |
+| 1.16 | CHANGELOG entry | `CHANGELOG.md` |
+
+---
+
+## 2. Tasks in order
+
+### 1.1 Identity tables
+
+Add these blocks to `server/db.ts` directly after §2z. Guard each
+`ALTER TABLE users ADD COLUMN` with `table_info`, mirroring §9i.
+
+```sql
+-- 2z-1
+ALTER TABLE users ADD COLUMN status TEXT NOT NULL DEFAULT 'active';           -- 'active' | 'disabled'
+ALTER TABLE users ADD COLUMN credentialState TEXT NOT NULL DEFAULT 'password'; -- 'password' | 'none'
+ALTER TABLE users ADD COLUMN mustChangePassword INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN passwordChangedAt TEXT;
+ALTER TABLE users ADD COLUMN disabledAt TEXT;
+ALTER TABLE users ADD COLUMN createdBy TEXT REFERENCES users(id) ON DELETE SET NULL;
+
+-- 2z-2
+CREATE TABLE IF NOT EXISTS app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL, updatedAt TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)); -- same DDL as §9g2
+CREATE TABLE IF NOT EXISTS api_tokens (
+  id TEXT PRIMARY KEY, userId TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL, tokenHash TEXT NOT NULL UNIQUE, tokenPrefix TEXT NOT NULL,
+  createdAt TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP), lastUsedAt TEXT, expiresAt TEXT, revokedAt TEXT);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(userId);
+CREATE TABLE IF NOT EXISTS invitations (
+  id TEXT PRIMARY KEY, email TEXT, role TEXT NOT NULL DEFAULT 'member', tokenHash TEXT NOT NULL UNIQUE,
+  invitedBy TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  createdAt TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP), expiresAt TEXT NOT NULL,
+  acceptedAt TEXT, acceptedBy TEXT REFERENCES users(id) ON DELETE SET NULL, revokedAt TEXT);
+CREATE TABLE IF NOT EXISTS user_settings (
+  userId TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE, key TEXT NOT NULL, value TEXT NOT NULL,
+  updatedAt TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP), PRIMARY KEY (userId, key));
+CREATE TABLE IF NOT EXISTS audit_log (
+  id TEXT PRIMARY KEY, actorUserId TEXT REFERENCES users(id) ON DELETE SET NULL, action TEXT NOT NULL,
+  targetType TEXT, targetId TEXT, details TEXT, ip TEXT, createdAt TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP));
+CREATE INDEX IF NOT EXISTS idx_audit_created ON audit_log(createdAt DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_actor ON audit_log(actorUserId, createdAt DESC);
+
+-- 2z-3: the three dedupe tables, identical DDL to §9c, §9d, §9e (those sections become no-ops)
+```
+
+Copy the exact `CREATE TABLE IF NOT EXISTS` text for `dedupe_suggestions`,
+`dedupe_exclusions`, and `dedupe_merge_log` from §9c to §9e into 2z-3,
+including their two indexes. They must exist before the tenancy block because
+`OWNED_TABLES` names them.
+
+Update `authService.ts`: `USER_COLUMNS`, the `User` type, `stripHash`, and
+`publicUser` gain `status`, `credentialState`, `mustChangePassword`,
+`passwordChangedAt`, `disabledAt`, `createdBy`. `publicUser` exposes
+`status`, `mustChangePassword`, and `credentialState`; never `passwordHash`.
+
+### 1.2 Local owner and claim (in `server/db.ts`)
+
+Add to `server/db.ts`, exported, raw SQL, no imports from services:
+
+```ts
+export const OWNED_TABLES = [
+  "contacts", "lists", "interactions", "action_items",
+  "dedupe_suggestions", "dedupe_exclusions", "dedupe_merge_log", "ai_invocations",
+] as const;
+
+function countUsers(): number { /* SELECT COUNT(*) FROM users */ }
+
+export function primaryAdminId(): string {
+  // SELECT id FROM users WHERE role = 'admin' AND status = 'active' ORDER BY createdAt ASC LIMIT 1
+  // throws if none: impossible after ensureLocalOwner has run once
+}
+
+export function ensureLocalOwner(): string {
+  const existing = sqlite.prepare(`SELECT id FROM users WHERE credentialState = 'none' LIMIT 1`).get() as { id: string } | undefined;
+  if (existing) return existing.id;
+  if (countUsers() > 0) return primaryAdminId();
+  const id = crypto.randomUUID();
+  sqlite.prepare(`
+    INSERT INTO users (id, email, username, displayName, passwordHash, role, credentialState)
+    VALUES (?, 'local@contrack.local', 'local', 'This device', 'none$', 'admin', 'none')
+  `).run(id);
+  return id;
+}
+
+export function claimUnownedData(ownerId: string): Record<string, number> {
+  // for each table in OWNED_TABLES: UPDATE <t> SET ownerId = ? WHERE ownerId IS NULL
+  // return { table: changes }
+}
+```
+
+`'none$'` never verifies: `parseHash` rejects any hash that does not split
+into six parts. Move the existing `claimUnownedData` body out of
+`authService.ts` into `db.ts` and have `authService.ts` import it, the same
+way it imports `OWNED_TABLES`.
+
+In `server/services/authService.ts`:
+
+- `reconcileOwnership()` becomes `const owner = ensureLocalOwner(); claimUnownedData(owner);`. Delete the "exactly one user" guard. `server/app.ts:113` keeps calling it.
+- `countUnownedContacts()` stays for the setup screen, but its meaning shifts to "contacts owned by the local owner account": `WHERE ownerId = (SELECT id FROM users WHERE credentialState = 'none') AND deletedAt IS NULL AND isGhost = 0`. Rename it `countDeviceContacts()`. The status payload field becomes `deviceContacts` (Phase 3 finishes the API rename; do both names in the payload from this phase so the current frontend keeps working).
+- `createUser` keeps "first account is admin". Add `convertLocalOwner(input)`: sets email, username, displayName, passwordHash, `credentialState = 'password'`, `passwordChangedAt = now`, keeps `id` and `role = 'admin'`. `POST /api/auth/setup` calls `convertLocalOwner` when a `credentialState = 'none'` row exists, else `createUser`. Ownership does not move, because the id does not change.
+- `setupRequired` in `/status` becomes `isAuthRequired() && COUNT(users WHERE credentialState = 'password') = 0`.
+- `validateUsername` rejects `local` (Q11 in the risks document). Today's pattern accepts it.
+
+Auth-off validity rule: at boot, if `!isAuthRequired()` and
+`SELECT COUNT(*) FROM users WHERE credentialState = 'password' > 0`, log
+`error` and set an in-process flag `forcedAuth = true` that `isAuthRequired()`
+returns. The log line: "AUTH_REQUIRED is false but accounts exist. Auth is
+enforced. Set AUTH_REQUIRED=true to silence this." The boot check lives in
+`server/app.ts` next to `reconcileOwnership()`.
+
+### 1.3 Child ownership, trigger drops, and invariant triggers
+
+All inside the tenancy block (task 1.8), in this order:
+
+1. `ownerId` on all eight `OWNED_TABLES`, the same `table_info`-guarded loop as today's §9i, moved here. Keep the single-column `idx_<table>_owner` creation for now.
+2. Drop the seventeen triggers:
+
+   ```sql
+   DROP TRIGGER IF EXISTS contacts_ai;  DROP TRIGGER IF EXISTS contacts_au;  DROP TRIGGER IF EXISTS contacts_ad;
+   DROP TRIGGER IF EXISTS fts_tags_ai;  DROP TRIGGER IF EXISTS fts_tags_ad;
+   DROP TRIGGER IF EXISTS fts_interests_ai;  DROP TRIGGER IF EXISTS fts_interests_ad;
+   DROP TRIGGER IF EXISTS fts_emails_ai;  DROP TRIGGER IF EXISTS fts_emails_ad;
+   DROP TRIGGER IF EXISTS fts_phones_ai;  DROP TRIGGER IF EXISTS fts_phones_ad;
+   DROP TRIGGER IF EXISTS contacts_auto_updated_at;  DROP TRIGGER IF EXISTS interactions_auto_updated_at;
+   DROP TRIGGER IF EXISTS action_items_auto_updated_at;
+   DROP TRIGGER IF EXISTS action_items_sync_insert;  DROP TRIGGER IF EXISTS action_items_sync_update;
+   DROP TRIGGER IF EXISTS action_items_sync_delete;
+   ```
+
+   Why: the claim and the backfill are bulk `UPDATE`s. With the triggers in place, `contacts_au` costs 5.4 ms per row (27 s per 5,000 rows measured) and the `_auto_updated_at` triggers stamp `updatedAt`, which makes the next deep dedupe scan re-embed the whole corpus through the paid provider. §3, §4, §5, and §6 of the file recreate all seventeen on the same boot; each already begins with `DROP TRIGGER IF EXISTS`.
+
+3. `ensureLocalOwner()` then `claimUnownedData(owner)`.
+4. Backfill:
+
+   ```sql
+   UPDATE interactions       SET ownerId = (SELECT ownerId FROM contacts WHERE id = interactions.contactId)      WHERE ownerId IS NULL;
+   UPDATE action_items       SET ownerId = (SELECT ownerId FROM contacts WHERE id = action_items.contactId)      WHERE ownerId IS NULL;
+   UPDATE dedupe_suggestions SET ownerId = (SELECT ownerId FROM contacts WHERE id = dedupe_suggestions.contactIdA) WHERE ownerId IS NULL;
+   UPDATE dedupe_exclusions  SET ownerId = (SELECT ownerId FROM contacts WHERE id = dedupe_exclusions.contactIdA)  WHERE ownerId IS NULL;
+   ```
+
+5. Invariant triggers, all `CREATE TRIGGER IF NOT EXISTS`:
+
+   ```sql
+   -- required on insert: contacts, lists, dedupe_merge_log, ai_invocations
+   CREATE TRIGGER IF NOT EXISTS contacts_owner_required BEFORE INSERT ON contacts
+   WHEN NEW.ownerId IS NULL BEGIN SELECT RAISE(ABORT, 'contacts.ownerId is required'); END;
+
+   -- fill from parent: interactions, action_items (by contactId), dedupe_suggestions (by contactIdA)
+   CREATE TRIGGER IF NOT EXISTS interactions_owner_fill AFTER INSERT ON interactions
+   WHEN NEW.ownerId IS NULL BEGIN
+     UPDATE interactions SET ownerId = (SELECT ownerId FROM contacts WHERE id = NEW.contactId) WHERE id = NEW.id;
+   END;
+   -- dedupe_exclusions has no id column: key on the composite primary key
+   CREATE TRIGGER IF NOT EXISTS dedupe_exclusions_owner_fill AFTER INSERT ON dedupe_exclusions
+   WHEN NEW.ownerId IS NULL BEGIN
+     UPDATE dedupe_exclusions SET ownerId = (SELECT ownerId FROM contacts WHERE id = NEW.contactIdA)
+      WHERE contactIdA = NEW.contactIdA AND contactIdB = NEW.contactIdB;
+   END;
+
+   -- mismatch check: interactions, action_items (contactId); dedupe_suggestions, dedupe_exclusions (both A and B)
+   CREATE TRIGGER IF NOT EXISTS interactions_owner_check BEFORE INSERT ON interactions
+   WHEN NEW.ownerId IS NOT NULL AND NEW.ownerId != (SELECT ownerId FROM contacts WHERE id = NEW.contactId)
+   BEGIN SELECT RAISE(ABORT, 'interactions.ownerId does not match contact owner'); END;
+
+   -- propagate: contacts
+   CREATE TRIGGER IF NOT EXISTS contacts_owner_propagate AFTER UPDATE OF ownerId ON contacts
+   WHEN NEW.ownerId IS NOT OLD.ownerId BEGIN
+     UPDATE interactions       SET ownerId = NEW.ownerId WHERE contactId = NEW.id;
+     UPDATE action_items       SET ownerId = NEW.ownerId WHERE contactId = NEW.id;
+     UPDATE dedupe_suggestions SET ownerId = NEW.ownerId WHERE contactIdA = NEW.id OR contactIdB = NEW.id;
+     UPDATE dedupe_exclusions  SET ownerId = NEW.ownerId WHERE contactIdA = NEW.id OR contactIdB = NEW.id;
+   END;
+   ```
+
+   The propagate trigger cannot touch the `vec0` tables (`UPDATE` of a partition key is refused). That is fine: the only owner change in 2.0 is the one-time claim, which runs before the `vec0` rebuild reads `contacts.ownerId`.
+
+Then update the tests that insert `NULL`-owned rows directly
+(`api.auth.test.ts:586`, `:605`, `:752-753`, `:760-761`): insert with the
+local owner's id and assert that setup **converts** the local owner rather
+than claiming from `NULL`.
+
+### 1.4 FTS v2
+
+Replace the eleven hand-written triggers with a generator:
+
+```ts
+const FTS_COLS = "contactId, name, company, role, headline, location, about, industry, extras, searchExpansion, ownerTok, cidTok";
+function ftsRowSelect(alias: string): string {
+  return `SELECT ${alias}.id, ${alias}.name, ${alias}.company, ${alias}.role, ${alias}.headline, ${alias}.location,
+          ${alias}.about, ${alias}.industry, <the four GROUP_CONCAT subselects as today>, COALESCE(${alias}.searchExpansion, ''),
+          'o' || replace(${alias}.ownerId, '-', ''), 'c' || replace(${alias}.id, '-', '')`;
+}
+function ftsDelete(idExpr: string): string {
+  return `DELETE FROM contacts_fts WHERE contacts_fts MATCH 'cidTok:c' || replace(${idExpr}, '-', '')`;
+}
+function childTrigger(table: string, event: "ai" | "ad"): string {
+  // ${ftsDelete(`${NEW|OLD}.contactId`)}; INSERT INTO contacts_fts(${FTS_COLS}) ${ftsRowSelect("c")} FROM contacts c
+  //   WHERE c.id = ${NEW|OLD}.contactId AND c.deletedAt IS NULL;
+}
+```
+
+Rules:
+
+1. The table DDL becomes `fts5(contactId UNINDEXED, name, company, role, headline, location, about, industry, extras, searchExpansion, ownerTok, cidTok)`. No `tokenize` option, as today.
+2. Every delete inside a trigger uses `ftsDelete(...)`. **Never** `WHERE contactId = ...`, which scans the table.
+3. `contacts_ai` gains `WHERE new.deletedAt IS NULL` (missing today).
+4. `contacts_au` stays `AFTER UPDATE ON contacts` with no column list.
+5. The bulk backfill at the end of §3 uses `ftsRowSelect("c")` with `WHERE c.deletedAt IS NULL`.
+6. `FTS_SCHEMA_VERSION = 2`.
+7. `BM25_WEIGHTS` in `hybridRetrieval.ts` becomes twelve values: `"0.0, 10.0, 5.0, 3.0, 2.0, 2.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0"` (or the preserve-today variant if Q13 decided that way). `searchService.searchFts` (`:193-208`) uses `ORDER BY rank` and needs no weight change.
+
+Snapshot-test the generated SQL (`tests/unit/ftsTriggers.test.ts`). Log the
+rebuild duration. Expected: the bulk backfill took 233 ms for 50,000 contacts
+in the review; a 10,000-contact instance should log well under one second.
+
+Verify with a test that updates 1,000 contacts in a loop on a 5,000-contact
+database and asserts the loop finishes in under 500 ms (the same loop takes
+about 5 s with the old triggers).
+
+### 1.5 vec0
+
+In `server/db.ts` (a new §9k after §9f-b):
+
+1. Parse `SELECT vec_version()`: strip the leading `v`, split on `.` and `-`, compare `[major, minor, patch]` to `[0, 1, 6]`. On failure, `throw new Error("sqlite-vec >= 0.1.6 is required for partitioned vector search; found " + v)`.
+2. Change the `CREATE VIRTUAL TABLE IF NOT EXISTS` DDL in §9f and §9f-b to include `ownerId TEXT PARTITION KEY` between `contactId` and `embedding`, so a fresh database gets the partition key directly.
+3. For each of `search_embeddings`, `contact_embeddings`: read `sql` from `sqlite_master`; if it lacks `PARTITION KEY` (case-insensitive), run the copy rebuild inside one `sqlite.transaction`: read `SELECT e.contactId, c.ownerId, e.embedding FROM <t> e JOIN contacts c ON c.id = e.contactId` in chunks of 5,000, `DROP TABLE <t>`, `CREATE VIRTUAL TABLE <t> USING vec0(contactId TEXT PRIMARY KEY, ownerId TEXT PARTITION KEY, embedding FLOAT[<dim>])`, reinsert. Read `<dim>` by parsing `vecTableWidth()` to an integer; throw with a clear message if it is `"unknown"`. Log rows copied and the duration (0.9 s per 50,000 × 384-dim rows measured). **Never** `ALTER TABLE ... RENAME` a `vec0` table.
+
+In `server/services/search/localEmbeddings.ts` and
+`server/services/dedupe/embeddings.ts`:
+
+- `rebuildSearchEmbeddingTable` and `rebuildDedupeEmbeddingTable` emit the partition key column. Export the dedupe one. A unit test asserts their DDL strings equal the string in `db.ts`.
+- `_upsertTxn`, `_stmts.upsert`, `upsertSearchEmbedding`, `storeEmbedding`, `storeEmbeddings`, `embedContact`, `generateAndStoreEmbedding`, `generateAndStoreBulkEmbeddings`, `reEmbedStaleContacts`, and both backfills supply `ownerId`, read from `contacts` by id inside the same transaction. New signature: `upsertSearchEmbedding(contactId, ownerId, embedding)`.
+- Every upsert is `DELETE` then `INSERT`. Run the existing `INSERT OR REPLACE` against a partitioned table in the day-one smoke test; if it fails on 0.1.9, replace it (risks document T24).
+- KNN statements do **not** yet filter by owner. That is Phase 2c. But the partition column must be populated for every row from this phase on, or Phase 2c's filter returns nothing for new rows.
+
+Day-one smoke test: run `bench/review-2026-09-08/01-vec-fts-smoke.cjs`
+against the installed `node_modules` and paste its output into the PR.
+
+### 1.6 Uploads
+
+- `server/utils/paths.ts`: add `ownerUploadDir(ownerId: string, kind: "avatars" | "files"): string` and `ownerUploadUrl(ownerId, kind, filename)`. Both validate `ownerId` against `/^[0-9a-f-]{36}$/` so a malformed id cannot form a path segment. Layout: `UPLOADS_DIR/u/<ownerId>/avatars/` and `UPLOADS_DIR/u/<ownerId>/files/`. `logos/` stays shared.
+- Multer `destination` callbacks in `server/routes/contacts.ts` and `server/routes/interactions.ts` resolve the directory from `req.principal` (multer passes `req` as the first argument; do not rely on the async context here) and call `ensureDir`. After Phase 1 every authenticated request has a user principal.
+- `contactService.updateAvatar` (`:637`), `avatarProcessor` (`:47-48`, `:65`), and `interactionService.handleAttachment` (`:310`, `:342`, `:370`) build URLs with `ownerUploadUrl`.
+- `server/db.ts` §11 relocation, run once per boot after the database migration, idempotent:
+  1. `SELECT id, ownerId, avatarUrl FROM contacts WHERE avatarUrl LIKE '/uploads/avatars/%'`. Move each file to `u/<ownerId>/avatars/<file>` and rewrite `avatarUrl`. Missing source file: rewrite the URL only.
+  2. `SELECT id, ownerId, fileUrl FROM interactions WHERE fileUrl LIKE '/uploads/%' AND fileUrl NOT LIKE '/uploads/u/%' AND fileUrl NOT LIKE '/uploads/logos/%'`. Same, into `files/`.
+  3. Leave `/api/avatar/...` and external `https://` URLs alone.
+  4. Move unreferenced files in the flat directories to `UPLOADS_DIR/orphaned/` and log them. Delete nothing.
+- `scripts/tenancy-rollback-uploads.mjs` reverses the moves using the restored 1.x database's URLs.
+
+The `/uploads` ownership guard middleware is Phase 2a. In Phase 1 alone, the
+old flat path returns 404 for relocated files and the new path is served to
+any authenticated principal, which is the same exposure as today.
+
+### 1.7 Indexes
+
+Inside the tenancy block, after the columns exist, all `IF NOT EXISTS`:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_status    ON contacts(ownerId, isGhost, isArchived, canonicalId);
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_deleted   ON contacts(ownerId, deletedAt);
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_lastc     ON contacts(ownerId, lastContactedAt);
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_added     ON contacts(ownerId, addedAt);
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_score     ON contacts(ownerId, relationshipScore);
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_phonetic  ON contacts(ownerId, phoneticHash);
+CREATE INDEX IF NOT EXISTS idx_contacts_owner_canon     ON contacts(ownerId, canonicalId);
+CREATE INDEX IF NOT EXISTS idx_interactions_owner_date  ON interactions(ownerId, date);
+CREATE INDEX IF NOT EXISTS idx_action_items_owner_due   ON action_items(ownerId, dueAt) WHERE completedAt IS NULL;
+CREATE INDEX IF NOT EXISTS idx_action_items_owner_done  ON action_items(ownerId, completedAt);
+CREATE INDEX IF NOT EXISTS idx_lists_owner_sort         ON lists(ownerId, sortOrder);
+CREATE INDEX IF NOT EXISTS idx_dedupe_sugg_owner_status ON dedupe_suggestions(ownerId, status);
+CREATE INDEX IF NOT EXISTS idx_dedupe_sugg_owner_conf   ON dedupe_suggestions(ownerId, confidence DESC);
+CREATE INDEX IF NOT EXISTS idx_dedupe_excl_owner        ON dedupe_exclusions(ownerId);
+CREATE INDEX IF NOT EXISTS idx_merge_log_owner_at       ON dedupe_merge_log(ownerId, mergedAt DESC);
+CREATE INDEX IF NOT EXISTS idx_ai_inv_owner_created     ON ai_invocations(ownerId, createdAt DESC);
+```
+
+Then `ANALYZE` (new) after the FTS and `vec0` steps. Do not drop the
+single-column owner indexes yet (Phase 2i).
+
+### 1.8 Version, backup, and boot order
+
+- `export const TENANCY_SCHEMA_VERSION = 1;` `readTenancyVersion()` and `writeTenancyVersion()` read and write `app_settings` key `schema.tenancy` with raw SQL.
+- Backup: when the version is behind and `SELECT COUNT(*) FROM contacts > 0`, and **before** any transaction opens: check `fs.statfsSync(DATA_DIR)` free bytes against 1.5 × the database file size; if enough, `VACUUM INTO '<DATA_DIR>/backups/pre-tenancy-<ISO stamp>.db'` (append a counter if the file exists); if not enough, log `error` and continue without a backup. Log the file name.
+- Wrap tasks 1.1 (2z-1 to 2z-3 are outside the transaction; they are `IF NOT EXISTS`), 1.3, 1.7, and the version write in one `sqlite.transaction`. Log each sub-step with its row count and duration in the style of the existing `log.info("Database", ...)` lines.
+- Final section order in the file:
+
+| § | Step |
+| - | ---- |
+| 2 | Drizzle migrations |
+| 2z | `users`, `sessions` |
+| 2z-1, 2z-2, 2z-3 | task 1.1 |
+| 2z-4 | tenancy block: version read, backup, transaction (columns, trigger drops, local owner, claim, backfill, invariant triggers, composite indexes, version write) |
+| 2a, 2b | unchanged |
+| 3 | FTS v2 (task 1.4) |
+| 4, 5, 6 | unchanged; they recreate the six non-FTS triggers |
+| 7, 8 | unchanged; the §8 backfill's `action_items` inserts get `ownerId` from the fill trigger |
+| 9a, 9b | unchanged |
+| 9c to 9e | now no-ops |
+| 9f, 9f-b | `vec0` DDL with the partition key |
+| 9k | `vec0` copy rebuild (task 1.5) |
+| 9g, 9g2 | unchanged (`app_settings` now a no-op) |
+| 9i | reduced to a guard that throws if any owned table lacks `ownerId` |
+| 9h | unchanged, then `ANALYZE` |
+| 10 | unchanged |
+| 11 | uploads relocation (task 1.6) |
+
+`reconcileOwnership()` in `server/app.ts:113` calls `ensureLocalOwner()` and
+`claimUnownedData()` unconditionally. With every row already owned, it is a
+no-op after the first boot.
+
+### 1.9 Verify script
+
+`scripts/tenancy-verify.ts` opens the database read-only, runs the eleven
+query groups in data model §11 (no unowned rows; child owner equals parent
+owner; FTS count equals active contacts; every FTS row has the right
+`ownerTok` and `cidTok`; both `vec0` tables have `PARTITION KEY` in their
+DDL; no `NULL` partitions; every vector row's owner equals its contact's
+owner; no legacy flat upload URLs; at most one local owner; the seventeen
+triggers exist), prints a pass or fail table, and exits non-zero on any
+failure. Add `"tenancy:verify": "tsx scripts/tenancy-verify.ts"` to
+`package.json`.
+
+### 1.10 Rollback script
+
+`scripts/tenancy-rollback-uploads.mjs`: given `DATA_DIR`, reads the restored
+1.x database's `avatarUrl` and `fileUrl` values and moves files from
+`uploads/u/<ownerId>/avatars/` back to `uploads/avatars/` and from
+`uploads/u/<ownerId>/files/` back to `uploads/`. Prints what it moved. The
+full rollback procedure is data model §12: stop, restore
+`backups/pre-tenancy-<stamp>.db` over `curator.db` (remove `-wal` and
+`-shm`), run this script, start the 1.x image.
+
+### 1.11 Principal rewrite
+
+In `server/middleware/auth.ts`:
+
+- `Principal` becomes:
+
+  ```ts
+  export type Principal =
+    | { kind: "user"; user: User; via: "session"; sessionId: string }
+    | { kind: "user"; user: User; via: "token"; tokenId: string }
+    | { kind: "user"; user: User; via: "implicit" }
+    | { kind: "user"; user: User; via: "legacy-env-token" };
+  ```
+
+- `attachPrincipal` order:
+  1. `Bearer ctk_...` → SHA-256 the token, look up `api_tokens` by `tokenHash`; reject `revokedAt`, past `expiresAt`, or a `disabled` user. Phase 3 adds the creation endpoints; Phase 1 adds the lookup and tests it with a row inserted directly.
+  2. `Bearer <env API_TOKEN>` (timing-safe compare, as today) → `{ kind: "user", user: primaryAdmin, via: "legacy-env-token" }`. Warn once at boot when `API_TOKEN` or `AUTH_TOKEN` is set.
+  3. Cookie → `session` as today, plus reject `status = 'disabled'`.
+  4. No credential and `!isAuthRequired()` → `{ kind: "user", user: localOwner, via: "implicit" }`. Cache the local owner row in memory; refresh it when `convertLocalOwner` runs.
+  5. Otherwise leave `req.principal` unset.
+- `requireUser` is renamed `requireSession` and passes only `via === "session"`. Its error code becomes `403 SESSION_REQUIRED`. Update the seven call sites in `server/routes/auth.ts` and the assertion at `api.auth.test.ts:379`. This is a documented breaking change (API changes document).
+- `requireAdmin` is added: `principal.user.role === "admin"`, else `403 ADMIN_REQUIRED`. Not yet mounted anywhere. Phase 2g and Phase 3 mount it.
+- `currentUser(req)` always returns a user for an authenticated request. Its return type drops `null`.
+- `scopeOf(req)` in `server/tenancy/scope.ts` drops the 401 branch for anonymous, because that kind no longer exists.
+- `isAuthRequired()` keeps returning true when `API_TOKEN` is set, and also when the boot flag `forcedAuth` is set (task 1.2).
+
+Update `api.auth.test.ts`:
+
+- "leaves everything open when AUTH_REQUIRED is off" still passes, but now asserts `/api/auth/status` reports `user.username === "local"` and `via` is not exposed on status.
+- "admits a bearer token without any account existing" changes: with a local owner always present, the token maps to that account. Assert `GET /api/auth/me` with the token returns `403 SESSION_REQUIRED` and a data endpoint works.
+- "cannot reach account endpoints, there is no account behind a token" (`:374`): the code changes from `USER_REQUIRED` to `SESSION_REQUIRED`.
+- Add: "disabled account cannot sign in and its live session stops working".
+- Add: "auth-off with a real account forces auth on" (boot flag).
+- Add: "the `local` username cannot be registered".
+
+### 1.12 Upgrade test
+
+`tests/integration/tenancy.migration.test.ts`:
+
+1. Open a fresh temp `DATA_DIR`. Before importing `server/db.ts`, build a 1.5.5-shaped database with `tests/fixtures/make-v1-database.ts`: run the two Drizzle migrations, create `users`, `sessions`, `app_settings` (with `ai.embeddingsState` and `ai.embeddingsState.dedupe` rows so no re-embed is triggered), `geocode_cache`, the dedupe tables, `dedupe_embedding_meta`, the two `vec0` tables **without** partition keys, the eleven v1 FTS triggers and the six other triggers, add `ownerId` to the four original tables, and insert 50 contacts with `ownerId = NULL` and distinct `updatedAt` values, 20 interactions, 5 action items, 3 lists, 2 dedupe suggestions, 10 rows in each `vec0` table with random vectors and matching `dedupe_embedding_meta` rows, 5 avatar files in `uploads/avatars/`, and 2 attachments in `uploads/`. Save a KNN result for a fixed query vector and the `updatedAt` map. This fixture is the only place that knows the old shape; comment it with the release it reproduces.
+2. Import `server/db.ts`. The migration runs.
+3. Assert every query group in data model §11 passes.
+4. Assert the vector row counts are unchanged and the KNN for the fixed query returns the same nearest neighbor.
+5. Assert `updatedAt` is byte-identical for every contact and interaction (the trigger-drop rule), and that the AI mock's `embedBatch` was never called.
+6. Assert the backup file exists and opens with the old shape.
+7. Import again (clear the module cache) and assert no log line reports a change and the version is unchanged.
+8. Run the same file with `AUTH_REQUIRED=true` and one real account in the fixture: the local owner is not created, the account keeps its rows, `setupRequired` is false.
+
+### 1.13 Test harness reset
+
+`resetAccounts()` in `tests/integration/tenancy/helpers.ts` (and
+`wipeAccounts()` in `api.auth.test.ts`) can no longer run `DELETE FROM users`
+alone: the local owner owns rows and `ON DELETE RESTRICT` refuses. New shape:
+delete every owned table's rows, `DELETE FROM sessions`,
+`DELETE FROM api_tokens`, `DELETE FROM users`, then `ensureLocalOwner()`.
+Every other integration file runs auth-off (`tests/integration-setup.ts`
+sets `AUTH_REQUIRED=""`), so their rows belong to the local owner and they
+pass unchanged.
+
+### 1.14 Seed scripts
+
+`scripts/seed.ts` and `scripts/seedMock.ts` import `server/db.ts`, so the
+migration and `ensureLocalOwner` have run by the time they insert. Both set
+`ownerId: ensureLocalOwner()` on every contact and interaction insert (or on
+contacts only and let the fill trigger handle interactions). Without this the
+`contacts_owner_required` trigger rejects the first insert.
+
+### 1.15 Schema mirror
+
+`src/db/schema.ts`: add the six `users` columns; new tables `apiTokens`,
+`invitations`, `userSettings`, `auditLog` with relations to `users`;
+`ownerId` on `interactions`, `actionItems`, `dedupeSuggestions`,
+`dedupeExclusions` with `owner` relations. Rewrite the OWNERSHIP comment block
+to state: `ownerId` is never `NULL` after boot, the four child tables carry a
+denormalized copy kept consistent by triggers, and the local owner account is
+what makes auth-off mode work.
+
+### 1.16 CHANGELOG
+
+Under Unreleased, a `Phase 1` block: the migration and its backup, the local
+owner account, the FTS trigger fix (state the measured before and after), the
+`vec0` partition rebuild with no provider calls, the uploads layout, the
+`SESSION_REQUIRED` rename as a breaking change.
+
+---
+
+## 3. Acceptance criteria
+
+- [ ] All Phase 0 criteria still hold.
+- [ ] `tenancy.migration.test.ts` passes, including the second-boot idempotency check, the `updatedAt` check, and the no-`embedBatch` check.
+- [ ] `npm run tenancy:verify` passes on: a fresh database, a migrated 1.5.5 fixture, a copy of a real 1.5.5 database with auth off, and one with auth on.
+- [ ] FTS rebuild time is logged and is under 1 s for 10,000 contacts.
+- [ ] Updating 1,000 contacts on a 5,000-contact database takes under 500 ms (the `cidTok` trigger fix).
+- [ ] Boot fails with a clear message when `vec_version()` is below 0.1.6 (unit test with a stubbed statement).
+- [ ] The day-one `vec0` smoke test output is in the PR.
+- [ ] Uploads: after migration, old URLs are gone from both columns and files exist at the new paths. Orphans land in `uploads/orphaned/`.
+- [ ] `api.auth.test.ts` green with the new principal kinds and `SESSION_REQUIRED`.
+- [ ] `npm run seed` works on a fresh `DATA_DIR`.
+- [ ] Rollback rehearsal documented in `docs/multi-tenant-plan/bench/rollback-rehearsal.md` with the exact commands run and their output.
+- [ ] `src/db/schema.ts` compiles and `tsc --noEmit` passes with the new types.
+- [ ] Every boot step logs its duration; a fresh test database boots in under 1 s more than before this phase.
+
+---
+
+## 4. Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| A trigger-based `NOT NULL` breaks a code path that inserted without an owner and relied on the boot claim | Phase 0 stamped every insert. The Phase 1 suite runs with `AUTH_REQUIRED=true` **and** with auth off. Any remaining path fails loudly with `ownerId is required`, which is the intended behavior. |
+| `VACUUM INTO` needs disk space | About one database size. The free-space check skips the backup with an `error` log rather than failing the boot. The rotating `curator-*.db` snapshots remain. |
+| The vector copy on a huge instance takes long | Chunked at 5,000 rows, logged. 50,000 × 384-dim measured at 0.9 s. |
+| An operator runs 1.x against a migrated database | The 1.x code finds partitioned `vec0` tables and its inserts lack `ownerId`, which now get a `NULL` partition rather than an error, and its FTS triggers reference columns that exist. It will run, but its rows are unowned. Document: downgrade requires the backup restore in data model §12. |
+| A crash between the trigger drops and the FTS rebuild | The next boot re-runs the tenancy block (no-op) and §3 to §6 recreate all seventeen triggers unconditionally. |
+| `INSERT OR REPLACE` fails on a partitioned `vec0` table | Smoke-tested on day one. Fallback is `DELETE` + `INSERT`, which the search store already uses. |
+
+---
+
+## 5. Contract this phase delivers to Phase 2
+
+- Every row in every owned table has a non-`NULL` `ownerId`. Triggers enforce it on insert.
+- `contacts_fts` has indexed `ownerTok` and `cidTok`. `ownerToken(scope)` and `contactToken(id)` match the SQL.
+- Both `vec0` tables have `ownerId TEXT PARTITION KEY` and every row carries it.
+- Composite indexes exist. The single-column owner indexes still exist.
+- Every request that passes `requireAuth` has a `user` principal. `requireSession` and `requireAdmin` exist.
+- Uploads live under `uploads/u/<ownerId>/`. `ownerUploadDir` and `ownerUploadUrl` exist.
+- The local owner account exists on every instance; setup converts it.
+
+---
+
+## 6. Do not do in this phase
+
+- Do not add `WHERE ownerId = ?` to reads. Phase 2.
+- Do not mount `requireAdmin` anywhere. Phase 2g and 3.
+- Do not add the `/uploads` guard. Phase 2a.
+- Do not drop the single-column owner indexes. Phase 2i.
+- Do not rename any `vec0` table.

--- a/docs/multi-tenant-plan/07-phase-2-scoping.md
+++ b/docs/multi-tenant-plan/07-phase-2-scoping.md
@@ -1,0 +1,407 @@
+# 07. Phase 2: Scope Every Read and Write
+
+**Goal:** every query that touches owned data carries the caller's `Scope`.
+Every shared cache and queue is keyed or checked by owner. Uploads are gated
+by owner. At the end of this phase the cross-owner matrix test is fully green
+and `tenant-lint --strict "server/**"` passes.
+
+**Lands on:** the `v2.0` branch, as nine PRs (one per sub-phase, 2a to 2i).
+
+**Size:** XL (about 13 to 19 engineering days).
+
+**Depends on:** Phase 1.
+
+This document is written so that an implementer can work from it alone.
+Section 0 gives the repository facts, the workflow, and the rules. Each
+sub-phase names every function and statement it converts with its `v1.5.5`
+line number. When a line has drifted, search for the function name. The
+complete inventory is [appendix-a-query-inventory.md](appendix-a-query-inventory.md).
+
+---
+
+## 0. Context for the implementer
+
+### 0.1 Repository, commands, and workflow
+
+Same as [05-phase-0-foundations.md](05-phase-0-foundations.md) sections 0.1
+and 0.2. In short: Express 5 API in `server/`, one SQLite file through
+better-sqlite3 with sqlite-vec 0.1.9 and FTS5, prepared statements compiled
+once into module-level `stmts` objects, a few Drizzle builder calls, three
+vitest projects, integration tests on a real database per file. Each
+sub-phase is one PR from `v2.0/phase-2<letter>-<slug>` into `v2.0`,
+squash-merged. `npm run lint` (which now includes `tenant-lint`) and
+`npm test` must pass. Paste the raw vitest summary line into the PR. No AI
+attribution in commits or PRs. `package.json` stays at `1.5.5`.
+
+### 0.2 State at the start of this phase (after Phase 1)
+
+- Every row in every owned table has a non-`NULL` `ownerId`. `contacts_owner_required` and the fill triggers enforce it on insert. The mismatch triggers reject a child row whose owner differs from its contact's.
+- Every request past `requireAuth` has `req.principal = { kind: "user", user, via }`. `scopeOf(req)` never throws for an authenticated request.
+- `contacts_fts` has indexed `ownerTok` and `cidTok`. `ownerToken(scope)` and `contactToken(id)` in `server/tenancy/scope.ts` match the SQL.
+- Both `vec0` tables carry `ownerId TEXT PARTITION KEY`, and every insert supplies it.
+- Composite indexes named `idx_<table>_owner_<suffix>` exist (list in Phase 1 task 1.7). The single-column `idx_<table>_owner` indexes still exist.
+- Uploads live under `uploads/u/<ownerId>/avatars/` and `uploads/u/<ownerId>/files/`. `ownerUploadDir` and `ownerUploadUrl` exist.
+- `requireSession` (was `requireUser`) and `requireAdmin` exist. `requireAdmin` is not mounted anywhere.
+- `ROUTE_MANIFEST` has every route with `isolated: false`. `tenancy.isolation.test.ts` has one `it.todo` per scoped route. `tenant-lint --report` runs in `npm run lint`.
+- `attachRequestContext` runs after `attachPrincipal`. `recordInvocation` reads `currentScopeOrNull()`.
+
+### 0.3 The rules
+
+1. **Signature.** Every repository function that reads or writes an owned table takes `scope: Scope` as its **first** parameter. Every service function a route calls takes `scope` first. Do not add it to functions that receive a parent id already owner-checked in the same call (hydration, child inserts).
+2. **Same statement.** A user-supplied id and the scope go in the same SQL statement: `WHERE id = ? AND ownerId = ?`. Never select by id and compare in JavaScript. One statement is one index probe; two statements are two probes and a race.
+3. **Inserts** set `ownerId = scope.ownerId` explicitly. The fill triggers are a safety net, not the path.
+4. **Not found.** A scoped lookup that returns no row throws `NotFoundError` (404, code `NOT_FOUND`). Do not distinguish "does not exist" from "not yours". The 404 body for a foreign id and a nonexistent id must be identical.
+5. **Route.** `const scope = scopeOf(req);` once at the top of the handler, passed down. Routes never read `ownerId` from the body or the query string.
+6. **Streams.** SSE and NDJSON handlers capture `scope` in the closure **before** subscribing or awaiting, and pass it explicitly. An `EventEmitter` listener runs in the emitter's async context, so `currentScope()` inside a queue listener returns the job's scope or `null`, never the request's.
+7. **Background jobs** wrap per-owner work in `runWithContext({ scope: scopeForOwnerId(id), principal: null, requestId: "job-<name>-<id>" }, fn)` so `recordInvocation` and cache keys attribute correctly.
+8. **Lint.** After converting a file, move it into the `--strict` glob. A statement that legitimately has no owner predicate carries `// tenant-lint: allow <reason>` on the line above, with one of: `instance sweep`, `owner-checked by caller`, `boot migration`, `admin cross-user`, `derived table`.
+9. **Test.** Replace the route's `it.todo` with a real test and flip `isolated: true` in the manifest in the same PR.
+10. **Vector rules** (sqlite-vec 0.1.9): filter with `AND ownerId = ?` in the KNN; never `ownerId IN (...)`; `k` at most 4096; upserts are `DELETE` then `INSERT`; never `UPDATE` a partition column.
+
+Helper added in 2a and reused everywhere:
+
+```ts
+// server/repositories/contactRepository.ts
+findOwned(scope: Scope, id: string): ContactRow | null           // SELECT * FROM contacts WHERE id = ? AND ownerId = ?
+findOwnedActive(scope: Scope, id: string): ContactRow | null     // ... AND deletedAt IS NULL
+findManyOwned(scope: Scope, ids: string[]): ContactRow[]         // chunked IN (...) AND ownerId = ?
+requireOwned(scope: Scope, id: string): ContactRow               // throws NotFoundError
+```
+
+`hydrate` and `hydrateMany` (`contactRepository.ts:161`, `:212`, chunks of
+500 at `:231`) are unchanged. They take rows that came from a scoped
+statement. They also read `lists` and `interactions` by contact id
+(`stmts.lists` `:122-127`, `stmts.interactionCount` `:128-130`, the chunked
+variants `:381-387`, `:396-401`), which are owned tables, so each of those
+statements carries `// tenant-lint: allow owner-checked by caller`.
+
+### 0.4 The isolation test shape
+
+For each `scoped` route, the matrix test in
+`tests/integration/tenancy.isolation.test.ts` uses the two-user harness (two
+actors, A seeded with 20 contacts, 10 interactions, 2 lists, 5 action items,
+one avatar and one attachment; B seeded with 5 contacts):
+
+| Route kind | Test |
+| ---------- | ---- |
+| `GET` by id | B requests A's id → `404`. A requests it → `200`. B requests a random UUID → `404` with an identical body (`deepEqual` minus `requestId`). |
+| `PUT`, `PATCH`, `DELETE` by id | B mutates A's id → `404`, and A's row is byte-identical before and after. |
+| `POST` child under a parent id | B posts under A's parent → `404`, no row created (count unchanged). |
+| Bulk with an id list | B sends `[A's ids..., B's ids...]` → only B's rows affected. Response count equals B's count. |
+| List endpoints | B's list contains zero ids from A's seed, and the reverse. |
+| Aggregates | B's numbers equal what B alone seeded. |
+| Search | A has a contact named `Zebulon Quarrington`. B searches that token in every search path → empty. |
+| Streams | B opens A's `scanId` or `batchId` → `404` before any event. |
+| Uploads | B fetches A's avatar and attachment URLs → `404`. |
+| Export | B's JSON export contains only B's rows in every table. |
+
+After every mutating attempt by B, `rowsOwnedBy(table, A.id)` is unchanged.
+
+---
+
+## 1. Sub-phases
+
+### 2a. Contacts core and uploads guard
+
+**Files:** `server/routes/contacts.ts`, `server/services/contactService.ts`, `server/repositories/contactRepository.ts`, `server/utils/avatarProcessor.ts`, `server/middleware/uploads.ts` (new), `server/app.ts`.
+
+| Function (line) | Change |
+| --------------- | ------ |
+| `getSlimContacts` (`:681`), `getAllContacts` (`:811`), `getMapContacts` (`:664`), `getArchivedContacts` (`:672`), `listTrash` (`:581`) | add `scope`, `WHERE ownerId = ?` first in the predicate. `getSlimContacts` is seven statements, not one: pass 2 (`:704-740`) runs six queries whose inner subselect `WHERE contactId IN (SELECT id FROM contacts WHERE isArchived = 0 ...)` must gain `AND ownerId = ?`. |
+| `getContactById` (`:820`) | `findOwned` |
+| `createContact` (`:198`), `bulkCreateContacts` (`:276`) | `buildInsertValues(scope, body, id)` sets `ownerId` from `scope`, replacing the Phase 0 context read |
+| `updateContact` (`:375`), `patchContact` (`:502`), `deleteContact` (`:535`), `restoreContact` (`:553`), `purgeTrashedContact` (`:597`), `updateAvatar` (`:637`) | `requireOwned` first, then the existing `UPDATE` with `AND ownerId = ?` added as well, so the statement is self-describing for the lint |
+| `hardDeleteContact` (`:155-163`, `db.delete(schema.contacts)`; called from `:602` and `:626`) | takes `scope`; the delete gains `eq(contacts.ownerId, scope.ownerId)`. Missed by the first inventory. |
+| `bulkDeleteContacts` (`:329`), `bulkUpdateContacts` (`:350`) | `findManyOwned` first, operate on the returned ids only, return the count actually affected |
+| `purgeExpiredTrash` (`:611`) | unchanged, instance-wide sweep. `// tenant-lint: allow instance sweep` |
+| Doc2Query fire-and-forget (`:239-265` and `:465-479`) | an AI call after the response, then `UPDATE contacts SET searchExpansion = ? WHERE id = ?`, then `embedContact`. Capture `scope` in the closure, run inside `runWithContext`, and add `AND ownerId = ?` to the `UPDATE`. Missed by the first inventory. |
+| `invalidateAllCaches` (`:124`) | becomes owner-scoped: `aiCache.invalidateForOwner(tier, scope.ownerId)` for each owner-keyed tier (2f defines the helper; in 2a call the whole-tier flush and leave a `TODO(2f)`) |
+| `routes/contacts.ts` import path: `normalizeContacts()` (`:234`), `loadNegativeConstraints()` (`:233`), `normalizeContactById` (`:246`) | these are the real cross-owner matching calls during import. Their signatures change in 2e. In 2a, pass `scope` through and add the predicate to these three functions only (the rest of dedupe waits for 2e), so `routes/contacts.ts` can go strict now. |
+| Duplicate probes in `routes/contacts.ts` (`:276`, `:281`, `:373`, `:378`, `:441`, `:446`) | each is `SELECT * FROM contacts WHERE id = ?` hydrating an already-matched pair → `findOwned`. The email probe (`:341-349`, `FROM contact_emails ce JOIN contacts c`) and the phone probe (`:411-416`, which loads every phone row in the database per imported contact) gain `AND c.ownerId = ?`. |
+| Non-stream bulk import tail (`:521-550`) | fires `generateAndStoreBulkEmbeddings` (`:523`) and, after 3 s, `ParallelQueue.process(createdIds, 1, incrementalDedupeCheck)` (`:530-549`). Capture `scope` and run both inside `runWithContext`. Missed by the first inventory. |
+| `POST /api/parse-contact` (`:556`) | AI only (`parseContactRecord`, `:562`), no owned data. Class `instance-read`. Its `recordInvocation` row gets the request scope from the context. |
+| `POST /api/contacts/:id/enrich` (`:704`) | `requireOwned` (`:737`) before calling the strategy; `mergeSearchResult(scope, ...)` (`:755`, changed in 2f) |
+| `GET /api/contacts/:id/score` (`:142`) | route does `requireOwned` then calls `relationshipService.explainScore(id)`, which stays unscoped because the route already checked. Note that `explainScore` also **writes** (`relationshipService.ts:250-252`, `UPDATE contacts SET relationshipScore`); the allow comment `owner-checked by caller` covers that `UPDATE` too. |
+
+**Uploads guard** (`server/middleware/uploads.ts`):
+
+```ts
+export function guardUploads(req, res, next) {
+  const p = req.path;                          // relative to /uploads
+  if (p.startsWith("/logos/")) return next();
+  const m = /^\/u\/([0-9a-f-]{36})\//.exec(p);
+  if (m && m[1] === req.principal.user.id) return next();
+  next(new NotFoundError());
+}
+```
+
+Mounted in `server/app.ts` between `requireAuth` and `express.static`. One
+regex, no database read. Token principals pass too, because they carry a
+user.
+
+Tests: user B fetches user A's avatar URL → 404. User A fetches it → 200.
+Both fetch `/uploads/logos/x.png` → 200. A path outside `/u/` and `/logos/`
+→ 404.
+
+**Isolation tests for this PR:** every route in `server/routes/contacts.ts`,
+plus `/uploads`.
+
+### 2b. Interactions, action items, lists
+
+**Files:** `server/services/interactionService.ts`, `server/services/actionItemService.ts`, `server/services/listService.ts`, `server/routes/interactions.ts`, `server/routes/actionItems.ts`, `server/routes/lists.ts`.
+
+| Function (line) | Change |
+| --------------- | ------ |
+| `interactionService.getTimeline` (`:104`), `createInteraction` (`:141`), `generateBriefing` (`:231`), `promoteGhost` (`:294`), `handleAttachment` (`:310`), `getRelationships` (`:449`) | `requireOwned(scope, contactId)` first |
+| `createInteraction` | insert `ownerId = scope.ownerId`. Two mention paths exist and both need a guard: the AI path (`runMentionExtraction`, `:49-93`) resolves names with `db.select().from(contacts).where(eq(contacts.name, m.name))` (`:60-64`) and writes `interactions.mentions` JSON; add `eq(contacts.ownerId, scope.ownerId)`. The explicit `data-id` path (`:166-177`) inserts client-supplied ids into `interaction_mentions` with `INSERT OR IGNORE` and no check; run the ids through `findManyOwned` first and insert only the owned ones. A ghost created from a mention (`:70-80`) is inserted with `ownerId = scope.ownerId`. |
+| Mention extraction `setTimeout` (`:216-218`) | captures `scope` in the closure and runs inside `runWithContext` |
+| `updateInteraction` (`:398`), `deleteInteraction` (`:430`) | `UPDATE/DELETE interactions WHERE id = ? AND ownerId = ?` (Drizzle: `and(eq(interactions.id, id), eq(interactions.ownerId, scope.ownerId))`), throw 404 on zero changes. `deleteInteraction` unlinks the attachment through `resolveUploadPath` only after the scoped delete succeeded. |
+| `handleAttachment` | file URL through `ownerUploadUrl` (done in Phase 1), insert `ownerId` |
+| `getRelationships` (`:449`) | the mention graph query (`:451`) joins `interaction_mentions` to `contacts` and gains `c.ownerId = ?` |
+| `actionItemService.getAllPending` (`:31`), `getRecentlyCompleted` (`:51`), `getUrgentCount` (`:73`) | `WHERE ai.ownerId = ?` on `action_items` using `idx_action_items_owner_due` and `idx_action_items_owner_done`. The `JOIN contacts c` stays because the payload needs `c.name, c.company, c.avatarUrl, c.themeColor` and the `c.isArchived` filter (`:36-41`, `:56-61`, `:79-82`); only the owner predicate moves to the `action_items` side. |
+| `getByContactId` (`:92`), `create` (`:107`) | `requireOwned(scope, contactId)`, insert `ownerId` |
+| `update` (`:129`), `complete` (`:167`), `delete` (`:190`) | `WHERE id = ? AND ownerId = ?` |
+| `listService.getAllLists` (`:14`) | `WHERE ownerId = ? ORDER BY sortOrder` |
+| `createList` (`:28`) | insert `ownerId` from `scope`. The `SELECT MAX(sortOrder) FROM lists` at `:29-31` gains `WHERE ownerId = ?` so each owner's lists number from zero. |
+| `updateList` (`:46`), `deleteList` (`:82`), `reorderLists` (`:95`) | `WHERE id = ? AND ownerId = ?`. `reorderLists` first checks `SELECT COUNT(*) FROM lists WHERE id IN (...) AND ownerId = ?` equals the input length, else 404 |
+| `getListContacts` (`:109`) | list owned check, then contacts `WHERE c.ownerId = ?` joined through `list_members` |
+| `addMember` (`:119`), `removeMember` (`:138`), `bulkAddMembers` (`:146`) | both the list and every contact must be owned. Two scoped lookups, then the insert or delete. Today `removeMember` checks nothing and `bulkAddMembers` checks the list only. |
+
+The `nextFollowUpAt` triggers on `action_items` (`server/db.ts:633-655`) key
+by `contactId` and are unaffected.
+
+`MCP` routes `GET /api/contacts/action-items`, `GET /api/interactions/search`,
+`GET /api/timeline` move to 2g with the rest of MCP, but their SQL in
+`mcpService` gains `ownerId = ?` here so the file can go strict in one PR.
+
+### 2c. Search: FTS, vector, hybrid, embeddings
+
+**Files:** `server/services/searchService.ts`, `server/services/search/hybridRetrieval.ts`, `server/services/search/localEmbeddings.ts`, `server/services/dedupe/embeddings.ts` (KNN only), `server/services/dedupe/blocking.ts` and `context.ts` (their private KNN statements only), `server/routes/search.ts`, `server/utils/aiCache.ts` (rerank keys).
+
+| Function (line) | Change |
+| --------------- | ------ |
+| `searchService.searchFts` (`:193-208`, the `GET /api/search` path) | MATCH expression becomes `ownerTok:${ownerToken(scope)} AND ("${safeQ}"*)`. It uses `ORDER BY rank` with no weights, so no weight change. The `JOIN contacts c` stays for the row payload and gains `c.ownerId = ?` for the lint and as a second guard. |
+| `searchService.semanticSearchStream` (`:225`), `semanticSearch` (`:413`) | thread `scope`. Capture it before the NDJSON stream starts (`res` is passed at `:228`; `req` is not, so the route passes `scope`). |
+| Candidate hydration: `hydrateCandidates` (`:77`, statement `:88-90`), `hydrateAiMatches` (`:163`, statement `:170-172`), `buildCompressedCandidates` (`:122-126`, one `SELECT ... FROM contacts WHERE id = ?` per candidate) | `findManyOwned` for the first two; the third becomes `findOwned` or a batched `findManyOwned` |
+| `hybridRetrieval.applyHardFilters` (`:176`) | corpus query `WHERE ${ACTIVE_GATE_SQL} AND c.ownerId = ?` (`ACTIVE_GATE_SQL` at `:148`) |
+| `hybridRetrieval.ftsRetrieval(query, preFilterIds, scope)` (`:276`, strategies at `:286-290`) | owner token wrap around each of the three strategies; `BM25_WEIGHTS` already has twelve values from Phase 1 |
+| `hybridRetrieval.vectorRetrieval` (`:329`) and `localEmbeddings.findSearchNeighbors(scope, vec, k, preFilterIds)` (`:227`) | `WHERE embedding MATCH ? AND k = ? AND ownerId = ?`. The `preFilterIds` post-filter (`:237-252`, cap 500 at `:247`) stays for the hard-filter case. |
+| `hybridRetrieval.buildTraitBoosts` (`:369`) | `AND c.ownerId = ?` |
+| `hybridRetrieval.hybridRetrieval(scope, query, rid)` (`:489`) | threads `scope` |
+| `localEmbeddings.getSearchEmbeddingCount(scope)` (`:258`) | `SELECT COUNT(*) FROM search_embeddings WHERE ownerId = ?` (works on a partition key). Keep an unscoped variant for the boot log with the allow comment. |
+| `localEmbeddings.embedContact(contactId)` (`:411`) | reads `ownerId` with the contact row it already loads, passes it to the upsert. Unscoped by design: called from fire-and-forget paths with a contact id that was owner-checked upstream. `// tenant-lint: allow owner-checked by caller` |
+| `backfillSearchEmbeddings` (`:322`), `backfillEmbeddings` (`dedupe/embeddings.ts:373`) | instance sweeps, allow comment. They insert `ownerId` from the joined contact row (Phase 1). 2h makes them iterate per owner. |
+| `dedupe/embeddings.findNearestNeighbors(scope, embedding, limit, excludeId)` (`:270`; `_stmts.knn` defined at `:198-204`) | `AND ownerId = ?` in `_stmts.knn` |
+| `dedupe/blocking.addEmbeddingCandidates` (`:168-175`) | compiles its **own** `knnStmt` with a `MATCH (SELECT embedding ...)` subquery and never calls `_stmts.knn`. It gains `AND ownerId = ?`. Missed by the first inventory. |
+| `dedupe/context.getEmbeddingSimilarity` (`:69-99`, statement `:79-88`) | a third private `contact_embeddings MATCH` statement. Same change. |
+| `rerank` cache key | built in `aiCache.getCachedSearch` and `setCachedSearch` (`server/utils/aiCache.ts:519-533`), called from `searchService.ts` at `:234`, `:333`, `:378`, `:391`, `:417`, `:459`, `:493`. Not in `searchIntel.ts`. Both helpers take `scope` and prefix the key with `${scope.ownerId}::`. `synthesis` (`searchIntel.ts:404-405`) gets the same prefix. `queryParse` (`:555-556`) and `hyde` (`:766-767`) stay shared. |
+| `POST /api/search/semantic` (`routes/search.ts:40`, NDJSON when `Accept: application/x-ndjson` at `:56-63`), `POST /api/search/synthesize` (`:101`, always NDJSON at `:135-158`) | `scope` captured before the stream starts and passed explicitly. Test asserts the `recordInvocation` rows written during the stream carry the right `ownerId`. |
+
+Plan checks (§2i): the FTS query must not show a full scan of `contacts_fts`
+beyond the MATCH; the corpus query must use `idx_contacts_owner_status`.
+
+Isolation tests: A has `Zebulon Quarrington`; B's `GET /api/search`,
+`POST /api/search/semantic` (JSON and NDJSON), and
+`POST /api/search/synthesize` never return A's contact, even when it is the
+only lexical or vector match on the instance.
+
+### 2d. Dashboard, zero-state, relationship route
+
+**Files:** `server/services/dashboardService.ts`, `server/services/zeroStateService.ts`, `server/routes/dashboard.ts`, `server/services/relationshipService.ts` (comments only).
+
+| Function (line) | Change |
+| --------------- | ------ |
+| `dashboardService.getDashboardPayload(scope)` (nine prepared statements at `:57-191`) | every aggregate gains `WHERE ownerId = ?`. Interaction aggregates (`:80`, `:168-178`) use `interactions.ownerId` directly with `idx_interactions_owner_date`. Mention-graph aggregates join to `contacts` with `c.ownerId = ?`. |
+| `dashboardService.getInsight(scope)` (six prepared statements at `:232-295`; cache at `:214` and `:313`) | statements scoped; cache key `dailyInsight` becomes `scope.ownerId`; `maxEntries` raised from 1 to 100 in `aiCache.ts:104-108` |
+| `zeroStateService.getPayload(scope)` (`stmts` at `:35-84`: `urgentCount` `:36`, `atRisk` `:45`, `topGhost` `:58`, `staleCount` `:70`, `pendingDedupeCount` `:79`) | all five statements scoped. The dedupe pending count uses `dedupe_suggestions.ownerId`. |
+| `relationshipService.recomputeAll` (`:289`) | unchanged, sweep. `// tenant-lint: allow instance sweep` |
+| `relationshipService.computeScore(contactId)` (`:261`), `explainScore(contactId)` (`:234`) | unchanged, owner-checked by callers. Allow comments, including on the `UPDATE` at `:250-252`. |
+
+Isolation tests: user B's dashboard totals are zero after user A seeds 50
+contacts. Zero-state for B lists none of A's contacts. B's insight is not A's
+cached insight.
+
+### 2e. Dedupe
+
+The largest sub-phase. Two rules govern it:
+
+1. **A scan runs for one owner over that owner's active contacts only.** Cross-owner duplicates must never be found, suggested, or merged.
+2. **Every merge asserts both contacts share the scope.** The database trigger backs this up, but the service checks first so the error is a 404, not a 500.
+
+**Files:** every file under `server/services/dedupe/`, `server/routes/dedupe/*.ts`.
+
+| Function (line) | Change |
+| --------------- | ------ |
+| `normalization.normalizeContacts(scope, filter)` (`:288-297`; child loads: emails `:302`, phones `:313`, sources `:324`, tags `:337`, interests `:348`) | `WHERE ownerId = ? AND ${filter}`. The five child-table batch loads become `... JOIN contacts c ON c.id = contactId WHERE c.ownerId = ?` so the maps only hold the owner's rows. This is also a memory win on a multi-owner instance. |
+| `normalization.normalizeContactById(scope, id)` (`:387`) | `findOwned` |
+| `blocking.loadNegativeConstraints(scope)` (`:227-261`) | two halves: the `dedupe_exclusions` read (`:255-261`) gains `WHERE ownerId = ?`; the `interaction_mentions` self-join (`:227-237`, co-occurrence constraints) joins `interactions` and gains `i.ownerId = ?`. Missed by the first inventory. |
+| `blocking.buildBlockIndex` (`:59`), `generateCandidatePairs` (`:84`), `isKnownDistinct` (`:287`) | pure functions over the scoped normalized list; no SQL |
+| `blocking.addEmbeddingCandidates(scope, ...)` (`:168-175`) | scoped KNN (2c) |
+| `context.buildPassContext(scope, rid)` (`:12`; contacts `:16-20`, social links `:34-38`, calls `normalizeContacts` `:26` and `loadNegativeConstraints` `:31`) | every statement scoped. `getEmbeddingSimilarity` (`:69-99`) scoped in 2c. |
+| `passes.ts` D1 emails self-join (`:98-109`), D2 all phones (`:127-129`), D3 contacts self-join (`:165-179`), all sources (`:181-183`) | the four whole-table loads gain the owner join. D1 and D2 currently rely on `contactMap.has()` in JavaScript (`:112`, `:132`) to drop rows outside the scan; keep that as well. |
+| `engine.runScan(scope, mode, scanId, rid)` (`:66`) | threads `scope` into everything above. Auto-merge calls the scoped merge. **Full mode** (`:108-110`) runs `DELETE FROM contact_embeddings` and `clearEmbeddingMeta()`, which today wipes every owner's dedupe index; it becomes `DELETE FROM contact_embeddings WHERE ownerId = ?` and a meta delete by `contactId IN (SELECT id FROM contacts WHERE ownerId = ?)`. Deep mode (`:137`) calls `findStaleEmbeddings` and `reEmbedStaleContacts` (`dedupe/embeddings.ts:298-357`), which are instance-wide; scope them by joining `contacts` on `ownerId`. |
+| `engine.incrementalDedupeCheck(contactId, rid)` (`:309`) | loads the contact with its `ownerId` first, builds `scopeForOwnerId(row.ownerId)`, runs the rest scoped inside `runWithContext`. It is a background path with no request. |
+| `engine.seedDuplicates` (`:571`, dev only; inserts at `:584-585`) | inserts `ownerId = scope.ownerId` (replacing the Phase 0 context read) |
+| `suggestions.storeSuggestion`, `storeSuggestions` | insert `ownerId = scope.ownerId` |
+| `suggestions.getPendingSuggestions(scope, limit)`, `getPendingCount(scope)`, `getPendingClusterCount(scope)`, `getSuggestionById(scope, id)`, `getSuggestionForContact(scope, contactId)`, `dismissSuggestion(scope, id, rid)`, `markSuggestionMerged(scope, id, by)`, `getMergeLog(scope, limit)` (`_stmts.getMergeLog` `:133-137`, no `WHERE` today), `undoSoftMerge(scope, id, rid)`, `clearStaleSuggestions(scope)`, `clearAllPendingSuggestions(scope)` (fifteen functions at `:156` to `:625`) | `WHERE ownerId = ?` and `WHERE id = ? AND ownerId = ?` |
+| `suggestions.recordMerge`, `recordMergeUnsafe` (`insertMergeLog` `:127-131`) | insert `ownerId` from `scope` (replacing the Phase 0 lookup) |
+| `merging.mergeContacts(scope, primaryId, duplicateId, ...)`, `softMergeContacts(scope, ...)` (59 prepared statements, Drizzle at `:307` and `:651`) | first statement: `SELECT id FROM contacts WHERE id IN (?, ?) AND ownerId = ?` must return 2 rows, else 404. Then the existing statements run on ids that are known-owned. Merging never inserts a contact: it runs `UPDATE contacts` (`:307-310`, `:656-658`) and `DELETE FROM contacts` (`:332`), re-parents children with `UPDATE ... SET contactId` (`:66-249`, `:410-593`, including `interactions` at `:66-68` and `interaction_mentions` at `:70-79`), and copies list memberships (`:290-297`, `:637-641`). Add `AND ownerId = ?` to the parent `contacts` statements so the lint passes without comments; child statements get `// tenant-lint: allow owner-checked by caller`. The re-parent of `interactions` keeps `ownerId` unchanged, which the mismatch trigger accepts because both contacts share the owner (that is exactly what the up-front check guarantees, so it must run before any child statement). |
+| `clustering.computePrimaryScore` (`:22`; interactions count statement at `:48-50`) | `AND ownerId = ?` |
+| `dedupe/jobQueue.ts` (`scans` `:30`, `processing` `:31`, `canStartScan` `:34`, `createScan` `:45`, `getScan` `:77`, `getActiveScan` `:82`, `isProcessing` `:93`) | `createScan(scope, mode)` stores `ownerId` on the scan. `getScan(scope, id)` returns null when the owner differs. `getActiveScan(scope)` returns only the owner's scan. `canStartScan(scope)`: if any scan is processing, return `{ allowed: false, reason: "busy", yours: <bool> }`. The run lock stays global. A short FIFO (`pending: OwnerId[]`) starts the next owner's scan when the current one completes. |
+| `routes/dedupe/scan.ts` | `POST /scan` (`:13`): `scopeOf(req)`. The `429` today is `res.status(429).json({ error: string })` (`:47-49`) and bypasses the error envelope; it becomes `next(new RateLimitedError("Another user's scan is running. Yours is queued.", { yours: false, queued: true }))` so the body is the standard `{ error: { message, code: "RATE_LIMITED", details } }`. `GET /stream` (`:68`, SSE at `:76-79`, subscribes with `dedupeQueue.on(scanId, handler)` at `:101`): capture `scope` before subscribing, look up the scan with it, 404 on mismatch before the first event; inside the listener use the captured `scope`, never `currentScope()`. `GET /status` (`:119`) and `GET /active` (`:108`): scoped. `POST /api/dev/seed-duplicates` (`:139`): scoped, dev only. |
+| `routes/dedupe/merge.ts` (`:12`, `:34`, `:94`, `:144`), `suggestions.ts` (`:19` to `:115`), `embeddings.ts` (`:14`, `:47`) | scope threaded. `POST /backfill-embeddings` stays an instance operation and becomes `admin` (mounted in Phase 3). `GET /embedding-status` (`:51-57`, a raw `SELECT COUNT(*) FROM contacts`) returns the owner's counts. |
+
+Isolation tests: A and B each import the same two duplicate contacts
+("Jane Doe" with the same email). A scan by A finds one cluster with A's two
+contacts only. B's suggestion list is empty. B calling merge with A's ids
+gets 404. B calling `GET /api/dedupe/status?scanId=<A's>` gets 404. The
+undo endpoint with A's merge-log id from B gets 404. A full-mode scan by A
+leaves B's `contact_embeddings` rows in place (count before equals count
+after).
+
+### 2f. AI Search batches, AI cache, AI stats
+
+**Files:** `server/services/aiSearch/jobQueue.ts`, `server/services/aiSearch/mergeEngine.ts`, `server/routes/aiSearch.ts`, `server/utils/aiCache.ts`, `server/services/aiStatsService.ts`, `server/routes/aiStats.ts`, `server/ai/services/*.ts` (cache keys), `server/services/interactionService.ts` (briefing cache key).
+
+| Function (line) | Change |
+| --------------- | ------ |
+| `jobQueue.createBatch(scope, contacts, strategy)` (`:147`) | stores `ownerId` on the batch. Contacts are `findManyOwned` in the route before this call. |
+| `jobQueue.canStartBatch(scope)` (`:126`) | global lock stays. The cooldown (`COOLDOWN_MS` 5 min at `:99`, `lastBatchCompletedAt` at `:120`) becomes `Map<OwnerId, Date>`. |
+| `jobQueue.processBatch(batchId)` (`:184`) | wraps the whole run in `runWithContext({ scope: scopeForOwnerId(batch.ownerId), ... })` so `recordInvocation` and cache keys attribute correctly. `contactService.getContactById(scope, id)` (`:240`) and `mergeSearchResult(scope, ...)` (`:256`) receive the scope. |
+| `jobQueue.getBatch(scope, id)` (`:324`), `getActiveBatches(scope)` (`:329`) | owner filtered |
+| `mergeEngine.mergeSearchResult(scope, ...)` (`:56`; `UPDATE contacts` at `:274-278` and `:291-293`) | the updates gain `AND ownerId = ?`. `invalidateSearchCache()` (`:298`, `aiCache.ts:539-541`), which flushes the whole `rerank` tier today, becomes `invalidateForOwner("rerank", scope.ownerId)`. |
+| `routes/aiSearch.ts` `POST /api/ai-search` (`:45`) | the `429` at `:75-78` is `res.status(429).json({ error: string })` today; it becomes `next(new RateLimitedError(message, { yours, queued: false, retryAfterSeconds }))`. `GET /status` (`:117`) and `GET /stream` (`:140`, SSE at `:149`): 404 on owner mismatch before the first event; `scope` captured in the closure. |
+| `aiCache` (tiers: `briefing` 24h/100 `:74`, `rerank` 12h/200 `:81`, `synthesis` 12h/100 `:88`, `mentions` 24h/200 `:97`, `dailyInsight` 24h/1 `:104`, `queryParse` 24h/500 `:117`, `hyde` 24h/500 `:131`; prefix invalidation with `startsWith` at `:328`) | new `ownerKey(scope, key)` helper. Tiers `briefing`, `rerank`, `synthesis`, `dailyInsight` keyed with it. `dailyInsight` `maxEntries` 100. `invalidateForOwner(tier, ownerId)` uses the existing prefix invalidation. `queryParse`, `hyde`, and `mentions` (key is `contentHash(text)` at `mentions.ts:33`; the result is a pure function of the note text) stay shared, on the condition in the risks document Q14: confirm the extraction prompt contains no owner data. Batch mode (`batchRefCount` `:166`, `pendingInvalidations` `:167`) stays global; it is a ref count around invalidation timing, not data. |
+| `aiStatsService.recordInvocation` (`:144`, `insertStmt` `:88-91`) | `ownerId` from `currentScopeOrNull()` (Phase 0). Boot jobs now run inside a context per owner where one exists, else `NULL`. 25 call sites: `relationshipIntel` `:81, :134, :220`; `contactParsing` `:242, :317`; `mentions` `:36, :97`; `searchIntel` `:279, :347, :407, :501, :558, :722, :769, :813`; `interactionService` `:257`; `searchService` `:240, :334, :423, :460`; `dashboardService` `:217`; `singlePass` `:49`; `searxng` `:200`; `twoPass` `:90, :167`. None of them change; the context does the work. |
+| `aiStatsService.getSummary(scope)` (`:173`), `getFeed(scope, params)` (`:273`, statements `:297`, `:306`) | `WHERE ownerId = ?` using `idx_ai_inv_owner_created`. Cache tier stats (`cacheTiers`, `:217`) are instance-wide counters and are returned only to admins (the field is omitted for members). |
+| `routes/aiStats.ts` (`:32`, `:52`) | scoped. Phase 3 adds `?scope=all` for admins. |
+| `cleanupOldInvocations` (`:346`) | sweep, unchanged, allow comment |
+
+Isolation tests: A's cached rerank for query Q is a miss for B. A's daily
+insight is not served to B. B's `GET /api/ai-search/status?batchId=<A's>`
+is 404. B's AI stats summary counts only B's invocations.
+
+### 2g. Export, trash, backups, MCP, settings gating
+
+**Files:** `server/services/exportService.ts`, `server/routes/dataLifecycle.ts`, `server/services/mcpService.ts`, `server/routes/mcp.ts`, `server/routes/aiSettings.ts`, `server/routes/auth.ts` (session policy), `server/routes/ai.ts`.
+
+| Route or function (line) | Change |
+| ------------------------ | ------ |
+| `exportService.buildFullExport(scope)` (`:23`; six tables at `:25-36`), `buildContactsCsv(scope)` (`:59`) | every table `WHERE ownerId = ?`. `list_members` through `lists.ownerId`. `buildFullExport` takes no argument today (`dataLifecycle.ts:111`); Phase 3's admin export calls it with `scopeForOwnerId(id)`. |
+| `GET /api/export/json` (`:108`), `GET /api/export/csv` (`:127`) | `scoped`. Filename gains the username. |
+| `GET /api/trash` (`:24`), restore (`:31`), purge (`:72`), bulk-restore (`:53`) | `scoped` (done through `contactService` in 2a, routes just pass scope) |
+| `GET /api/backups` (`:89`), `POST /api/backups` (`:96`) | class `admin`. `requireAdmin` is mounted in Phase 3. |
+| `mcpService.queryContacts(scope, ...)` (`:5`), `getActionItems(scope)` (`:48`), `getTags(scope)` (`:68`; reads `contact_tags` alone at `:70`), `getIndustries(scope)` (`:74`), `searchInteractions(scope, ...)` (`:82`), `getGlobalTimeline(scope, ...)` (`:101`) | `WHERE ownerId = ?`. `getTags` joins `contact_tags` to `contacts`. `queryContacts` (`:13`) has no `deletedAt IS NULL` or `isGhost` filter today and returns trashed and ghost rows; add both filters while the statement is rewritten (note it in the CHANGELOG as a fix). |
+| `routes/mcp.ts` (`:9` to `:82`) | `scopeOf(req)`. The token principal makes this work for MCP clients. `GET /api/contacts/action-items` is reachable since Phase 0. |
+| `PUT /api/settings/ai/*`, `DELETE /api/settings/ai/*`, `POST .../refresh-models` (`aiSettings.ts:63` to `:205`) | class `admin` |
+| `GET /api/settings/ai/` (`:37`), `GET .../models/:capability` (`:45`) | class `instance-read`. Keys are already redacted. |
+| `PUT /api/auth/session-policy` (`auth.ts:266`) | class `admin`. `GET` (`:257`) stays `session-self`. |
+| `GET /api/ai/diagnostics` (`ai.ts:34`), `GET /api/ai/grounding-capacity` (`:87`) | class `admin` (diagnostics reveal provider configuration) |
+| `GET /api/logos/:domain`, `GET /api/avatar/:style`, `GET /api/link-preview/unfurl` | class `instance-read`, no database |
+
+### 2h. Background jobs and boot sweeps
+
+Sweeps that do uniform per-row work stay instance-wide. Sweeps that call AI
+or write attributable rows run per owner inside a context.
+
+| Job (where) | Change |
+| ----------- | ------ |
+| `relationshipService.recomputeAll` (`server.ts:210-217`, hourly) | unchanged |
+| `purgeExpiredTrash` (`server.ts:157-167`, daily) | unchanged |
+| `cleanupOldInvocations` (`server.ts:170-174`, boot only) | unchanged here; Phase 3 moves it into the daily maintenance interval |
+| `startRetroactiveGeocoding` (`server.ts:153`; `geocoding/index.ts:7-25`, `queue.ts` Drizzle updates `:32`, `:121`, `:128`) | unchanged. An address is not user data and the cache is shared by design. The `UPDATE contacts SET lat, lng` by contact id carries `// tenant-lint: allow instance sweep`. |
+| `backfillSearchEmbeddings` (`server.ts:222-253`; `localEmbeddings.ts:322`) | iterate `SELECT DISTINCT ownerId FROM contacts` and run each owner's batch inside `runWithContext`, interleaving owners in rounds of 200 so a huge owner does not delay a small owner's first results |
+| `backfillEmbeddings` (dedupe, provider-billed; `dedupe/embeddings.ts:373`) | same per-owner loop |
+| `refreshStaleModelCaches` (`server.ts:181-188`) | instance, unchanged |
+| `scheduleIncrementalDedupe` (`contactService.ts:62-83`) | already resolves the owner from the contact row (2e) |
+| Mention extraction `setTimeout` (`interactionService.ts:216`) | done in 2b |
+| Doc2Query and bulk-import tails (`contactService.ts:239-265`, `:465-479`; `routes/contacts.ts:521-550`) | done in 2a |
+| Boot backfills in `server/db.ts` (avatar URL `:219-262`, phonetic `:943-965`, legacy follow-up `:679-703`) | `// tenant-lint: allow boot migration`. The follow-up backfill's `action_items` inserts get `ownerId` from the fill trigger (Phase 1 order). |
+
+### 2i. Strict lint, plan checks, and matrix completion
+
+- `package.json`: `"lint:tenant": "node scripts/tenant-lint.mjs --strict \"server/**/*.ts\""`, included in `npm run lint`.
+- `tests/integration/tenancy.queryPlans.test.ts`: seed two owners with 500 contacts each, run `ANALYZE`, then for each statement below run `EXPLAIN QUERY PLAN` and assert the named index appears and no `SCAN <table>` does:
+
+| Statement | Expected index |
+| --------- | -------------- |
+| slim contacts list | `idx_contacts_owner_status` |
+| trash list | `idx_contacts_owner_deleted` |
+| dashboard at-risk | `idx_contacts_owner_lastc` |
+| pending action items | `idx_action_items_owner_due` |
+| lists | `idx_lists_owner_sort` |
+| pending suggestions | `idx_dedupe_sugg_owner_status` |
+| merge log | `idx_merge_log_owner_at` |
+| AI stats feed | `idx_ai_inv_owner_created` |
+| global timeline (MCP) | `idx_interactions_owner_date` |
+| phonetic block load | `idx_contacts_owner_phonetic` |
+| FTS scoped query | `SCAN contacts_fts VIRTUAL TABLE INDEX 0:M...` and nothing else |
+
+- `tenancy.routeManifest.test.ts` gains the assertion `every scoped route has isolated === true`.
+- `tenancy.isolation.test.ts` has zero `it.todo` left.
+- Drop the four single-column owner indexes (`idx_contacts_owner`, `idx_lists_owner`, `idx_ai_invocations_owner`, `idx_dedupe_merge_log_owner`) after the plan tests prove the composites are used. Mechanics: bump `TENANCY_SCHEMA_VERSION` to `2` and add a second step inside the tenancy block that runs when the stored `schema.tenancy` is `1`: four `DROP INDEX IF EXISTS`, then write `2`. Remove the `CREATE INDEX IF NOT EXISTS idx_${table}_owner` line from the ownership loop at the same time, or the next boot recreates them. The migration test gains a case that starts from a version-1 database and asserts the four indexes are gone and the version reads `2`.
+- Run `bench-tenancy` at `10 × 2000` and commit `bench/phase-2.md` next to the Phase 0 baseline.
+
+---
+
+## 2. Acceptance criteria
+
+- [ ] `npm run lint` passes with `tenant-lint --strict "server/**/*.ts"`.
+- [ ] `tenancy.isolation.test.ts`: no `todo`, all green, run with `AUTH_REQUIRED=true` and two accounts.
+- [ ] `tenancy.queryPlans.test.ts` green.
+- [ ] Manifest: every `scoped` route `isolated: true`. Every `admin` route has its class set (the middleware is mounted in Phase 3).
+- [ ] `bench-tenancy` at `10 × 2000`: every per-owner endpoint returns only that owner's rows, and p95 for the slim list is under 40 ms, FTS search under 10 ms, semantic search (mock AI) under 30 ms, dashboard under 60 ms. Numbers recorded in `bench/phase-2.md`.
+- [ ] Single-account instance (local owner or one real account): the full 1.x integration suite still passes with the scope threaded through.
+- [ ] The dedupe scan on a two-owner instance never produces a cross-owner pair. A full-mode scan by one owner leaves the other owner's embeddings intact.
+- [ ] `aiCache` test: owner A's cached rerank for query Q is a miss for owner B.
+- [ ] SSE and NDJSON handlers: `recordInvocation` rows written during a semantic search stream and during a dedupe scan carry the right `ownerId`.
+- [ ] The dedupe and AI Search `429` responses use the standard error envelope with `details.yours`.
+- [ ] CHANGELOG Unreleased has a `Phase 2` block, including the MCP `queryContacts` trash filter fix.
+
+---
+
+## 3. Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| A statement is missed | Three guards: lint (static), matrix (per route), and the mismatch triggers (per row, for writes). A missed **read** is caught by the lint or the matrix. Appendix A section A2 lists the sites the review added. |
+| Signature churn breaks many call sites at once | One domain per PR. TypeScript reports every call site. |
+| `dedupe/merging.ts` has 59 statements and dense logic | Convert it last in 2e. Add `AND ownerId = ?` only to the parent `contacts` statements. Cover with the existing merge tests run as two owners. |
+| Global run locks make one heavy user block another's scan | Accepted for 2.0. The FIFO makes it fair. A per-owner cap is in [11-future.md](11-future.md). |
+| A stream handler reads the context inside a listener and gets the wrong scope | Rule 6, and a test that opens an SSE stream while a different owner's job emits. |
+| Performance regression from the extra predicate | The predicate is an equality on the leading index column. The plan tests prove index use. The benchmark proves latency. |
+
+---
+
+## 4. Contract this phase delivers to Phase 3
+
+- Every route in class `scoped` filters by the caller's scope and returns 404 for foreign ids. The matrix proves it.
+- Every route in class `admin` is classified in the manifest and its handler is scoped or instance-level as required; `requireAdmin` is not yet mounted.
+- `exportService.buildFullExport(scope)` exists, for the admin offboarding export.
+- `aiCache.invalidateForOwner` and `ownerKey` exist.
+- The `429` envelopes for dedupe and AI Search carry `details.yours`.
+- `tenant-lint --strict` covers all of `server/`.
+
+---
+
+## 5. Do not do in this phase
+
+- Do not mount `requireAdmin`. Phase 3 does it and tests it.
+- Do not add admin endpoints, tokens, invitations, or the audit log.
+- Do not change the frontend beyond what a changed response shape strictly requires (the `429` envelope: update `src/api/dedupe.ts:40-43` and `src/api/aiSearch.ts:29` to read `error.error.message` so the UI keeps showing the message). Phase 4 does the rest.
+- Do not bump `package.json` version.
+
+---
+
+## 6. Names used in this phase
+
+| Name | Where |
+| ---- | ----- |
+| `Scope`, `OwnerId`, `scopeOf`, `scopeForUser`, `scopeForOwnerId`, `ownerToken`, `contactToken` | `server/tenancy/scope.ts` |
+| `runWithContext`, `currentScope`, `currentScopeOrNull` | `server/tenancy/requestContext.ts` |
+| `findOwned`, `findOwnedActive`, `findManyOwned`, `requireOwned` | `server/repositories/contactRepository.ts` (added in 2a) |
+| `guardUploads` | `server/middleware/uploads.ts` (added in 2a) |
+| `ownerKey`, `invalidateForOwner` | `server/utils/aiCache.ts` (added in 2f) |
+| `NotFoundError`, `RateLimitedError(message, details)` | `server/utils/AppError.ts` (exist today) |
+| `ROUTE_MANIFEST`, `isolated` | `server/tenancy/routeManifest.ts` |
+| Allow-comment reasons | `instance sweep`, `owner-checked by caller`, `boot migration`, `admin cross-user`, `derived table` |

--- a/docs/multi-tenant-plan/08-phase-3-accounts-admin.md
+++ b/docs/multi-tenant-plan/08-phase-3-accounts-admin.md
@@ -1,0 +1,341 @@
+# 08. Phase 3: Accounts, Roles, and the Admin API
+
+**Goal:** an admin can create, invite, disable, and delete users, and manage
+instance settings. Members get personal API tokens. Roles are enforced on
+every route the manifest marks `admin`. Every admin action is audit-logged.
+One daily maintenance interval sweeps expired and old rows.
+
+**Lands on:** the `v2.0` branch, one PR (or two: accounts, then tokens and
+audit) from `v2.0/phase-3-accounts-admin`.
+
+**Size:** L (about 7 to 10 engineering days).
+
+**Depends on:** Phase 2 (so that every new endpoint is scoped from the start
+and the `admin` class exists in the manifest).
+
+This document is written so that an implementer can work from it alone.
+Every request and response shape is in [13-api-changes.md](13-api-changes.md);
+the ones needed here are repeated in section 2.
+
+---
+
+## 0. Context for the implementer
+
+### 0.1 Repository, commands, and workflow
+
+Same as [05-phase-0-foundations.md](05-phase-0-foundations.md) sections 0.1
+and 0.2. Feature branch into `v2.0`, squash-merge, `npm run lint` and
+`npm test` green, raw vitest summary in the PR, no AI attribution,
+`package.json` stays at `1.5.5`.
+
+### 0.2 State at the start of this phase (after Phase 2)
+
+- Every scoped route filters by owner. The matrix is green. `tenant-lint --strict` covers `server/`.
+- `requireSession` (403 `SESSION_REQUIRED`) and `requireAdmin` (403 `ADMIN_REQUIRED`) exist in `server/middleware/auth.ts`. `requireAdmin` is not mounted anywhere.
+- `attachPrincipal` already resolves `Bearer ctk_...` against `api_tokens` (Phase 1). No endpoint creates tokens.
+- Tables `api_tokens`, `invitations`, `user_settings`, `audit_log` exist and are empty. `users` has `status`, `credentialState`, `mustChangePassword`, `passwordChangedAt`, `disabledAt`, `createdBy`.
+- `exportService.buildFullExport(scope)` exists.
+- `aiEndpointRateLimit` (per IP, 60 per minute on `AI_COST_PATTERNS`) mounts **before** `attachPrincipal` in `server/app.ts`. `req.requestId` is assigned above it (Phase 0). `createRateLimiter({ windowMs, max, name })` (`server/middleware/rateLimit.ts:37-41`) keys by `req.ip` and has no `keyBy` option. `RateLimitedError` (`server/utils/AppError.ts:100-104`) accepts `details`. No `Retry-After` header is set anywhere.
+- `credentialLimiter` (10 per minute per IP) and `setupLimiter` (5 per minute) are module-private in `server/routes/auth.ts:60-71`, with `__resetAuthRateLimits()` at `:74`.
+- `cleanupOldInvocations` runs once at boot (`server.ts:170-174`). The session sweep is boot-only (`server/db.ts:193-198`). There is no daily interval to attach to.
+- `AI_COST_PATTERNS` (`rateLimit.ts:82-91`) covers `/api/search/semantic`, `/api/search/synthesize`, `/api/parse-contact`, `/api/contacts/:id/enrich`, `/api/contacts/:id/briefing`, `/api/ai-search` (exact), `/api/dedupe/backfill-embeddings`, and the `/api/link-preview` prefix. It does not cover `GET /api/dashboard/insight`, `POST /api/dedupe/scan`, or `POST /api/contacts/bulk`, all of which call a provider.
+- `validateBody` with zod schemas lives in `server/utils/validators.ts`. `AppError` subclasses: `NotFoundError`, `ValidationError`, `ConflictError`, `RateLimitedError`, `ServiceUnavailableError`, `UpstreamTimeoutError`.
+- `passwords.ts` exports `hashPassword` and `verifyPassword` (scrypt, self-describing hash).
+- FK behavior that matters for delete: `sessions.userId`, `api_tokens.userId`, `user_settings.userId`, `invitations.invitedBy` are `ON DELETE CASCADE`; `audit_log.actorUserId`, `invitations.acceptedBy`, `users.createdBy` are `ON DELETE SET NULL`; every `ownerId` is `ON DELETE RESTRICT`; `search_embeddings`, `contact_embeddings`, `dedupe_embedding_meta`, and `dedupe_merge_log` have **no** FK to `contacts` or `users` and must be deleted explicitly.
+- FTS triggers delete by `cidTok` (Phase 1). An owner purge of 5,000 contacts with 10,000 emails measured 0.2 s; with the old triggers it took 77 s.
+
+---
+
+## 1. Deliverables
+
+| # | Deliverable | Files |
+| - | ----------- | ----- |
+| 3.1 | `requireAdmin` mounted on every `admin` route. Member gets `403 ADMIN_REQUIRED`. | `server/middleware/auth.ts`, route files |
+| 3.2 | `adminService` and `/api/admin/users/*` | `server/services/adminService.ts` (new), `server/routes/admin.ts` (new) |
+| 3.3 | `invitationService`, `/api/admin/invitations/*`, `POST /api/auth/accept-invitation` | `server/services/invitationService.ts` (new), `server/routes/admin.ts`, `server/routes/auth.ts` |
+| 3.4 | Temporary password and forced change | `adminService`, `server/middleware/auth.ts` (`requirePasswordCurrent`), `server/routes/auth.ts` |
+| 3.5 | Disable and enable. Delete with a data decision. Last-admin and self guards. | `adminService` |
+| 3.6 | `apiTokenService` and `/api/auth/tokens/*` | `server/services/apiTokenService.ts` (new), `server/routes/auth.ts` |
+| 3.7 | Open registration setting and `POST /api/auth/register` | `server/services/settingsService.ts` (key), `server/routes/auth.ts`, `server/routes/admin.ts` |
+| 3.8 | `auditService`, `GET /api/admin/audit`, and the daily maintenance interval | `server/services/auditService.ts` (new), `server.ts` |
+| 3.9 | Per-user rate limiter on AI-cost routes, mounted after `attachPrincipal` | `server/middleware/rateLimit.ts`, `server/app.ts` |
+| 3.10 | Admin views of AI stats and cache tiers | `server/routes/aiStats.ts` |
+| 3.11 | `/api/auth/status` and `/api/auth/me` additions | `server/routes/auth.ts` |
+| 3.12 | Legacy `API_TOKEN` deprecation path | `server/middleware/auth.ts`, docs |
+| 3.13 | Route manifest rows for every new route, `api.admin.test.ts` | `server/tenancy/routeManifest.ts`, `tests/integration/api.admin.test.ts` (new) |
+| 3.14 | CHANGELOG entry | `CHANGELOG.md` |
+
+---
+
+## 2. Tasks
+
+### 3.1 Role enforcement
+
+Mount `requireAdmin` at **route level** (not with `router.use`) on every
+route classed `admin` in the manifest, so the manifest test can see it in
+`route.stack`:
+
+- `server/routes/admin.ts`: every route.
+- `server/routes/dataLifecycle.ts`: `GET /backups`, `POST /backups`.
+- `server/routes/aiSettings.ts`: every `PUT`, `DELETE`, `POST`.
+- `server/routes/auth.ts`: `PUT /session-policy`.
+- `server/routes/ai.ts`: `GET /diagnostics`, `GET /grounding-capacity`.
+- `server/routes/dedupe/embeddings.ts`: `POST /backfill-embeddings`.
+- `GET /api/debug/cache-stats` (dev only, inside `createApp()` since Phase 0).
+
+Test: a member calling each of these gets `403 ADMIN_REQUIRED`. The route
+manifest test asserts every `admin` route's `route.stack` contains a handler
+named `requireAdmin` (the function must be a named function, not an arrow
+assigned to a const, or `handle.name` is empty).
+
+### 3.2 User management
+
+`server/services/adminService.ts`:
+
+```ts
+listUsers(): AdminUserSummary[]
+// id, email, username, displayName, role, status, credentialState, mustChangePassword,
+// createdAt, lastLoginAt, passwordChangedAt, contactCount, sessionCount, tokenCount, isLocalOwner
+getUser(id): { user: AdminUserSummary; counts: { contacts, interactions, lists, files } }
+createUser(actor, input: { email, username, displayName?, role, temporaryPassword? })
+//   validates like authService.createUser (reuse its validators), generates a 20-char password from a
+//   62-char alphabet when omitted, sets mustChangePassword = 1, createdBy = actor.id
+updateUser(actor, id, patch: { role?, displayName? })
+//   role change: LAST_ADMIN guard when demoting the last active admin
+resetPassword(actor, id): { temporaryPassword }
+//   new hash, mustChangePassword = 1, revoke every session and every token for the user
+disableUser(actor, id) / enableUser(actor, id)
+//   disable: status = 'disabled', disabledAt, revoke sessions; tokens stay but are refused while disabled
+//   LAST_ADMIN guard on disable. CANNOT_TARGET_SELF.
+deleteUser(actor, id, decision?: "purge"): { deleted: true, counts } | throws USER_HAS_DATA with counts
+exportUserData(actor, id): FullExport
+//   exportService.buildFullExport(scopeForOwnerId(id)), audit-logged. The one admin read of member data.
+```
+
+`contactCount` uses `idx_contacts_owner_deleted`:
+`SELECT COUNT(*) FROM contacts WHERE ownerId = ? AND deletedAt IS NULL`.
+`files` counts rows with a non-null `fileUrl` under `interactions` plus
+contacts with an `/uploads/` avatar.
+
+`server/routes/admin.ts` is mounted at `/api/admin` in `server/app.ts` after
+`requireAuth`. Every handler uses `validateBody` with zod schemas added to
+`server/utils/validators.ts` and `asyncHandler`.
+
+The local owner account (`credentialState = 'none'`) appears in the list with
+`isLocalOwner: true` and cannot be disabled or deleted while
+`isAuthRequired()` is false. When auth is on it has been converted by setup
+and is a normal admin account.
+
+### 3.3 Invitations
+
+`server/services/invitationService.ts`:
+
+```ts
+createInvitation(actor, { email?, role, expiresInDays = 7 }, origin): { id, link, expiresAt }
+//   secret = 32 random bytes base64url. Store sha256 hex. Return the link once.
+listInvitations(): InvitationSummary[]   // pending, accepted, revoked, expired (derived from expiresAt)
+revokeInvitation(actor, id)
+acceptInvitation({ token, email, username, password, displayName? }): User
+//   hash lookup, check not accepted/revoked/expired, createUser with role from the row,
+//   mark acceptedAt/acceptedBy, create session.
+```
+
+The link format is `${origin}/join?token=${secret}`. `origin` comes from the
+request (`x-forwarded-proto` and `host`, which `trust proxy` in `app.ts`
+already honors), so it is right behind a proxy. The admin copies it. There
+is no mail.
+
+`POST /api/auth/accept-invitation` lives in `server/routes/auth.ts` so it can
+reuse the module-private `credentialLimiter`. It returns `404` for an unknown
+or malformed token (same body for both, no enumeration), `410` with
+`INVITATION_USED`, `INVITATION_EXPIRED`, or `INVITATION_REVOKED` otherwise.
+
+Deleting an admin cascades their pending invitations
+(`invitations.invitedBy ON DELETE CASCADE`). Accepted invitations keep their
+row with `invitedBy` gone. Document this in the admin UI copy (Phase 4).
+
+### 3.4 Temporary password and forced change
+
+- `users.mustChangePassword = 1` is set by `createUser` (admin path) and `resetPassword`.
+- `requirePasswordCurrent` middleware, mounted after `requireAuth` on `/api` and `/uploads`: when `principal.user.mustChangePassword` is set, every path except `/api/auth/*` returns `403 PASSWORD_CHANGE_REQUIRED`. This applies to `session`, `token`, and `legacy-env-token` principals alike, because the temporary password is not a credential the user chose. The `implicit` principal never has the flag.
+- `POST /api/auth/change-password` clears the flag and sets `passwordChangedAt`. For a `mustChangePassword` user, `currentPassword` is still required (it is the temporary one).
+- `GET /api/auth/status` and `/me` return `mustChangePassword`.
+
+### 3.5 Disable and delete
+
+**Disable** is the recommended first step and is reversible. Sessions are
+revoked immediately. The next request from a disabled user's cookie or token
+is refused because `resolveSession` and the token lookup check `status`
+(Phase 1).
+
+**Delete** requires `decision: "purge"` in the body. Without it, the response
+is `409 USER_HAS_DATA` with the counts, so the admin knows what will go. The
+UI shows the export button next to the delete button.
+
+Purge order, in one transaction, for `ownerId = target`:
+
+1. `DELETE FROM search_embeddings WHERE ownerId = ?` and the same for `contact_embeddings` (a `vec0` delete by partition key, verified). Then `DELETE FROM dedupe_embedding_meta WHERE contactId IN (SELECT id FROM contacts WHERE ownerId = ?)`.
+2. `DELETE FROM dedupe_suggestions`, `dedupe_exclusions`, `dedupe_merge_log`, `ai_invocations` `WHERE ownerId = ?`.
+3. `DELETE FROM action_items`, `interactions` `WHERE ownerId = ?` (cascades `interaction_mentions`).
+4. `DELETE FROM lists WHERE ownerId = ?` (cascades `list_members`).
+5. `DELETE FROM contacts WHERE ownerId = ?` (cascades the ten child tables; the FTS triggers remove index rows by `cidTok`).
+6. `DELETE FROM users WHERE id = ?` (cascades `sessions`, `api_tokens`, `user_settings`, and the user's pending `invitations`; `audit_log.actorUserId`, `invitations.acceptedBy`, and `users.createdBy` become `NULL`).
+7. After commit: `fs.rm(ownerUploadDir(target, "avatars"), { recursive: true, force: true })` and the same for `files`.
+
+Guards: cannot delete self (`400 CANNOT_TARGET_SELF`). `409 LAST_ADMIN` when
+the target is the last active admin. Audit log entry with the counts.
+
+Cost: 5,000 contacts with 10,000 emails purged in 0.2 s on the synthetic
+schema with the `cidTok` triggers (measured). The acceptance criterion is
+10,000 contacts in under 2 s on the real schema. If a real database exceeds
+that, chunk step 5 at 1,000 contacts per transaction; a crash between chunks
+leaves a partially deleted but consistent owner that the next purge call
+finishes.
+
+### 3.6 API tokens
+
+`server/services/apiTokenService.ts`:
+
+```ts
+createToken(user, { name, expiresInDays? }): { id, token, tokenPrefix, expiresAt }
+//   token = "ctk_" + base64url(32 random bytes). Store sha256 hex. Return the token once.
+listTokens(userId): TokenSummary[]   // id, name, tokenPrefix, createdAt, lastUsedAt, expiresAt, revokedAt
+revokeToken(userId, id)              // WHERE id = ? AND userId = ?, 404 otherwise
+resolveToken(presented): { user, tokenId } | null
+//   hash lookup, reject revoked/expired, reject disabled user, touch lastUsedAt at most hourly
+```
+
+Routes under `/api/auth/tokens` with `requireSession`. A token cannot create
+or list tokens. Token creation is limited to 10 per hour per user with the
+`keyBy` limiter from 3.9. `attachPrincipal` already calls `resolveToken`
+(Phase 1); move that lookup into this service.
+
+### 3.7 Open registration
+
+- Setting key `auth.registrationOpen` in `app_settings`, default `false`, added to `SETTING_KEYS` in `settingsService.ts`.
+- `GET /api/admin/settings` and `PUT /api/admin/settings` expose it, alongside `sessionTtlDays` (which moves from `/api/auth/session-policy` to here; the old endpoint stays as an alias for one release).
+- `POST /api/auth/register` lives in `server/routes/auth.ts`, uses `credentialLimiter`, and returns `403 REGISTRATION_CLOSED` when the flag is off. Creates a `member`.
+- `/api/auth/status` returns `registrationOpen`.
+
+### 3.8 Audit log and the daily maintenance interval
+
+`server/services/auditService.ts`: `record(actor, action, target?, details?, ip?)`.
+Synchronous insert inside a `try/catch` that logs and never throws into the
+caller.
+
+Events recorded:
+
+| Action | Where |
+| ------ | ----- |
+| `auth.login.success`, `auth.login.failed` (username only, no password), `auth.logout` | `routes/auth.ts` |
+| `auth.password.changed` | `routes/auth.ts` |
+| `auth.token.created`, `auth.token.revoked` | `apiTokenService` |
+| `user.created`, `user.invited`, `user.invitation.accepted`, `user.invitation.revoked` | `adminService`, `invitationService` |
+| `user.role.changed`, `user.disabled`, `user.enabled`, `user.password.reset`, `user.deleted`, `user.exported` | `adminService` |
+| `settings.changed` (key names only) | `routes/aiSettings.ts`, `routes/admin.ts` |
+| `backup.created` | `routes/dataLifecycle.ts` |
+
+`GET /api/admin/audit?limit=&before=` paginates newest first with
+`idx_audit_created`.
+
+**Daily maintenance interval.** Add one `setInterval` in `server.ts`, gated
+by `DISABLE_BACKGROUND_JOBS` like the trash purge, that runs at boot and
+every 24 h:
+
+1. `DELETE FROM audit_log WHERE createdAt < datetime('now', '-90 days')`.
+2. `DELETE FROM sessions WHERE expiresAt <= datetime('now')` (today boot-only).
+3. `DELETE FROM api_tokens WHERE revokedAt IS NOT NULL AND revokedAt < datetime('now', '-30 days')` (expired tokens stay listed as expired; revoked ones age out).
+4. `DELETE FROM invitations WHERE (revokedAt IS NOT NULL OR expiresAt < datetime('now')) AND createdAt < datetime('now', '-30 days')`.
+5. `cleanupOldInvocations()` (move the boot-only call here so it runs daily).
+
+Log one line with the five counts.
+
+### 3.9 Per-user rate limits
+
+- `createRateLimiter` gains `keyBy?: (req) => string | null` (default `req.ip`). A `null` key skips the limiter for that request.
+- A second limiter `aiUserLimiter` keyed by `req.principal?.user.id ?? null` at 30 requests per minute, applied to the same `AI_COST_PATTERNS` plus `GET /api/dashboard/insight` and `POST /api/dedupe/scan` (risks document Q16). It is mounted in `server/app.ts` **after** `attachPrincipal` and `attachRequestContext`, before the routers. The existing per-IP limiter stays where it is (before `attachPrincipal`) and its pattern list gains the same two paths.
+- Both limiters set a `Retry-After` header (seconds until the window resets) on the `429`.
+- The `disableRateLimit` test option disables both.
+- Token creation (3.6) uses `createRateLimiter({ windowMs: 3_600_000, max: 10, keyBy: user id, name: "token creation" })`.
+
+### 3.10 Admin AI stats
+
+`GET /api/ai/stats/summary?scope=all` and `GET /api/ai/stats/feed?scope=all`
+return instance totals and a `byUser` breakdown for admins. Members get
+`403 ADMIN_REQUIRED` for `scope=all`. The `cacheTiers` block is admin-only
+(omitted for members since Phase 2f).
+
+### 3.11 Status and me
+
+`/api/auth/status` adds: `registrationOpen`, `localOwnerPresent`,
+`legacyTokenConfigured`, `user.role` (already present), `user.status`,
+`user.mustChangePassword`. `setupRequired` semantics from Phase 1.
+`existingContacts` becomes `deviceContacts` (count owned by the local owner);
+keep both names in the payload for this release so the current frontend
+works until Phase 4 switches.
+
+`/api/auth/me` adds `role`, `status`, `mustChangePassword`, `credentialState`,
+and `via`.
+
+### 3.12 Legacy token
+
+- Boot warning when `API_TOKEN` or `AUTH_TOKEN` is set (Phase 1 added the once-only warning; keep it).
+- Docs: "Create a personal token in Settings → Account → API tokens and remove `API_TOKEN` from your environment. The environment token maps to the first admin and will be removed in 3.0."
+- `GET /api/auth/status` reports `legacyTokenConfigured: true` so the admin UI can show a banner.
+
+### 3.13 Manifest and tests
+
+Add every new route to `ROUTE_MANIFEST` with its class (appendix B, "Routes
+added in Phase 3"). `tests/integration/api.admin.test.ts` covers the
+acceptance list below with the two-user harness plus a third actor for the
+"two admins" cases.
+
+---
+
+## 3. Acceptance criteria
+
+- [ ] Every `admin` route returns `403 ADMIN_REQUIRED` to a member and `200` to an admin. Tested by iterating the manifest. The manifest test asserts `requireAdmin` in each route's stack.
+- [ ] Create user with temporary password: user signs in, every data route returns `403 PASSWORD_CHANGE_REQUIRED`, change succeeds, data routes work. A token created before the reset is refused with the same code until the change.
+- [ ] Invite: link accepted once. Second acceptance `410 INVITATION_USED`. Expired `410 INVITATION_EXPIRED`. Revoked `410 INVITATION_REVOKED`. Unknown and malformed token both `404` with identical bodies.
+- [ ] Disable: live session refused on next request. Token refused. Enable restores the token; the session stays revoked.
+- [ ] Delete without decision `409 USER_HAS_DATA` with counts. With `purge`: every owned row gone, upload directory gone, FTS and `vec0` rows gone, `dedupe_embedding_meta` rows gone, verified by counting. Other owners' rows untouched (counted before and after). 10,000 contacts purge in under 2 s.
+- [ ] Last admin: demote, disable, delete each return `409 LAST_ADMIN`. Two admins: allowed.
+- [ ] Self: disable and delete return `400 CANNOT_TARGET_SELF`.
+- [ ] Tokens: created token works on `GET /api/contacts` and on every MCP route, is refused on `GET /api/auth/me` (`403 SESSION_REQUIRED`), revoked token `401`, expired token `401`, token of a disabled user `401`. `lastUsedAt` updates at most hourly. Eleventh token in an hour `429`.
+- [ ] Registration: closed by default `403 REGISTRATION_CLOSED`. Open: creates a member, closes again when toggled off.
+- [ ] Audit: each listed action produces one row. `GET /api/admin/audit` paginates. Details never contain a password, token, invitation secret, or provider key (grep the test output for `ctk_` and for the seeded passwords).
+- [ ] Per-user AI rate limit: user A hitting 31 semantic searches in a minute gets `429` with `Retry-After`. User B on the same IP is unaffected. `GET /api/dashboard/insight` and `POST /api/dedupe/scan` are covered.
+- [ ] Daily maintenance interval: with the clock advanced, old audit rows, expired sessions, aged revoked tokens, aged dead invitations, and old invocations are gone. Gated by `DISABLE_BACKGROUND_JOBS`.
+- [ ] Legacy `API_TOKEN` still works, maps to the primary admin, and logs one warning.
+- [ ] `tenant-lint --strict` still green. Route manifest green with the new routes classified.
+- [ ] CHANGELOG Unreleased has a `Phase 3` block.
+
+---
+
+## 4. Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Admin deletes the wrong user | Two-step: `409` with counts first, then `purge`. Export button next to delete. Audit row. The docs recommend disabling for a week before deleting, in line with Immich's 7-day model. |
+| Purge transaction holds the write lock | Measured 0.2 s per 5,000 contacts with the `cidTok` triggers. `busy_timeout` is 5 s. The chunking fallback is described in 3.5. |
+| Invitation link leaked | 7-day expiry, single use, revocable. The secret is only in the link. |
+| Temporary password visible to the admin | By design and documented. The forced change is what makes it acceptable. |
+| A route-level `requireAdmin` is forgotten on a new admin route | The manifest test checks `route.stack` for every `admin` row. |
+
+---
+
+## 5. Contract this phase delivers to Phase 4
+
+- Every endpoint in [13-api-changes.md](13-api-changes.md) sections 3 and 4 exists with the documented shapes.
+- `/api/auth/status` and `/me` carry the new fields; `deviceContacts` and `existingContacts` are both present.
+- The `429` bodies carry `details.yours` (Phase 2) and a `Retry-After` header.
+- `403` codes: `ADMIN_REQUIRED`, `SESSION_REQUIRED`, `ACCOUNT_DISABLED`, `PASSWORD_CHANGE_REQUIRED`, `REGISTRATION_CLOSED`.
+
+---
+
+## 6. Do not do in this phase
+
+- Do not build UI. Phase 4.
+- Do not add reverse-proxy auth, OIDC, or email. [11-future.md](11-future.md).
+- Do not remove `PUT /api/auth/session-policy` or the environment `API_TOKEN`. Both are deprecated, not removed, in 2.0.
+- Do not bump `package.json` version.

--- a/docs/multi-tenant-plan/09-phase-4-frontend.md
+++ b/docs/multi-tenant-plan/09-phase-4-frontend.md
@@ -1,0 +1,324 @@
+# 09. Phase 4: Frontend
+
+**Goal:** the UI knows who is signed in and what they may do. Admins get a
+user-management area. Members get personal tokens. The setup and sign-in
+flows cover invitations, registration, forced password change, and the
+local owner account. Every API module reports errors through one handler so
+the new `403` codes reach the gate from every call site.
+
+**Lands on:** the `v2.0` branch, one PR from `v2.0/phase-4-frontend` (or
+two: auth flows and account settings, then the admin area).
+
+**Size:** L (about 8 to 11 engineering days).
+
+**Depends on:** Phase 3 for the endpoints. UI work can start against the
+API contracts in [13-api-changes.md](13-api-changes.md) once Phase 3 has
+stubbed them.
+
+This document is written so that an implementer can work from it alone.
+Section 0 gives the repository facts, the workflow, and the exact state of
+the frontend files this phase edits.
+
+---
+
+## 0. Context for the implementer
+
+### 0.1 Repository, commands, and workflow
+
+Same as [05-phase-0-foundations.md](05-phase-0-foundations.md) sections 0.1
+and 0.2. The SPA is React 19 with Vite 8, TanStack Query 5, react-router 7,
+Tailwind 4, and `lucide-react`. `npm run dev` serves it. `npm run build`
+must pass. `npm run audit:contrast` (`scripts/contrast-audit.mjs`) checks
+color contrast. Frontend unit tests live in `tests/unit/frontend.*.test.ts`
+(three files today: `commandPalette`, `importers`, `utils`; pure functions,
+no component rendering). Feature branch into `v2.0`, squash-merge, raw
+vitest summary in the PR, no AI attribution, `package.json` stays at
+`1.5.5`.
+
+Design rules from `.agent/STYLE.md`: no `border-*` for sectioning (surface
+shifts instead), pill buttons at `9999px`, `glass-panel` for modals and
+dropdowns, touch targets `p-2 sm:p-1` for buttons and `py-3 sm:py-2.5` for
+list items. The shared primitives `src/components/ui/Modal.tsx` (renders as
+a bottom sheet on mobile, 44 px close target, safe-area inset) and
+`src/components/ui/IconButton.tsx` (44 × 44) carry the mobile rules; use
+them. Write those two rules into `.agent/STYLE.md` in this phase, because
+the file does not state them today.
+
+### 0.2 State at the start of this phase (after Phase 3)
+
+Backend: every endpoint in [13-api-changes.md](13-api-changes.md) exists.
+`/api/auth/status` carries `registrationOpen`, `localOwnerPresent`,
+`legacyTokenConfigured`, `deviceContacts` (and `existingContacts` as an
+alias), `user.role`, `user.status`, `user.mustChangePassword`. `/api/auth/me`
+carries `role`, `status`, `mustChangePassword`, `credentialState`, `via`.
+`403` codes: `ADMIN_REQUIRED`, `SESSION_REQUIRED`, `ACCOUNT_DISABLED`,
+`PASSWORD_CHANGE_REQUIRED`, `REGISTRATION_CLOSED`. `429` bodies are the
+standard envelope `{ error: { message, code: "RATE_LIMITED", details } }`
+with `details.yours` for the dedupe and AI Search locks and a `Retry-After`
+header.
+
+Frontend facts, `v1.5.5` line numbers:
+
+| File | Fact |
+| ---- | ---- |
+| `src/main.tsx` | `queryClient.prefetchQuery({ queryKey: ["contacts"] })` at `:53-64` runs at module load, before `AuthGate` mounts (`:66-76`). On a gated instance it returns 401. |
+| `src/components/auth/AuthGate.tsx` | `GateState = "checking" \| "setup" \| "signin" \| "open" \| "unreachable"` (`:59`). `useAuth()` exposes `user, authRequired, refresh, signOut` (`:32-41`). **`AuthContext.Provider` wraps `children` only when `state === "open"`** (`:155-166`); `SetupWizard` and `SignIn` render outside it. `handleAuthenticated` runs `queryClient.clear()` then `check()` (`:103-107`). The `AUTH_EXPIRED_EVENT` listener (`:124-138`) acts only when `state === "open"`. |
+| `src/api/auth.ts` | `AccountUser` (`:18-26`) has `id, email, username, displayName, role: string, createdAt, lastLoginAt`. `AuthStatus` (`:28-39`) consumes `authRequired, authenticated, setupRequired, hasAccounts, user, existingContacts`. Uses raw `fetch` by design because these endpoints sit outside the gate. |
+| `src/api/client.ts` | `apiFetch()` (`:46`) emits `emitAuthExpired()` on any 401 (`:64-65`). |
+| `src/lib/appEvents.ts` | `emitAuthExpired()` dispatches a bare `Event` named `contrack:auth-expired` (`:54-56`), no payload. |
+| `src/api/*.ts` | **Ten of twelve modules bypass `apiFetch`** and call `fetch` directly: `actionItems` (4 calls), `aiSearch` (1 plus an `EventSource`), `aiStats` (1), `dashboard` (3), `dedupe` (7 plus an `EventSource`), `enrichment` (2), `interactions` (6), `lists` (8), `search` (2), `suggestions` (5). Only `contacts.ts` (18) and `aiSettings.ts` (9) use `apiFetch`. `index.ts` is a barrel that re-exports every module except `auth`, `client`, and `enrichment`. |
+| `src/api/dedupe.ts:40-43`, `src/api/aiSearch.ts:29` | Read the old `429` body as `err.error` (a string). Phase 2 changed the body to the standard envelope; these two were patched to read `error.error.message`. |
+| `src/api/enrichment.ts:67` | Maps **every** `429` to "Grounding quota exhausted for today". Wrong for the per-user limiter. |
+| `src/components/auth/SetupWizard.tsx` | Prop `existingContacts` (`:58-62`). Title "Set up Contrack" (`:127`). Copy at `:129-137` and `:143-147`. Mirrors server validation: `USERNAME_PATTERN` `:20`, `EMAIL_PATTERN` `:21`, `MIN_PASSWORD_LENGTH = 8` `:22`. |
+| `src/components/auth/SignIn.tsx` | `reason?: "expired"` prop (`:19-21`). |
+| `src/components/layout/Sidebar.tsx` | Desktop only (`hidden md:flex` at `src/App.tsx:180`). No identity UI. Settings gear link at `:255-261`. Mobile uses a bottom tab bar at `App.tsx:103`. |
+| `src/views/SettingsView.tsx` | Segments `account, ai-config, ai-search, ai-stats, lists, dedupe, archived, trash` (`:54-83`). Every subview is a **static import** (`:28-36`); `SettingsView` itself is `React.lazy` in `App.tsx:35-37`, so one chunk holds all settings pages. `/settings/ai-config` renders `src/views/ai-settings/AISettingsView.tsx` (`:175-182`). |
+| `src/views/settings/SettingsHome.tsx` | `useAuth()` at `:297`. Account group shown only when `authRequired` (`:308-311`, `:399-415`). Groups: Account, Preferences (`:417`), Intelligence with "AI Configuration" → `/settings/ai-config` (`:518-550`), Organize (`:551`), Data (`:584`). No Administration group. |
+| `src/views/settings/AccountSettings.tsx` | Returns a "No account needed" card when `!authRequired \|\| !user` (`:483-500`). Sections: Profile, Password, **"Signed in on"** (`SessionsCard`, key `["auth","sessions"]`, `:309-381`), **"Session length"** (`SessionLengthCard`, key `["auth","session-policy"]`, `PUT /api/auth/session-policy`, `:383-478`), Session with the sign-out button (`:524-548`). No section is called "Devices". |
+| Backups | **No UI exists.** A case-insensitive grep for `backup` across `src/` hits only a comment in `src/db/schema.ts:61`. |
+| `src/contexts/SessionContext.tsx` | Holds `RecentContext` (`lastContactId`, `:41`, `:82`) and `AISearchSessionContext` (`lastAISearchQuery`, `lastAISearchData`, `lastAISearchPhase`, `:90-94`). There is no `RecentContext.tsx` file. |
+| `src/contexts/DedupeContext.tsx` | Holds `scan, scanId, clusters` (`:59-61`) and a `liveScanId` ref (`:68`). **On mount it calls `GET /api/dedupe/active` and adopts any in-progress scan** (`:73-80`). Toasts the error message on failure (`:145-146`). |
+| `src/contexts/AISearchContext.tsx` | Holds `batch, batchId, isVisible` (`:42-44`). Toasts on failure (`:64-65`). |
+| `src/App.tsx` | `React.lazy` for `MapView, SettingsView, SearchView, DashboardView` (`:32-43`). The three contexts above mount inside `App` (`:395-409`), which is inside `AuthGate` (`main.tsx:70-72`). |
+| `src/views/ai-stats/AIStatsView.tsx` | Renders `CacheTiersAccordion` only when `summary?.cacheTiers` is truthy (`:219-221`). `src/api/aiStats.ts:44` types it. |
+| Role | Nothing in `src/` reads `AccountUser.role`. Every `.role` hit is `contact.role` (job title). |
+| React Query keys | No key includes a user id. The cross-user mitigation is `queryClient.clear()` in `AuthGate` (three call sites). |
+
+---
+
+## 1. Deliverables
+
+| # | Deliverable | Files |
+| - | ----------- | ----- |
+| 4.1 | `useAuth` exposes `role`, `isAdmin`, `mustChangePassword`, `registrationOpen`, `legacyTokenConfigured`, `localOwnerPresent`; the provider wraps every gate state | `src/components/auth/AuthGate.tsx`, `src/api/auth.ts` |
+| 4.2 | New gate states: `password-change`, `join`, `register`; `signin` reasons `expired` and `disabled` | `AuthGate.tsx`, new screens under `src/components/auth/` |
+| 4.3 | Setup wizard wording for the local owner; `deviceContacts` | `src/components/auth/SetupWizard.tsx`, `src/api/auth.ts` |
+| 4.4 | Identity in the sidebar (desktop) and at the top of Settings (mobile), with sign-out | `src/components/layout/Sidebar.tsx`, `src/views/settings/SettingsHome.tsx` |
+| 4.5 | Per-identity query cache reset and post-auth prefetch | `src/main.tsx`, `AuthGate.tsx` |
+| 4.6 | Account settings: API tokens section | `src/views/settings/AccountSettings.tsx`, `src/api/auth.ts` |
+| 4.7 | Admin area: Users, Invitations, Instance, Audit, Backups, lazy-loaded | `src/views/settings/admin/*` (new), `src/views/SettingsView.tsx`, `src/views/settings/SettingsHome.tsx`, `src/api/admin.ts` (new) |
+| 4.8 | Route guard `RequireAdmin` | `src/components/auth/RequireAdmin.tsx` (new) |
+| 4.9 | AI stats: "all users" toggle for admins | `src/views/ai-stats/*`, `src/api/aiStats.ts` |
+| 4.10 | Dedupe and AI Search: queued-behind-another-user states; correct `429` messages | `src/views/dedupe/DedupeView.tsx`, `src/views/ai-search/*`, `src/contexts/DedupeContext.tsx`, `src/contexts/AISearchContext.tsx`, `src/api/dedupe.ts`, `src/api/aiSearch.ts`, `src/api/enrichment.ts` |
+| 4.11 | One shared response handler for every API module; `CustomEvent` reasons; SSE fallback | `src/api/client.ts`, every `src/api/*.ts`, `src/lib/appEvents.ts` |
+| 4.12 | STYLE.md gains the bottom-sheet and 44 px rules; CHANGELOG entry | `.agent/STYLE.md`, `CHANGELOG.md` |
+
+---
+
+## 2. Tasks
+
+### 4.1 `useAuth` and the provider
+
+```ts
+interface AuthContextValue {
+  user: AccountUser | null;      // set for every state except "checking", "unreachable", and pre-setup
+  authRequired: boolean;
+  isAdmin: boolean;              // user?.role === "admin"
+  mustChangePassword: boolean;
+  registrationOpen: boolean;
+  legacyTokenConfigured: boolean;
+  localOwnerPresent: boolean;
+  refresh(): Promise<void>;
+  signOut(): Promise<void>;
+}
+```
+
+`AccountUser` gains `status`, `mustChangePassword`, `credentialState`.
+`AuthStatus` gains the new fields and renames `existingContacts` to
+`deviceContacts` (the server sends both for 2.0; read `deviceContacts`).
+
+Move `AuthContext.Provider` **above** the screen switch in `AuthGate` so
+that `ForcedPasswordChange`, `AcceptInvitation`, and `Register` can call
+`useAuth()` for `refresh()` and `user`. Today the provider wraps only the
+`open` state.
+
+One rule for hiding account UI: **hide it when `!authRequired`.** On an
+auth-off instance the principal is the local owner (`via: "implicit"`), which
+exists only when `authRequired` is false, so the two conditions are the same
+and `via` is not needed on the client. Apply the rule in `AuthGate` (no
+sign-out affordance), `AccountSettings` (`:483`), `SettingsHome` (`:308`),
+and the new sidebar identity.
+
+### 4.2 Gate states
+
+`GateState` becomes
+`"checking" | "setup" | "signin" | "password-change" | "join" | "register" | "open" | "unreachable"`.
+
+- `join`: when `window.location.pathname === "/join"` and `token` is in the query. `AuthGate` mounts **outside** `BrowserRouter` (`src/main.tsx:70-76` wraps `App`, and `App.tsx:2` owns the router), so it cannot use `useLocation` and reads `window.location` directly; `App`'s route table never sees `/join` because the gate renders the screen instead of `App`. Renders `AcceptInvitation` (email, username, password, display name; mirrors the `SetupWizard` validation constants). On success, `history.replaceState({}, "", "/")` and then `handleAuthenticated`. The token lives in component state only while the form is open and is removed from the URL with `history.replaceState` on mount.
+- `register`: reachable from a "Create an account" link on `SignIn` when `registrationOpen`.
+- `password-change`: when `user.mustChangePassword`. Renders `ForcedPasswordChange` (current temporary password, new password twice). On success, `refresh()`.
+- `signin` gains `reason: "expired" | "disabled" | null`. A `403 ACCOUNT_DISABLED` on sign-in or from any call shows "This account is disabled. Ask your administrator."
+
+### 4.3 Setup wizard
+
+When `status.localOwnerPresent` is true, the title is "Secure this instance"
+and the copy says "Contrack has been running without sign-in. Create the
+administrator account. The `<deviceContacts>` contacts already here stay
+with it." The endpoint is the same `POST /api/auth/setup`. Update the
+`existingContacts` references at `src/api/auth.ts:38`, `AuthGate.tsx:65`,
+`:77`, `:149`, and `SetupWizard.tsx:58-62`, `:129-147`.
+
+### 4.4 Identity
+
+Desktop: at the bottom of the sidebar, an avatar built from
+`/api/avatar/initials?seed=<username>` with a tooltip of the display name.
+Click opens a small `glass-panel` menu: display name, role badge, "Account
+settings", "Sign out".
+
+Mobile: the sidebar is `hidden md:flex`, so the same identity row renders at
+the top of `SettingsHome` (the mobile tab bar at `App.tsx:103` is
+unchanged). Hidden when `!authRequired`.
+
+### 4.5 Cache and prefetch
+
+- `main.tsx` stops prefetching `["contacts"]` before the gate resolves. The prefetch moves into `AuthGate` and runs the moment the state becomes `open`. Same result for Cmd+K after the first paint, without a 401 on gated instances.
+- `AuthGate` renders `<AppScope key={user?.id ?? "anon"}>` around `children`. A change of identity remounts the tree, which drops every `useState` that might hold another user's data: `RecentContext` and `AISearchSessionContext` in `SessionContext.tsx`, `DedupeContext`, `AISearchContext`. `queryClient.clear()` stays as well.
+
+### 4.6 Account settings: API tokens
+
+New section "API tokens" between "Signed in on" and "Session length": table
+of name, prefix, created, last used, expires. "Create token" opens a `Modal`
+(name, optional expiry). The token is shown once in a copy field with the
+text "Copy it now. It will not be shown again." Revoke with confirmation.
+React Query key `["auth", "tokens"]`. API functions `fetchTokens`,
+`createToken`, `revokeToken` in `src/api/auth.ts`.
+
+A banner in this section when `legacyTokenConfigured`: "This instance still
+uses the environment `API_TOKEN`. Create a personal token and remove the
+variable."
+
+The "Session length" card moves to the admin Instance view (4.7). For a
+member, the card is gone; for an admin, `AccountSettings` shows a link
+"Session length is set under Administration".
+
+### 4.7 Admin area
+
+`src/api/admin.ts` follows the `aiSettings.ts` pattern (uses the shared
+client, section 4.11) and covers every `/api/admin/*` endpoint in
+[13-api-changes.md](13-api-changes.md) section 4.
+
+Routes under `/settings/admin/*`, all wrapped in `RequireAdmin`, and each
+loaded with `React.lazy` inside `SettingsView` so that members never
+download the admin chunk. `SettingsView` uses static imports today; convert
+the admin routes (and only those) to lazy imports with a `Suspense`
+fallback.
+
+| Route | View | Contents |
+| ----- | ---- | -------- |
+| `/settings/admin/users` | `UsersView` | Table: display name, username, email, role badge, status badge, contacts, last sign-in. "This device" badge for `isLocalOwner`. Row menu: Edit, Reset password, Disable or Enable, Export data, Delete. "Create user" and "Invite" buttons. Mobile: card list. |
+| `/settings/admin/users/new` | `CreateUserModal` | Email, username, display name, role, temporary password (generated, shown once, copy button). |
+| `/settings/admin/invitations` | `InvitationsView` | Pending links with copy and revoke. Accepted and expired below. "New invitation" form: optional email, role, expiry. The link is shown once after creation. Copy: "Deleting the admin who created a pending invitation revokes it." |
+| `/settings/admin/instance` | `InstanceView` | Registration toggle, session length (moved from Account), AI configuration (the existing `AISettingsView` renders here for admins), SearXNG. |
+| `/settings/admin/backups` | `BackupsView` | **New UI**: list from `GET /api/backups`, "Snapshot now" → `POST /api/backups`. Nothing surfaces backups in the UI today. |
+| `/settings/admin/audit` | `AuditView` | Newest first, "Load more" with `nextBefore`, filter by action. |
+
+`SettingsHome` shows an "Administration" group only for admins. The
+"AI Configuration" row moves into that group for admins and becomes a
+read-only "Available AI capabilities" card (from `GET /api/settings/ai/`)
+for members. `/settings/ai-config` becomes a `<Navigate>`: admins to
+`/settings/admin/instance`, members to `/settings`.
+
+Delete user flow: click Delete → call `DELETE` without a decision → modal
+shows the counts from the `409` (contacts, interactions, lists, files) →
+"Export first" button → checkbox "I understand this cannot be undone" →
+Delete with `decision: "purge"`.
+
+Reset password flow: confirm → response shows the temporary password once
+with copy.
+
+### 4.8 `RequireAdmin`
+
+```tsx
+export function RequireAdmin({ children }) {
+  const { isAdmin } = useAuth();
+  if (!isAdmin) return <Navigate to="/settings" replace />;
+  return children;
+}
+```
+
+Server enforcement is the real gate. This only hides UI.
+
+### 4.9 AI stats
+
+Admins get a segmented control "Mine / All users" that adds `?scope=all`.
+"All users" adds a per-user table under the summary. Members see only their
+own. The cache tiers accordion already renders only when the payload
+contains `cacheTiers`; no change there.
+
+### 4.10 Queued states and `429` messages
+
+- Dedupe: when `POST /api/dedupe/scan` returns `429` with `details.yours === false`, the progress overlay shows "Another user's scan is running. Yours will start automatically." and polls `GET /api/dedupe/active` every 3 s until the owner's scan appears, then attaches to its SSE stream. `DedupeContext`'s mount-time adoption of the active scan (`:73-80`) is correct once `GET /api/dedupe/active` is scoped (Phase 2e); keep it.
+- AI Search: cooldown message uses `details.retryAfterSeconds` (or the `Retry-After` header). A global-lock `429` (`details.yours === false`) shows "Another user's enrichment is running. Try again in a moment."
+- `src/api/enrichment.ts:67`: branch on the envelope. `code === "RATE_LIMITED"` → "Too many requests. Try again in `<Retry-After>` seconds." Only a provider-quota error (its own code from the server) keeps the grounding message.
+- `src/api/dedupe.ts` and `src/api/aiSearch.ts` read `error.error.message` and `error.error.details` (the Phase 2 patch already reads the message).
+
+### 4.11 One response handler
+
+Add to `src/api/client.ts`:
+
+```ts
+export async function handleResponse<T>(res: Response): Promise<T>
+// 401 → emitAuthExpired("expired"); 403 ACCOUNT_DISABLED → emitAuthExpired("disabled");
+// 403 PASSWORD_CHANGE_REQUIRED → emitPasswordChangeRequired(); 403 ADMIN_REQUIRED → toast;
+// 429 → ApiError with code, details, retryAfter; other non-2xx → ApiError with the envelope; 2xx → parsed JSON
+```
+
+Then migrate every module that calls `fetch` directly (`actionItems`,
+`aiSearch`, `aiStats`, `dashboard`, `dedupe`, `enrichment`, `interactions`,
+`lists`, `search`, `suggestions`) to `apiFetch` or to `fetch(...).then(handleResponse)`.
+A unit test (`tests/unit/frontend.apiClient.test.ts`) reads every file under
+`src/api/` except `auth.ts` and `client.ts` and fails if it finds a `fetch(`
+call whose result is not passed through `apiFetch` or `handleResponse`.
+
+`src/lib/appEvents.ts`: `emitAuthExpired(reason: "expired" | "disabled")`
+dispatches a `CustomEvent` with `detail: { reason }`. New
+`emitPasswordChangeRequired()` and its event name. `AuthGate` reads
+`event.detail.reason` and flips to `signin` with that reason, or to
+`password-change`.
+
+`EventSource` streams (`dedupe.ts`, `aiSearch.ts`) cannot carry a `403`
+body. On the `error` event, the context calls `fetchAuthStatus()`; if the
+account is no longer authenticated or is disabled, the gate handles it;
+otherwise the context falls back to polling the `status` endpoint every 3 s
+until the job completes.
+
+---
+
+## 3. Acceptance criteria
+
+- [ ] Manual walkthrough recorded in `docs/multi-tenant-plan/bench/ui-walkthrough.md` with screenshots: fresh install with auth off (no account UI shown), turn auth on (setup wizard says "Secure this instance"), invite a member, accept in a private window, member cannot see the Administration group, admin resets the member's password, member is forced to change it, admin disables the member (the member's tab drops to sign-in with the disabled reason), admin exports and deletes the member.
+- [ ] Two browsers signed in as two users: contacts, lists, dashboard, search, dedupe, AI stats show only their own data.
+- [ ] Mobile viewport: every admin table renders as cards, modals as bottom sheets, touch targets 44 px, identity row visible at the top of Settings.
+- [ ] Contrast audit (`npm run audit:contrast`) passes for the new views.
+- [ ] `npm run build` passes. The admin views are in their own chunk (check the Vite build output).
+- [ ] `frontend.apiClient.test.ts` proves no API module bypasses the shared handler.
+- [ ] Existing frontend unit tests pass. New pure-function tests for the invitation link parser and the temporary-password display formatter (`tests/unit/frontend.invite.test.ts`).
+- [ ] `.agent/STYLE.md` states the bottom-sheet and 44 px rules.
+- [ ] CHANGELOG Unreleased has a `Phase 4` block.
+
+---
+
+## 4. Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Remounting on identity change loses in-progress UI state on sign-out | That is the goal. Sign-out is rare and the alternative is stale state from another user. |
+| The `fetch` migration touches every API module | Mechanical. The unit test that scans `src/api/` keeps it from regressing. |
+| Admin views bloat the main bundle | Lazy import per admin route inside `SettingsView`, verified in the build output. |
+| The AI configuration move confuses existing single-user operators | For an admin (which every single-user operator is), the page is one click deeper under Administration, and the old route redirects. |
+
+---
+
+## 5. Contract this phase delivers to Phase 5
+
+- Every flow in the walkthrough works end to end on desktop and mobile.
+- Every API module reports through the shared handler.
+- The identity, admin, and token UI hide correctly on an auth-off instance.
+
+---
+
+## 6. Do not do in this phase
+
+- Do not add per-user server-side preferences UI. `user_settings` stays empty in 2.0 (see [15-additional-v2-features.md](15-additional-v2-features.md)).
+- Do not add instance branding beyond what the features document decides.
+- Do not bump `package.json` version.

--- a/docs/multi-tenant-plan/10-phase-5-hardening-release.md
+++ b/docs/multi-tenant-plan/10-phase-5-hardening-release.md
@@ -1,0 +1,238 @@
+# 10. Phase 5: Hardening, Performance, Docs, and Release
+
+**Goal:** prove the isolation and the performance claims with evidence, close
+the security review, update every document, merge `v2.0` into `main`, and
+publish `2.0.0` with an upgrade guide.
+
+**Lands on:** `v2.0` for the hardening PRs, then `main` through the release
+PR (section 4).
+
+**Size:** M (about 5 to 7 engineering days).
+
+**Depends on:** Phases 1 to 4, and any extras accepted from
+[15-additional-v2-features.md](15-additional-v2-features.md).
+
+This document is written so that an implementer can work from it alone.
+Section 4 is the exact release procedure for this repository.
+
+---
+
+## 0. Context for the implementer
+
+### 0.1 Repository, commands, and workflow
+
+Same as [05-phase-0-foundations.md](05-phase-0-foundations.md) sections 0.1
+and 0.2. Hardening work is one or more PRs into `v2.0`. The release itself
+is one PR from `v2.0` into `main`, merged with a merge commit, then a tag.
+
+### 0.2 How CI and releases work in this repository
+
+From `docs/ci-and-release.md` and `.github/workflows/ci.yml`:
+
+| Event | Tests | Container image | GitHub release |
+| ----- | ----- | --------------- | -------------- |
+| Pull request into `main` or `v2.0` (the branch was added in Phase 0) | yes | no | no |
+| Push to `main` | yes | `latest`, `<sha>` | no |
+| Push of a `v*` tag | yes | `X.Y.Z`, `X.Y` | yes, unless one exists |
+| Manual dispatch | yes | no | no |
+
+`build-and-test` runs `npm run lint`, `npm run format:check`,
+`npm run test:coverage`, and `npm run build` on Node 22. `build-image` runs
+only for `refs/heads/main` and `refs/tags/v*`, builds `linux/amd64` and
+`linux/arm64` on native runners, and `merge-image` asserts both
+architectures are present. `release` runs only on tags and creates a GitHub
+release only if none exists, so hand-written notes must be published before
+the job gets there. `npm run test:contract` (real provider calls, skips
+without keys) is run by hand before a release, per `CONTRIBUTING.md`.
+
+### 0.3 State at the start of this phase
+
+Phases 0 to 4 are merged into `v2.0`. `package.json` still says `1.5.5`.
+`CHANGELOG.md` has one `Unreleased` section with a block per phase.
+`bench/` holds `baseline-phase-0.md`, `tenant-lint-baseline.txt`,
+`rollback-rehearsal.md`, `phase-2.md`, and `ui-walkthrough.md`.
+
+---
+
+## 1. Performance
+
+### 1.1 Benchmarks
+
+Run `scripts/bench-tenancy.ts` at four shapes and record in `bench/phase-5.md`:
+
+| Shape | Purpose |
+| ----- | ------- |
+| `1 × 5000` | single-user regression against the Phase 0 baseline |
+| `10 × 2000` | typical household or small team |
+| `25 × 2000` | upper bound this release targets |
+| `5 × 10000` | heavy per-owner slices, checks index selectivity within an owner |
+
+Targets (p95, laptop-class hardware, mock AI):
+
+| Endpoint or operation | Target |
+| --------------------- | ------ |
+| `GET /api/contacts?view=slim` (2,000 owned) | 40 ms |
+| `GET /api/contacts/:id` | 5 ms |
+| `GET /api/search?q=` | 10 ms |
+| `POST /api/search/semantic` (FTS + vector, no AI) | 30 ms |
+| `GET /api/dashboard` | 60 ms |
+| `GET /api/command-palette/zero-state` | 30 ms |
+| `GET /api/contacts/:id/timeline` | 10 ms |
+| `GET /api/action-items` | 10 ms |
+| `PATCH /api/contacts/:id` (the FTS trigger cost) | 5 ms, and lower than the Phase 0 baseline |
+| dedupe scan, 2,000 contacts, deterministic passes only | 3 s wall |
+| owner purge, 10,000 contacts | 2 s |
+| boot migration on the 10,000-contact fixture, excluding the backup copy | 5 s |
+
+Any endpoint that misses its target gets an `EXPLAIN QUERY PLAN` review and
+either a new composite index or a query rewrite, recorded in the same file.
+
+### 1.2 Concurrency test
+
+`scripts/bench-concurrency.ts`: 10 owners, each running a loop of list, detail,
+search, and one write (create interaction) with 5 ms think time, for 60
+seconds, while one owner runs a dedupe scan and one admin runs a 5,000-contact
+purge midway. Record: p95 per endpoint, count of `503 SQLITE_BUSY`, and the
+longest write wait. `busy_timeout` is 5 s. The expectation is zero 503s. If
+any appear, the fix is to shorten long transactions (the purge and the
+dedupe scan are the candidates), not to raise the timeout.
+
+### 1.3 Index audit
+
+With the benchmark database open, run `PRAGMA index_list` and `sqlite_stat1`
+after `ANALYZE`. Drop any index the plan tests prove unused. Confirm the
+single-column owner indexes were dropped in Phase 2i. Record the final index
+list in `bench/phase-5.md`.
+
+### 1.4 Memory
+
+Measure RSS at `25 × 2000` after a full dedupe scan for one owner and after
+`backfillSearchEmbeddings`. The per-owner `normalizeContacts` maps should hold
+2,000 entries, not 50,000. Record.
+
+---
+
+## 2. Security review
+
+Run the `security-review` skill against the whole `v2.0` diff (`git diff
+main...v2.0`), then walk this checklist by hand:
+
+| Area | Check |
+| ---- | ----- |
+| IDOR | Matrix test green. Spot-check 10 routes by hand with two accounts and copied ids. |
+| Enumeration | Cross-owner ids return `404` with the same body and timing as a nonexistent id. `POST /login` unchanged. `accept-invitation` returns the same `404` for an unknown token and a malformed one. |
+| CSRF | Cookies are `HttpOnly; SameSite=Strict` (`server/middleware/auth.ts:144`). Token endpoints require a session. `POST /api/auth/register` and `accept-invitation` are pre-auth and only create accounts. |
+| Uploads | `guardUploads` regex. Path traversal on `ownerId` rejected by the pattern. `resolveUploadPath` unchanged. Multer `destination` uses the principal, not the body. |
+| Tokens | `ctk_` prefix, 256-bit random, SHA-256 at rest, equality on a hash lookup, shown once. Revoked, expired, disabled all refused. |
+| Invitations | 256-bit random, hashed, 7-day expiry, single use. |
+| Passwords | Temporary passwords 20 chars from a 62-char alphabet (about 119 bits). Forced change. scrypt unchanged. |
+| Sessions | Disable revokes. Reset revokes. Role change does not revoke (the next request reads the fresh row). |
+| Rate limits | Per IP on pre-auth. Per user on AI-cost routes, mounted after `attachPrincipal`. Token creation. `Retry-After` set. |
+| Admin | Every `admin` route has `requireAdmin` at route level (manifest test). Last-admin and self guards. Audit rows. |
+| Local owner | `passwordHash = 'none$'` never verifies (unit test). Forced-auth rule when accounts exist. The local account cannot be disabled or deleted while auth is off. `local` username reserved. |
+| Legacy token | Maps to the primary admin only. Warning at boot. |
+| Streams | Every SSE and NDJSON handler captures the scope in its closure (grep for `currentScope()` inside listeners: none). |
+| Logs | No password, token, invitation secret, or provider key in any log line or audit row (grep the test output for `ctk_` and for the seeded passwords). |
+| Backups | Admin only. The pre-tenancy backup file is documented and its name is logged. |
+| Errors | Production error handler strips stacks (unchanged). New codes documented. |
+
+Findings go into `docs/multi-tenant-plan/bench/security-review.md` with a
+status each.
+
+---
+
+## 3. Documentation
+
+| Document | Change |
+| -------- | ------ |
+| `README.md` | Feature list: "Multi-user with an admin". Quick start: mention that auth off is single-user and how to turn it on. Version 2.0. |
+| `docs/configuration.md` | Rewrite "Authentication & Remote Access": accounts and roles, the local owner account, the forced-auth rule, invitations vs temporary passwords, personal tokens, `API_TOKEN` deprecation, registration setting, forgot-password recovery for a member (admin resets) and for the last admin (the `sqlite3` recipe, which today `NULL`s `ownerId` on four tables and deletes users; rewrite it for eight owned tables and the `contacts_owner_required` trigger, or better, replace it with a documented CLI step). Upgrade section pointing at the guide. |
+| `docs/api-reference.md` | New sections: Admin, Invitations, API tokens, Registration. Updated Authentication section. Error code table including `SESSION_REQUIRED`. Every scoped endpoint gets one sentence: "Returns only the caller's data." |
+| `docs/architecture.md` | New "Tenancy" section: owner column, Scope, request context, FTS owner and contact tokens, `vec0` partition keys, uploads layout, the three guards, the daily maintenance interval. Schema tables updated. |
+| `docs/ci-and-release.md` | `v2.0` in the "what runs when" table while the branch exists; `lint:tenant` and `tenancy:verify` in the test description. |
+| `docs/features/deduplication.md` | Per-user scans and the queue behavior. |
+| `docs/features/ai-search.md` | Per-user cooldown, global lock. |
+| `docs/features/dashboard-pulse.md` | Per-user insight. |
+| `docs/getting-started.md` | New scripts: `tenancy:verify`, `lint:tenant`. |
+| `docs/upgrade-2.0.md` (new) | Backup, what the migration does and its measured durations, how to verify, how to roll back, what changes for auth-off and for token users, the `USER_REQUIRED` and `429` envelope changes for script authors. |
+| `CONTRIBUTING.md` | The Scope rule, the tenant lint, how to add a route (classify it in the manifest, add the isolation test), the `v2.0` branch note removed after release. |
+| `.agent/ARCHITECTURE.md` | Tenancy section, invariants, new tables, new middleware order. |
+| `.agent/PHILOSOPHY.md` | "What This Is NOT": replace "no multi-user sync" with "no cloud sync. Multiple people can share one self-hosted instance, each with a private CRM." |
+| `.agent/TESTING.md` | Three projects, new test files, the route coverage matrix columns for `403 admin` and `404 cross-owner`, the real test count. |
+| `.agent/STATUS.md` | Current state and test count. |
+| `CHANGELOG.md` | The `Unreleased` blocks become the `2.0.0` entry: Breaking, Added, Changed, Fixed, Migration notes. |
+| `.env.example` | `API_TOKEN` block marked deprecated with the replacement. |
+
+### Breaking changes to state plainly
+
+- `API_TOKEN` now acts as the first administrator's identity. Scripts see only that user's contacts. Create personal tokens instead.
+- `GET /api/auth/me` and the other account endpoints return `403 SESSION_REQUIRED` (was `USER_REQUIRED`) when called with a token.
+- The dedupe and AI Search `429` bodies are the standard error envelope, not `{ error: string }`.
+- Auth-off instances get a hidden local owner account. Nothing changes for the person using the instance. `GET /api/auth/status` now reports a `user`.
+- `GET /api/export/*` return the caller's data, not the instance. Admins export other users from the admin API.
+- Members cannot change AI configuration, session policy, or backups.
+- Upload URLs changed shape. Any external tool that stored `/uploads/avatars/...` URLs must re-read the contact.
+- `GET /api/query/contacts` no longer returns trashed or ghost contacts.
+- Search ranking changed when the BM25 weight offset was fixed (Phase 0).
+
+---
+
+## 4. Release procedure
+
+Follow these steps in order. Do not skip the rehearsals.
+
+### 4.1 Freeze and rehearse on `v2.0`
+
+1. Merge `main` into `v2.0` one last time: `git checkout v2.0 && git pull && git merge origin/main`. Resolve conflicts, run `npm run lint && npm test && npm run build`, push.
+2. Run `npm run test:contract` with whatever provider keys are available. Record the summary in `bench/phase-5.md`.
+3. Upgrade rehearsal on a copy of a real 1.5.5 database, both auth modes: boot the `v2.0` build against the copy, capture the boot log with step durations, run `npm run tenancy:verify`, record everything in `bench/upgrade-rehearsal.md`.
+4. Rollback rehearsal on the same copy: restore `backups/pre-tenancy-<stamp>.db`, run `scripts/tenancy-rollback-uploads.mjs`, boot the 1.5.5 image, confirm it works. Record in `bench/rollback-rehearsal.md` (append to the Phase 1 record).
+5. Confirm every acceptance box in this document is ticked and every document in section 3 is updated.
+
+### 4.2 Version and notes PR (into `v2.0`)
+
+1. On a branch from `v2.0`: `npm version major --no-git-tag-version` sets `package.json` and `package-lock.json` to `2.0.0`.
+2. In `CHANGELOG.md`, rename `## [Unreleased]` to `## [2.0.0] — <YYYY-MM-DD>` and regroup the phase blocks under `### Breaking`, `### Added`, `### Changed`, `### Fixed`, `### Migration`. Add a fresh empty `## [Unreleased]` above it.
+3. Write `notes.md` (not committed) from the CHANGELOG entry plus a link to `docs/upgrade-2.0.md`.
+4. Commit `chore(release): v2.0.0`, open the PR into `v2.0`, squash-merge.
+
+### 4.3 Release PR (`v2.0` into `main`)
+
+1. `gh pr create --base main --head v2.0 --title "release: v2.0.0, multi-user Contrack" --body-file <summary>`. The body is a short plain summary: what 2.0 adds, the breaking changes list from section 3, the link to the upgrade guide, and the test evidence.
+2. CI runs on the PR. It must be green.
+3. Merge with a **merge commit**, not a squash: `gh pr merge --merge --subject "release: v2.0.0" <pr>`. Reason: each phase is already one squashed commit on `v2.0`; a merge commit keeps those commits on `main`, so `git bisect` and `git blame` can point at a phase. The repository squashes ordinary PRs, and this is the one deliberate exception.
+4. The push to `main` publishes the `latest` and `<sha>` images. Watch the `merge-image` job confirm both architectures.
+
+### 4.4 Tag and publish
+
+```bash
+git checkout main && git pull
+git tag -a v2.0.0 -m "v2.0.0"
+git push origin v2.0.0
+
+# Publish hand-written notes before the workflow's release job runs, otherwise
+# the job creates a release with an auto-generated commit list.
+gh release create v2.0.0 --title "v2.0.0" --notes-file notes.md --verify-tag
+```
+
+The tag push runs CI again and publishes the `2.0.0` and `2.0` images.
+Confirm the release page shows the hand-written notes.
+
+### 4.5 After the release
+
+1. Keep `v2.0` until the first patch release (`2.0.1`) or for two weeks, whichever is first, as the hotfix source if `main` moves on. Hotfixes for 2.0.x branch from `main` after the merge and follow the normal PR flow.
+2. Then delete the branch (`git push origin --delete v2.0`) and remove `"v2.0"` from `.github/workflows/ci.yml` and from `docs/ci-and-release.md` in a small `chore(ci)` PR.
+3. **Retire the plan folder in that same PR.** `docs/multi-tenant-plan/` was un-ignored and committed on `v2.0` (Phase 0 task 0.0), so it lands on `main` with the release merge. The repository keeps finished project plans under `docs/archive/`, which `.gitignore` excludes (line 51), the same way earlier projects were archived per `.agent/STATUS.md`. Move the folder to `docs/archive/multi-tenant-2.0/` and restore the ignore line for `docs/multi-tenant-plan/`. The `v2.0.0` tag keeps the tracked copy forever, and `docs/upgrade-2.0.md` (which stays in `docs/`) links to it by tag path. `docs/README.md` needs no row for it.
+4. Label incoming issues `2.0`. Watch for migration reports: the boot log step durations and `npm run tenancy:verify` output are the first things to ask for.
+
+---
+
+## 5. Acceptance criteria
+
+- [ ] `bench/phase-5.md` with all four shapes, targets met or deviations explained with a fix, the contract test summary, and the final index list.
+- [ ] `bench-concurrency` with zero 503s at 10 owners, including the scan and the purge.
+- [ ] `security-review.md` with every checklist row closed.
+- [ ] Every document in section 3 updated. Reviewed by reading, not by grep.
+- [ ] `bench/upgrade-rehearsal.md` and the rollback record on the final build, both auth modes.
+- [ ] Release PR merged with a merge commit. `v2.0.0` tagged. Images `2.0.0`, `2.0`, and `latest` published for both architectures. Release notes published by hand.
+- [ ] Post-release cleanup PR opened when the branch is retired.

--- a/docs/multi-tenant-plan/11-future.md
+++ b/docs/multi-tenant-plan/11-future.md
@@ -1,0 +1,117 @@
+# 11. Future Work (Not in 2.0)
+
+Items considered during design and deliberately deferred. Each has the
+decision it depends on and the cost it would add now.
+
+## 1. Shared workspaces
+
+Sharing a CRM between two people (a household, a two-person firm). The
+upgrade path is in [03-architecture.md](03-architecture.md) section 12: a
+`workspaces` table whose personal workspace id equals the user id, so
+`ownerId` becomes a workspace id with no data migration. `Scope` gains
+`actorUserId`. Needs a product decision on per-contact vs per-workspace
+sharing, and a UI for switching workspaces. Not started until someone asks
+for it.
+
+## 2. Reverse-proxy header authentication
+
+Gitea, Miniflux, and Grafana accept a trusted header such as
+`X-WEBAUTH-USER` from an authenticating proxy (Authelia, Authentik, Tailscale
+serve). Requirements recorded from their docs: a trusted-proxy CIDR list is
+mandatory, auto-registration is a separate flag, and local password login can
+be disabled. Implementation is about 150 lines in `attachPrincipal` plus
+three settings. Deferred because the session model works behind any proxy
+already, and the trusted-CIDR mistake is the most common self-hosting
+security hole.
+
+## 3. OIDC
+
+Same shape as above with an OAuth code flow. Depends on a decision to add a
+dependency (`openid-client`). Deferred.
+
+## 4. Per-user AI keys and budgets
+
+Some operators want each member to bring their own provider key or to cap
+each member's spend. `user_settings` is the home for the key, and
+`ai_invocations.ownerId` with `tokenCount` already supports a budget check.
+The provider registry would need to resolve per owner, which changes the
+`instances` cache key from credential fingerprint to owner plus fingerprint.
+Deferred: instance keys paid by the operator is the common case for a home
+server.
+
+## 5. Per-owner job concurrency
+
+The dedupe scan and the AI Search batch keep a global run lock in 2.0. A
+per-owner concurrency cap of 1 with a global cap of 2 would let two users run
+scans at once. The SQLite writer would serialize their writes anyway, and the
+scan is CPU-bound on one thread. Revisit with evidence from the concurrency
+benchmark.
+
+## 6. User quotas
+
+Immich lets the admin cap storage per user. The equivalent here is a maximum
+contact count or upload size per user. The `contacts_owner_required` trigger
+is the place a count check would go, or the service layer. Deferred until
+there is a reason.
+
+## 7. Soft-delete users with a grace period
+
+Immich disables immediately and purges after 7 days. 2.0 has disable and
+purge as separate manual steps. A scheduled purge with `users.deleteAfter`
+is a small addition on top.
+
+## 8. Move all DDL into Drizzle migrations
+
+`server/db.ts` holds most of the schema as idempotent boot DDL. Consolidating
+it into numbered Drizzle migrations would need the snapshot reconciled (it
+lacks `users`, `sessions`, and every `ownerId` column, and it contains the
+three dedupe tables that no migration file creates) and a one-time
+"baseline" migration that is a no-op on existing databases. Worth doing, in
+a release that has no schema change of its own.
+
+## 9. Admin impersonation
+
+Some admin consoles offer "sign in as user" for support. Rejected for this
+product: it contradicts D10 (an admin does not read member data). The export
+endpoint covers offboarding.
+
+## 10. Passkeys and two-factor
+
+WebAuthn on top of the session model. Miniflux added passkeys recently. No
+dependency on tenancy. Separate project.
+
+## 11. Email delivery for invitations and resets
+
+A self-hosted app usually has no mail server. If SMTP settings are ever
+added, invitations and resets can send the link instead of showing it. The
+token flow is the same.
+
+## 12. Per-owner backups and scheduled exports
+
+Backups are whole-database snapshots for the operator. A member who wants a
+scheduled export of their own data can use a personal token and the export
+endpoint from cron. A built-in scheduler is a convenience for later.
+
+## 13. Per-user server-side preferences
+
+Weather unit, list density, and the dedupe threshold preset live in browser
+`localStorage` today. `user_settings` gets its first rows in 2.0 (the per-user notification
+settings in [15-additional-v2-features.md](15-additional-v2-features.md)),
+so these three values can follow with a small settings UI per value.
+
+## 14. sqlite-vec 0.1.10
+
+The 0.1.10 pre-releases add ANN indexes, `ALTER TABLE RENAME` for `vec0`
+tables, and `INSERT OR REPLACE`. The plan pins 0.1.9 and uses copy-rebuilds
+and `DELETE` plus `INSERT`. When 0.1.10 is a stable release, the rebuild
+helpers can use `RENAME` and the dedupe upsert can go back to
+`INSERT OR REPLACE`.
+
+## 15. An FTS external-content table
+
+`contacts_fts` stores its own copy of every indexed column. An
+external-content table keyed by `contacts.rowid` would halve the storage and
+make the trigger delete a rowid lookup with no token column. It needs
+`contacts` to have a stable `INTEGER PRIMARY KEY`, which it does not (its
+key is a `TEXT` UUID), so it is a larger change than `cidTok` and is not
+worth it for 2.0.

--- a/docs/multi-tenant-plan/12-testing-strategy.md
+++ b/docs/multi-tenant-plan/12-testing-strategy.md
@@ -1,0 +1,206 @@
+# 12. Testing Strategy
+
+Isolation cannot be proven by reading code. This document defines the tests
+that prove it, the tools that keep it proven, and the definition of done for
+each phase.
+
+The existing harness is kept: vitest with three projects (`unit` with a
+mocked database, `integration` with a real SQLite database per file in a
+temp `DATA_DIR`, and `contract` against real providers, which `npm test`
+does not run), `createApp()` mounted with supertest,
+`DISABLE_BACKGROUND_JOBS=true`, and AI in mock mode. See
+`tests/integration-setup.ts` and `tests/integration/helpers.ts`. Today:
+41 files, 575 tests, about 16 s.
+
+---
+
+## 1. Test inventory
+
+| File | Phase | Purpose |
+| ---- | ----- | ------- |
+| `tests/unit/tenancy.scope.test.ts` | 0 | `Scope` constructors, `ownerToken` and `contactToken` equal SQLite's expressions, each token is one FTS5 term, `currentScope()` throws `NO_SCOPE` outside a context |
+| `tests/unit/tenancy.requestContext.test.ts` | 0 | context survives `await`, `setTimeout`, `setImmediate`, and `Promise.all`; an `EventEmitter` listener sees the emitter's context, and `null` when the emit comes from outside any context |
+| `tests/integration/tenancy.context.upload.test.ts` | 0 | context intact inside multer `destination` and `filename` and in the handler after `upload.single()` with a text field in the body (multer issue #1111) |
+| `tests/unit/tenantLint.test.ts` | 0 | the lint flags a statement without `ownerId`, honors the allow comment, rejects an unknown reason, and ignores non-owned tables |
+| `tests/unit/search.test.ts` (extended) | 0 | `bm25()` weights are positional and include `UNINDEXED` columns |
+| `tests/unit/ftsTriggers.test.ts` | 1 | snapshot of the generated FTS trigger SQL; every delete uses `MATCH 'cidTok:...'`; `contacts_ai` has the `deletedAt` guard; the `vec0` DDL strings in `db.ts` and the two rebuild helpers are equal |
+| `tests/integration/tenancy.triggerCost.test.ts` | 1 | updating 1,000 contacts on a 5,000-contact database finishes in under 500 ms |
+| `tests/integration/tenancy.routeManifest.test.ts` | 0, 2i, 3 | every route classified. From 2i: every `scoped` route `isolated`. From 3: every `admin` route carries `requireAdmin` |
+| `tests/integration/tenancy.stamping.test.ts` | 0 | every insert into an owned table carries the caller's id |
+| `tests/integration/tenancy.isolation.test.ts` | 0 (skeleton), 2 (filled) | the cross-owner matrix |
+| `tests/integration/tenancy.migration.test.ts` | 1 | 1.5.5-shaped database migrates, verifies, and is idempotent on second boot; `updatedAt` unchanged on every contact and interaction; `embedBatch` never called; the seventeen triggers exist afterward; the backup file opens; the auth-on variant keeps the real account |
+| `tests/integration/tenancy.localOwner.test.ts` | 1 | local owner creation, claim, conversion by setup, forced-auth rule |
+| `tests/integration/tenancy.uploads.test.ts` | 1, 2a | files land under the owner dir, guard returns 404 across owners |
+| `tests/integration/tenancy.search.test.ts` | 2c | FTS owner token, vector partition, hybrid retrieval never returns another owner's contact even when that contact is the best match |
+| `tests/integration/tenancy.dedupe.test.ts` | 2e | identical contacts under two owners never pair, scan state per owner, merge and undo 404 across owners |
+| `tests/integration/tenancy.cache.test.ts` | 2f | `aiCache` owner keys, `dailyInsight` per owner |
+| `tests/integration/tenancy.jobs.test.ts` | 2f, 2h | AI Search batch state per owner, `recordInvocation` attribution inside SSE and background contexts |
+| `tests/integration/tenancy.queryPlans.test.ts` | 2i | `EXPLAIN QUERY PLAN` names the composite index for each hot statement |
+| `tests/integration/api.admin.test.ts` | 3 | user management, invitations, tokens, registration, audit, last-admin and self guards, disable and purge |
+| `tests/integration/api.auth.test.ts` | 1, 3 | updated for the new principal kinds, `requireSession`, status fields |
+| `tests/unit/frontend.invite.test.ts` | 4 | invitation link parsing and token display formatting |
+| `tests/unit/frontend.apiClient.test.ts` | 4 | no file under `src/api/` (except `auth.ts` and `client.ts`) calls `fetch` without the shared response handler |
+| `scripts/bench-tenancy.ts` | 0, 2i, 5 | latency at four data shapes |
+| `scripts/bench-concurrency.ts` | 5 | 10 owners for 60 s, count `503`s |
+
+---
+
+## 2. The two-user harness
+
+`tests/integration/tenancy/helpers.ts`:
+
+```ts
+export interface Actor { user: AccountUser; cookie: string[]; scope: Scope }
+
+export async function createActor(app, overrides?): Promise<Actor>
+// First call: POST /api/auth/setup (admin). Later calls: authService.createUser (member)
+// then POST /api/auth/login. Returns the cookie and a Scope for direct DB assertions.
+
+export async function seedOwner(app, actor, shape: { contacts: number; interactions?: number; lists?: number; actionItems?: number }): Promise<Seeded>
+// Uses the public API so every row is stamped the way production stamps it.
+// Returns every created id grouped by table, plus one uploaded avatar URL and one attachment URL.
+
+export function rowsOwnedBy(table: string, ownerId: string): number
+// SELECT COUNT(*) FROM <table> WHERE ownerId = ?  (for before/after assertions)
+
+export function resetAccounts(): void
+// Deletes every owned table's rows, then sessions, api_tokens, users, then calls ensureLocalOwner().
+// A bare DELETE FROM users fails on ON DELETE RESTRICT once the local owner owns rows.
+```
+
+Every isolation file does:
+
+```ts
+beforeAll(async () => { process.env.AUTH_REQUIRED = "true"; A = await createActor(app); B = await createActor(app, { username: "b" }); seedA = await seedOwner(app, A, { contacts: 20, interactions: 10, lists: 2, actionItems: 5 }); seedB = await seedOwner(app, B, { contacts: 5 }); });
+```
+
+---
+
+## 3. The isolation matrix
+
+For each `scoped` route in `ROUTE_MANIFEST`, one test with this shape:
+
+| Route kind | Test |
+| ---------- | ---- |
+| `GET` by id | B requests A's id → `404`. A requests it → `200`. B requests a random UUID → `404` with an identical body. |
+| `PUT`/`PATCH`/`DELETE` by id | B mutates A's id → `404`, and A's row is unchanged (compare the row before and after). |
+| `POST` child under a parent id (`/contacts/:id/interactions`, `/action-items`, `/lists/:id/members`) | B posts under A's parent → `404`, no row created (count unchanged). |
+| Bulk with an id list | B sends `[A's ids..., B's ids...]` → only B's rows affected. Response count equals B's count. |
+| List endpoints | B's list contains zero ids from `seedA`. A's list contains zero from `seedB`. |
+| Aggregates (`/dashboard`, `/zero-state`, `/action-items/count`, `/dedupe/suggestions/count`, `/ai/stats/summary`) | B's numbers equal what B alone seeded. |
+| Search (`/search`, `/search/semantic`, `/search/synthesize`, `/query/contacts`, `/interactions/search`, `/timeline`) | Seed A with a contact whose name is a unique token (`"Zebulon Quarrington"`). B searches that token → empty. |
+| Streams (SSE and NDJSON) | B opens A's `scanId` or `batchId` → `404` before any event. |
+| Uploads | B fetches A's avatar and attachment URLs → `404`. |
+| Export | B's JSON export contains only B's rows in every table. |
+
+Assertions on the **database**, not only the response: after every mutating
+attempt by B, `rowsOwnedBy` for A is unchanged and the specific row is
+byte-identical.
+
+Enumeration check: the `404` body for a foreign id and for a nonexistent id
+must be identical (`deepEqual` on the JSON minus `requestId`).
+
+---
+
+## 4. Route manifest test
+
+```ts
+const registered = listRoutes(app);            // [{ method, path }]
+const manifest = new Map(ROUTE_MANIFEST.map(r => [`${r.method} ${r.path}`, r]));
+for (const r of registered) expect(manifest.has(key(r)), `unclassified route ${key(r)}`).toBe(true);
+for (const k of manifest.keys()) expect(registered.some(r => key(r) === k), `stale manifest entry ${k}`).toBe(true);
+// Phase 2i:
+for (const r of ROUTE_MANIFEST.filter(r => r.class === "scoped")) expect(r.isolated, `${key(r)} not isolated`).toBe(true);
+// Phase 3:
+for (const r of ROUTE_MANIFEST.filter(r => r.class === "admin")) expect(hasMiddleware(app, r, "requireAdmin")).toBe(true);
+```
+
+`listRoutes` cannot join mount paths from the stack alone: Express 5's
+router (`router@2.2.0`) does not store mount path strings, layers have no
+`regexp`, and `layer.path` is set only after `layer.match(url)`. The helper
+wraps `Router.prototype.use` and `app.use` while `createApp()` runs to record
+each mount path, restores them, then walks `app.router.stack` and joins the
+recorded prefixes with `route.path`. About forty lines, pinned to
+`router@2.2.0` with a comment. It also reports `route.stack` handler names so
+the Phase 3 `requireAdmin` check works, and it recognises the
+`express.static` layer (`layer.name === "serveStatic"`) for the `/uploads`
+row. Rows marked `devOnly` are expected only when `NODE_ENV !== "production"`.
+
+---
+
+## 5. Tenant lint
+
+`scripts/tenant-lint.mjs` is a regex scanner, not a parser. That is
+deliberate: it must be fast, dependency-free, and readable by anyone. It
+looks for SQL keywords followed by an owned table name inside string and
+template literals, and for Drizzle chains on owned schema objects. It checks
+the same literal (or the same chain expression up to the terminating `;`)
+for `ownerId` or `ownerTok`.
+
+False positives are silenced with `// tenant-lint: allow <reason>` on the
+line above the statement. The reason is mandatory and appears in the report.
+Accepted reasons:
+
+- `instance sweep` (background maintenance across owners)
+- `owner-checked by caller` (child statement after a scoped parent lookup)
+- `boot migration`
+- `admin cross-user` (an admin report or the purge)
+- `derived table` (a `contact_*` read by contact id)
+
+`tests/unit/tenantLint.test.ts` runs the scanner on fixture strings.
+
+---
+
+## 6. Query plan tests
+
+For each statement in the Phase 2i table:
+
+```ts
+const plan = sqlite.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(...params).map(r => r.detail).join("\n");
+expect(plan).toMatch(/USING (COVERING )?INDEX idx_contacts_owner_status/);
+expect(plan).not.toMatch(/SCAN contacts\b/);
+```
+
+For the scoped FTS query the plan is `SCAN contacts_fts VIRTUAL TABLE INDEX
+0:M...` (the `MATCH` index) and nothing else; a `SCAN contacts_fts VIRTUAL
+TABLE INDEX 0:` with no `M` means the owner predicate fell out of the
+`MATCH` expression.
+
+The database is seeded with two owners and 500 contacts each before the
+check, then `ANALYZE` runs, because SQLite's planner prefers a scan on an
+empty table.
+
+---
+
+## 7. Migration test
+
+Described in [06-phase-1-storage.md](06-phase-1-storage.md) section 2, task
+1.12. The fixture builder `tests/fixtures/make-v1-database.ts` is the only
+code that encodes the 1.5.5 shape. It is versioned with a comment naming the
+release it reproduces.
+
+---
+
+## 8. Benchmarks
+
+`scripts/bench-tenancy.ts` output is committed under
+`docs/multi-tenant-plan/bench/` at Phase 0 (baseline), Phase 2i, and Phase
+5. Each file records the machine, the Node version, the SQLite version, the
+data shape, and a markdown table of p50 and p95 per endpoint. Regressions
+between files are explained in the same file.
+
+---
+
+## 9. Definition of done per phase
+
+| Phase | Done when |
+| ----- | --------- |
+| 0 | Existing 575 tests green. Manifest test green with every route classified. Stamping test green. Context tests green, including the emitter rule and the multipart case. Lint report committed. Bench baseline committed. CI runs on `v2.0`. |
+| 1 | Migration test green including second boot, `updatedAt` unchanged, no `embedBatch`. `tenancy:verify` passes on a real copied database in both auth modes. Local owner tests green. Upload relocation test green. Trigger cost test green. Day-one `vec0` smoke output in the PR. |
+| 2 | Matrix has zero `todo` and is green. `tenant-lint --strict "server/**"` green. Query plan tests green. Bench at `10 × 2000` meets Phase 2 targets. |
+| 3 | `api.admin.test.ts` green. Manifest asserts `requireAdmin` on every `admin` route. Audit rows asserted. |
+| 4 | UI walkthrough recorded with screenshots. Two-browser manual check. Contrast audit green. Build green. |
+| 5 | Four bench shapes recorded. Concurrency run with zero `503`s. Security checklist closed. Docs updated. Upgrade and rollback rehearsals recorded. Release PR merged with a merge commit, `v2.0.0` tagged, images and notes published. |
+
+"Green" means the raw vitest summary line is pasted into the PR description,
+as `.agent/TESTING.md` section 3 requires.

--- a/docs/multi-tenant-plan/13-api-changes.md
+++ b/docs/multi-tenant-plan/13-api-changes.md
@@ -1,0 +1,135 @@
+# 13. API Changes
+
+Every endpoint added, changed, or removed by this plan. Request and response
+bodies use the existing conventions: JSON, `{ error: { message, code } }` on
+failure, `requestId` in the error envelope.
+
+---
+
+## 1. Error codes added
+
+| Status | `code` | When |
+| ------ | ------ | ---- |
+| 403 | `ADMIN_REQUIRED` | member calls an `admin` route |
+| 403 | `SESSION_REQUIRED` | token or implicit principal calls a `session-self` route. **Replaces `USER_REQUIRED`**, which `requireUser` returns today and `api.auth.test.ts` asserts. Breaking for scripts that match on the code. |
+| 403 | `ACCOUNT_DISABLED` | sign-in or request by a disabled account |
+| 403 | `PASSWORD_CHANGE_REQUIRED` | any data route while `mustChangePassword` |
+| 403 | `REGISTRATION_CLOSED` | `POST /api/auth/register` while closed |
+| 409 | `LAST_ADMIN` | demote, disable, or delete the last active admin |
+| 409 | `USER_HAS_DATA` | delete without `decision: "purge"` |
+| 400 | `CANNOT_TARGET_SELF` | admin disables or deletes their own account |
+| 410 | `INVITATION_USED`, `INVITATION_EXPIRED`, `INVITATION_REVOKED` | accept flow |
+| 429 | `RATE_LIMITED` (existing) with `details.yours: false` and a `Retry-After` header | dedupe or AI Search lock held by another user, or the per-user AI limiter. **The dedupe and AI Search `429` bodies change shape**: today `POST /api/dedupe/scan` and `POST /api/ai-search` return `{ error: string }` and bypass the envelope; in 2.0 they return the standard `{ error: { message, code, details, requestId } }`. |
+| 500 | `NO_SCOPE` | programmer error, a scoped path ran without a scope |
+
+`404 NOT_FOUND` is returned for any owned id that does not belong to the
+caller. This is unchanged in shape and deliberate in semantics.
+
+---
+
+## 2. Changed endpoints
+
+| Endpoint | Change |
+| -------- | ------ |
+| `GET /api/auth/status` | adds `registrationOpen`, `localOwnerPresent`, `legacyTokenConfigured`, `user.role`, `user.status`, `user.mustChangePassword`. `existingContacts` renamed `deviceContacts`; both names are sent in 2.0 and `existingContacts` is removed in 3.0. `setupRequired` is true only when no account has `credentialState = 'password'`. On an auth-off instance `user` is the local owner. |
+| `POST /api/auth/setup` | converts the local owner when present, else creates. Same body. |
+| `GET /api/auth/me` | adds `role`, `status`, `mustChangePassword`, `credentialState`, `via` (`session`, `token`, `implicit`, `legacy-env-token`). Returns `403 SESSION_REQUIRED` (was `USER_REQUIRED`) for a token. |
+| `POST /api/auth/change-password` | clears `mustChangePassword`. |
+| `GET /api/auth/session-policy` | unchanged, aliased by `GET /api/admin/settings`. |
+| `PUT /api/auth/session-policy` | now `admin`. Aliased by `PUT /api/admin/settings`. Removed in 3.0. |
+| Every route in class `scoped` | returns only the caller's rows. Ids from other owners give `404`. |
+| `POST /api/contacts/bulk-delete`, `PUT /api/contacts/bulk-update`, `POST /api/trash/bulk-restore`, `PUT /api/lists/reorder`, `POST /api/lists/:id/members/bulk`, `POST /api/contacts/merge-batch`, `merge-cluster`, `merge-clusters` | operate on the caller's subset of the supplied ids. `count` reflects rows actually affected. `reorder` returns `404` if any id is foreign. |
+| `POST /api/dedupe/scan` | `429` moves into the standard error envelope and gains `details: { yours: boolean, queued: boolean }`. |
+| `GET /api/dedupe/active`, `GET /api/dedupe/status`, `GET /api/dedupe/stream` | scoped to the caller's scans. |
+| `POST /api/ai-search` | per-user cooldown. `429` moves into the standard error envelope and gains `details: { yours, queued: false, retryAfterSeconds }`. |
+| `GET /api/ai-search/status`, `/stream` | scoped. |
+| `GET /api/dashboard/insight` | per user. |
+| `GET /api/ai/stats/summary`, `GET /api/ai/stats/feed` | scoped. `?scope=all` for admins returns instance totals plus `byUser[]`. `cacheTiers` admin-only. |
+| `GET /api/export/json`, `GET /api/export/csv` | caller's data. Filename includes the username. |
+| `GET /api/backups`, `POST /api/backups` | `admin`. |
+| `PUT`, `DELETE`, `POST` under `/api/settings/ai` | `admin`. |
+| `GET /api/ai/diagnostics`, `GET /api/ai/grounding-capacity` | `admin`. |
+| `POST /api/dedupe/backfill-embeddings` | `admin`. |
+| `GET /api/dedupe/embedding-status` | caller's counts. |
+| MCP routes (`/api/query/contacts`, `/api/contacts/action-items`, `/api/tags`, `/api/industries`, `/api/interactions/search`, `/api/timeline`) | scoped to the token's user. `GET /api/contacts/action-items` becomes reachable (it was shadowed by `GET /api/contacts/:id` in 1.5.5). `GET /api/query/contacts` excludes trashed and ghost contacts. |
+| `GET /healthz` | unchanged in the plan; optionally gains `schema` and `vec` versions (features document F4). |
+| Every `429` | carries a `Retry-After` header. |
+| `/uploads/u/<ownerId>/...` | new URL shape. Served only to that owner. `/uploads/logos/*` unchanged. Old flat URLs `404`. |
+| `Authorization: Bearer <API_TOKEN>` | acts as the primary admin. Deprecated. |
+
+---
+
+## 3. New endpoints: authentication
+
+| Method | Path | Class | Body | Response |
+| ------ | ---- | ----- | ---- | -------- |
+| POST | `/api/auth/register` | public, `credentialLimiter` | `{ email, username, password, displayName? }` | `201 { user }` and session cookie. `403 REGISTRATION_CLOSED`. |
+| POST | `/api/auth/accept-invitation` | public, `credentialLimiter` | `{ token, email, username, password, displayName? }` | `201 { user }` and session cookie. `404` unknown token. `410` used, expired, revoked. |
+| GET | `/api/auth/tokens` | session-self | | `{ tokens: [{ id, name, tokenPrefix, createdAt, lastUsedAt, expiresAt, revokedAt }] }` |
+| POST | `/api/auth/tokens` | session-self, 10 per hour | `{ name, expiresInDays? }` | `201 { id, token, tokenPrefix, expiresAt }`. `token` appears only here. |
+| DELETE | `/api/auth/tokens/:id` | session-self | | `{ revoked: true }`. `404` if not the caller's. |
+
+---
+
+## 4. New endpoints: administration
+
+All under `/api/admin`, class `admin`.
+
+| Method | Path | Body | Response |
+| ------ | ---- | ---- | -------- |
+| GET | `/users` | | `{ users: AdminUserSummary[] }` |
+| POST | `/users` | `{ email, username, displayName?, role, temporaryPassword? }` (server generates when omitted) | `201 { user, temporaryPassword }` |
+| GET | `/users/:id` | | `{ user: AdminUserSummary, counts: { contacts, interactions, lists, files } }` |
+| PATCH | `/users/:id` | `{ role?, displayName? }` | `{ user }`. `409 LAST_ADMIN`. |
+| POST | `/users/:id/reset-password` | | `{ temporaryPassword }`. Revokes sessions and tokens. |
+| POST | `/users/:id/disable` | | `{ user }`. `409 LAST_ADMIN`. `400 CANNOT_TARGET_SELF`. |
+| POST | `/users/:id/enable` | | `{ user }` |
+| GET | `/users/:id/export` | | JSON export of that user's data as a download. Audit-logged. |
+| DELETE | `/users/:id` | `{ decision: "purge" }` | `{ deleted: true, counts }`. Without body: `409 USER_HAS_DATA { counts }`. `409 LAST_ADMIN`. `400 CANNOT_TARGET_SELF`. |
+| GET | `/invitations` | | `{ invitations: [{ id, email, role, createdAt, expiresAt, acceptedAt, acceptedBy, revokedAt, invitedBy }] }` |
+| POST | `/invitations` | `{ email?, role, expiresInDays? }` | `201 { id, link, expiresAt }`. `link` appears only here. |
+| DELETE | `/invitations/:id` | | `{ revoked: true }` |
+| GET | `/settings` | | `{ registrationOpen, sessionTtlDays, sessionTtlRange: { min, max, default } }` |
+| PUT | `/settings` | `{ registrationOpen?, sessionTtlDays? }` | same shape |
+| GET | `/audit?limit=&before=` | | `{ entries: [{ id, actor: { id, username } \| null, action, targetType, targetId, details, ip, createdAt }], nextBefore }` |
+
+`AdminUserSummary`:
+
+```json
+{
+  "id": "…", "email": "…", "username": "…", "displayName": "…",
+  "role": "admin", "status": "active", "credentialState": "password",
+  "mustChangePassword": false, "createdAt": "…", "lastLoginAt": "…",
+  "passwordChangedAt": "…", "contactCount": 431, "sessionCount": 2, "tokenCount": 1,
+  "isLocalOwner": false, "isSelf": false
+}
+```
+
+---
+
+## 5. Removed
+
+Nothing is removed in 2.0. `PUT /api/auth/session-policy` and the environment
+`API_TOKEN` are deprecated with a removal note for 3.0. The `AUTH_TOKEN`
+alias is removed if feature F5 in
+[15-additional-v2-features.md](15-additional-v2-features.md) is accepted.
+
+## 5a. Changed shapes, for script authors
+
+| What | 1.5.5 | 2.0 |
+| ---- | ----- | --- |
+| Account endpoint called with a token | `403 { error: { code: "USER_REQUIRED" } }` | `403 { error: { code: "SESSION_REQUIRED" } }` |
+| `POST /api/dedupe/scan` while busy | `429 { error: "<string>" }` | `429 { error: { message, code: "RATE_LIMITED", details: { yours, queued } } }` plus `Retry-After` |
+| `POST /api/ai-search` while busy or cooling down | `429 { error: "<string>" }` | same envelope with `details: { yours, queued, retryAfterSeconds }` |
+| Upload URLs | `/uploads/avatars/<file>`, `/uploads/<file>` | `/uploads/u/<ownerId>/avatars/<file>`, `/uploads/u/<ownerId>/files/<file>` |
+| `GET /api/export/json` | every row on the instance | the caller's rows |
+| `GET /api/query/contacts` | includes trashed and ghost contacts | excludes them |
+
+---
+
+## 6. MCP note
+
+MCP clients configured with the environment `API_TOKEN` keep working and see
+the primary admin's contacts. The documented path is a personal token created
+in Settings → Account → API tokens, used the same way:
+`Authorization: Bearer ctk_...`.

--- a/docs/multi-tenant-plan/14-risks-and-open-questions.md
+++ b/docs/multi-tenant-plan/14-risks-and-open-questions.md
@@ -1,0 +1,143 @@
+# 14. Risks and Open Questions
+
+Decisions in this plan that the project owner should confirm before Phase 1
+starts, the technical questions and their answers, risks that span phases,
+and the effort estimate.
+
+Reviewed against `v1.5.5` on 2026-09-08. Every technical question in section
+2 was tested on the installed engines (Node v22.23.2, SQLite 3.53.2,
+sqlite-vec v0.1.9, Express 5.2.1, multer 2.2.0) or checked against a primary
+source. The scripts and raw numbers are in
+[bench/review-2026-09-08/](bench/review-2026-09-08/README.md). Section 5 lists
+what the review changed in the other documents.
+
+---
+
+## 1. Decisions to confirm
+
+| # | Decision in the plan | Alternative | Why the plan chose this | Review note |
+| - | -------------------- | ----------- | ----------------------- | ----------- |
+| Q1 | An admin cannot read a member's contacts (D10). The only admin read of member data is the offboarding export, which is audit-logged. | Admin sees everything (Paperless model). | Personal CRM. Privacy is a stated core belief. A household admin should not be able to browse a partner's notes by default. | Miniflux and Monica keep user data private. Paperless is the counterexample. No change. |
+| Q2 | Auth-off mode gets a hidden local owner account (D3). | Keep `ownerId IS NULL` as "the local user" and branch every query. | One query shape, one index shape, no `IS NULL` branches, and the setup screen converts the account instead of re-claiming. The cost is one hidden row. | The `passwordHash = 'none$'` value can never verify: `parseHash` rejects it because it has two parts, not six (`server/services/passwords.ts:151-156`). No change. |
+| Q3 | The environment `API_TOKEN` maps to the primary admin and is deprecated (D11). | Refuse it once a second account exists. | Breaking an existing MCP setup on the day a second user is added is a worse surprise than a warning. | `isAuthRequired()` today is `AUTH_REQUIRED === "true" || API_TOKEN is set` (`server/middleware/auth.ts:103-105`). The plan keeps that rule. No change. |
+| Q4 | Ship as `2.0.0` (D15). | `1.7.0` with the token change flagged. | The token semantics change is breaking for scripts. Semver says major. | Two more breaking changes were found: `USER_REQUIRED` becomes `SESSION_REQUIRED`, and the dedupe and AI Search `429` bodies move into the standard error envelope. Both are listed in [13-api-changes.md](13-api-changes.md). Major is confirmed. |
+| Q5 | `interactions`, `action_items`, `dedupe_suggestions`, `dedupe_exclusions` get a denormalized `ownerId` (D5). | Join through `contacts` everywhere. | Covering composite indexes for the global timeline, the action item swimlane, and the suggestion badge. Triggers keep it consistent. | `dedupe_exclusions` has no `id` column. Its primary key is `(contactIdA, contactIdB)`. The fill trigger uses the composite key. No change to the decision. |
+| Q6 | FTS owner token as an indexed column (D6). | `UNINDEXED` column with a post-filter. | Index-level intersection. The post-filter is the fallback if the token approach shows a problem in Phase 2c. | Measured at 50,000 contacts: the indexed token is 3 to 5 times faster than the post-filter and 8 to 10 times faster than a join. It is also faster than today's unfiltered query. Confirmed. |
+| Q7 | Registration closed by default. | Open by default. | Every self-hosted app surveyed defaults closed. | Confirmed against Gitea, Vaultwarden, Miniflux, Immich, Monica docs. |
+| Q8 | Both invitation links and temporary passwords. | One of them. | Different operators want different flows. Both are small. | No change. |
+| Q9 | Global run lock for dedupe scans and AI Search batches with per-owner state and a FIFO. | Per-owner concurrency. | SQLite single writer and provider rate limits. Revisit with the concurrency benchmark. | No change. |
+| Q10 | Members can read the redacted AI settings view. | Members see nothing about AI configuration. | The UI needs to know which capabilities exist to show or hide features. Keys are already redacted. | No change. |
+| Q11 | The `local` username is reserved. A real user cannot register it. | Use a UUID username for the local owner. | A readable name in the admin list. Reservation is one check in `validateUsername`. | `local` passes today's `validateUsername` pattern (`server/services/authService.ts:137`), so the reservation is required, not optional. |
+| Q12 | Rollback of uploads needs a script. | Keep a copy of the flat directory for one release. | Doubling upload storage on every instance for a rollback few will use is a poor trade. The script is 40 lines. | No change. |
+| Q13 | **New.** Fix the BM25 weight offset in Phase 0 as its own small PR. | Preserve today's effective weights forever. | `bm25()` weights are positional and include the `UNINDEXED` `contactId` column at position 0. Today's nine-value string gives `name` 5.0 instead of the intended 10.0 and shifts every other column by one. The FTS v2 rebuild must touch this string anyway. Fixing it in Phase 0 isolates any ranking change from the tenancy work. | Recommended: fix. Alternative: keep the effective weights by writing the twelve-value string `0, 5, 3, 2, 2, 1, 1, 1, 1, 1, 0, 0`. |
+| Q14 | **New.** The `mentions` AI cache tier stays shared across owners. | Prefix it with the owner id. | Its key is a content hash of the note text, and the cached value is the AI's extraction from that text. It is a pure function of the input, like `queryParse` and `hyde`. Sharing saves paid calls. | Confirm during 2f that the extraction prompt contains no owner data. If it does, prefix the key. |
+| Q15 | **New.** Fix the router mount order in Phase 0 so `GET /api/contacts/action-items` is reachable. | Rename the path. | `contactsRouter` mounts before `mcpRouter` (`server/app.ts:202`, `:204`), so `GET /contacts/:id` captures `action-items` as an id and returns 404. The route is dead today. Reordering changes nothing for any working client. | Recommended: mount `mcpRouter` first. |
+| Q16 | **New.** Add `GET /api/dashboard/insight` and `POST /api/dedupe/scan` to the per-user AI limiter. Leave `POST /api/contacts/bulk` out. | Limit only what `AI_COST_PATTERNS` lists today. | Both routes call a provider and are not in the pattern list. The bulk import is rare, already 50 MB-capped, and runs its AI work asynchronously. | Recommended as written. |
+
+---
+
+## 2. Technical questions
+
+Status: **Resolved** means tested or verified from a primary source, and the
+plan documents were updated. **Open** means a small check remains and a
+fallback exists.
+
+### 2.1 Questions from the first draft
+
+| # | Question | Answer | Status |
+| - | -------- | ------ | ------ |
+| T1 | Does sqlite-vec 0.1.9 accept `TEXT PARTITION KEY` with UUID values and filter KNN correctly? | Yes. Verified with script 01: two owners, KNN with `ownerId = ?` returns only that owner's rows. `DELETE`, `SELECT`, and `COUNT(*)` with `WHERE ownerId = ?` also work. The 0.1.6 release post states partition keys may be `TEXT` or `INTEGER`. | Resolved |
+| T2 | Does `ALTER TABLE ... RENAME` work on `vec0` tables? | No, and it is dangerous. On 0.1.9 the statement returns OK but the shadow tables keep their old names, and the next read fails with `no such table: main.<new>_rowids`. Rename support arrives in 0.1.10 (pre-release). The plan's copy-through-memory rebuild is required. Never rename a `vec0` table. | Resolved |
+| T3 | Does Express 5 expose `app.router.stack` or `app._router.stack`? | `app.router` (a lazy getter). `app._router` is undefined. Router layers have no `regexp` property and do not store the mount path string; `layer.path` is set only after `layer.match(url)`. A naive walk yields leaf paths without their prefixes. The route manifest test records mount paths by wrapping `use` during `createApp()`, or probes with `layer.match()`. See [05-phase-0-foundations.md](05-phase-0-foundations.md) task 0.3. | Resolved |
+| T4 | Does `AsyncLocalStorage` context survive multer's `destination` callback and SSE `EventEmitter` listeners? | Multer 2.2.0 `destination` and `filename` keep the context (script 03). `await`, `setTimeout`, and `Promise.all` keep it. An `EventEmitter` listener runs in the context of the code that calls `emit`, not the code that subscribed: an emit from a background job or from outside any context gives the listener that context or `null`. SSE handlers therefore capture `scope` in the closure and never read it from the context inside a listener. One open item: multer issue #1111 reports context loss in the route handler after `upload.single()` when the multipart body also carries text fields. See T25. | Resolved, one sub-item open |
+| T5 | FTS5 `unicode61` with `remove_diacritics` and the owner token. | The table uses the default tokenizer with no options (`server/db.ts:390-392`). `fts5vocab` shows the 33-character token stored as one term. ASCII letters and digits are token characters; `-` is a separator; diacritic removal does not touch ASCII. | Resolved |
+| T6 | Does the FTS `AND` wrapper interact badly with the prefix strategy `"john"* OR "smith"*`? | No. Verified for all three shapes: `ownerTok:X AND ("john smith")`, `ownerTok:X AND ("john"* OR "smith"*)`, and `ownerTok:X AND ({name company} : (john OR acme))`. A wrong owner token returns nothing. | Resolved |
+| T7 | `VACUUM INTO` disk space on a small NAS. | `VACUUM INTO` needs free space for one compacted copy, not two. The output file must not exist. It must run outside any transaction (verified: "cannot VACUUM from within a transaction"). `fs.statfsSync` exists on Node 22. The plan checks free space before the backup and skips with an `error` log below 1.5 × database size. | Resolved |
+| T8 | Does the `vec0` copy step slow the integration suite? | No. The detection is one `sqlite_master` read. On a fresh database the tables are created with the partition key and nothing is copied. When rows exist, 50,000 × 384-dim rows copy in 0.9 s. | Resolved |
+| T9 | Is `hydrateMany` a lint exception or should it carry `ownerId`? | Lint exception with reason `owner-checked by caller`. The parent rows came from a scoped statement. `hydrate` also reads `lists` and `interactions` by contact id (`server/repositories/contactRepository.ts:122-130`, `:381-401`), which are owned tables, so those statements carry the same comment. | Resolved |
+
+### 2.2 Questions found by the review
+
+| # | Question | Answer | Status |
+| - | -------- | ------ | ------ |
+| T10 | Why does the ownership claim take 5 ms per contact, and the purge 15 ms per contact? | Every FTS trigger starts with `DELETE FROM contacts_fts WHERE contactId = ?`. That column is `UNINDEXED`, so SQLite scans the whole virtual table on every contact update and on every child-row insert or delete (4 ms at 40,000 rows). This is a latent cost in 1.5.5, not something the plan introduces. FTS v2 adds an indexed `cidTok` column and every trigger deletes with `MATCH 'cidTok:...'` (0.011 ms). Measured on 5,000 contacts: the claim drops from 27.1 s to 0.23 s, the purge from 77.1 s to 0.2 s. See the data model document, section 5. | Resolved |
+| T11 | Does the claim `UPDATE contacts SET ownerId` have side effects? | Yes. It fires `contacts_auto_updated_at`, which stamps `updatedAt` on every claimed row. `findStaleEmbeddings` compares `contacts.updatedAt` with `dedupe_embedding_meta.embeddedAt`, so the next deep dedupe scan would re-embed the whole corpus through the paid provider. The child backfill fires `interactions_auto_updated_at` the same way. The migration drops the three `_auto_updated_at` triggers and the three `action_items_sync_*` triggers before the claim and the backfill. Sections 4, 5, and 6 of `server/db.ts` recreate them (each begins with `DROP TRIGGER IF EXISTS`). The migration test asserts `updatedAt` is byte-identical before and after. | Resolved |
+| T12 | Can a fresh 2.0 database boot with the plan's section order? | No, as first written. The FTS block (§3) referenced `contacts.ownerId`, and on a fresh database that column was added later, at §9i. The backfill `INSERT ... SELECT` fails at prepare time with `no such column` even with zero rows. The tenancy block now runs before the FTS block, and the three dedupe tables move above it. See the data model document, section 10. | Resolved |
+| T13 | Can `server/db.ts` call `ensureLocalOwner` from `authService`? | No. `authService.ts` imports `sqlite` and `OWNED_TABLES` from `db.ts` and runs `sqlite.prepare` at module top level. An import in the other direction is a cycle that throws at boot. `ensureLocalOwner`, `primaryAdminId`, and `claimUnownedData` live in `server/db.ts` as raw SQL and are exported. `authService` imports them, the same way it imports `OWNED_TABLES` today. | Resolved |
+| T14 | Are the BM25 weights right? | No. `bm25()` weights are positional and include `UNINDEXED` columns. The current nine-value string covers ten columns, so every weight sits one column to the left of its intended target. The v2 table has twelve columns and needs twelve weights, with `0.0` for `ownerTok` and `cidTok`. See Q13 for the decision. | Resolved, decision Q13 |
+| T15 | What does sqlite-vec 0.1.9 refuse on a partitioned table? | `UPDATE` of a partition key column ("not supported yet"). `UPDATE` of another column with an `EXISTS` subquery in the `WHERE` trips the same error (issue #261). `ownerId IN (...)` is not supported (issue #142). `k` has a maximum of 4096 (issue #157). An `INSERT` that omits `ownerId` succeeds with a `NULL` partition and no error. The plan uses `DELETE` plus `INSERT` for every upsert, never `IN` on the partition column, and adds a `NULL`-partition count to the verification queries. | Resolved |
+| T16 | How long does an owner purge hold the write lock? | With today's triggers, 77 s for 5,000 contacts, which would starve every other writer past `busy_timeout`. With the `cidTok` triggers, 0.2 s. The Phase 3 acceptance criterion is 10,000 contacts under 2 s, measured. | Resolved by T10 |
+| T17 | Do the frontend's error paths see the new `403` codes? | Not as first written. Ten of twelve API modules call `fetch` directly and bypass `apiFetch`, so an interceptor in `apiFetch` reaches only `contacts.ts` and `aiSettings.ts`. `emitAuthExpired()` dispatches a bare `Event` with no reason. `EventSource` streams cannot deliver a `403` body. Phase 4 adds one shared response handler used by every module, a `CustomEvent` with a `detail.reason`, and status polling as the SSE fallback. | Resolved |
+| T18 | Why is `GET /api/contacts/action-items` unreachable? | Mount order (Q15). | Resolved, decision Q15 |
+| T19 | Can a per-user rate limiter read the principal? | Not where the AI limiter mounts today. `aiEndpointRateLimit` runs at `server/app.ts:142`, before `attachPrincipal` at `:170` and before `req.requestId` at `:145`. Phase 0 moves the request id above the limiter. Phase 3 mounts the user-keyed limiter after `attachPrincipal`. | Resolved |
+| T20 | Where does the daily audit-log sweep run? | Nowhere today. `cleanupOldInvocations` runs once at boot with no interval (`server.ts:170-174`). Phase 3 adds one daily maintenance interval, gated by `DISABLE_BACKGROUND_JOBS`, that sweeps `audit_log`, expired `sessions`, expired `api_tokens`, expired `invitations`, and old `ai_invocations`. | Resolved |
+| T21 | Does the test harness survive a permanent local owner? | Not as written. `wipeAccounts()` in `api.auth.test.ts` runs `DELETE FROM users`, which fails on `ON DELETE RESTRICT` once the local owner owns rows. Every other integration file runs auth-off and creates rows owned by the local owner. The harness reset becomes: delete owned rows, delete sessions, delete users, then `ensureLocalOwner()`. | Resolved |
+| T22 | Does the fill-trigger template fit every child table? | `dedupe_exclusions` has no `id` column. Its trigger keys on `(contactIdA, contactIdB)`. | Resolved |
+| T23 | Is renaming `USER_REQUIRED` to `SESSION_REQUIRED` free? | No. `requireUser` returns `403 USER_REQUIRED` today and `api.auth.test.ts:379` asserts it. The frontend does not read the code. The rename is a documented breaking change in 2.0. The alternative is to keep the old string under the new middleware name. The plan renames it, because the new name describes the check and 2.0 is a major. | Resolved |
+| T24 | Does `INSERT OR REPLACE` work on a partitioned `vec0` table? | The dedupe upsert uses `INSERT OR REPLACE INTO contact_embeddings` (`server/services/dedupe/embeddings.ts:188`). sqlite-vec lists `INSERT OR REPLACE` support as new in 0.1.10. Phase 1 day one runs it on a partitioned table in the smoke test. Fallback: `DELETE` then `INSERT`, which the search store already does. | Open, one-line fallback |
+| T25 | Does the route handler after `upload.single()` keep the `AsyncLocalStorage` context when the multipart body has text fields? | Multer issue #1111 (open) reports loss on 1.4.4-lts.1 and later in that exact case. Not reproduced here because the upload routes carry no text fields today. The Phase 0 context test includes a multipart request with one text field. Fallback: the two upload handlers read the scope from `req.principal`, which is always present. | Open, one-line fallback |
+| T26 | Does an FK cascade fire the child table's triggers? | Yes (verified). `DELETE FROM contacts` fires `fts_emails_ad` and the others for every cascaded child row. This is why T10 mattered for the purge. With `cidTok` each firing is cheap. | Resolved |
+| T27 | Does the mismatch trigger fire when the parent contact has `NULL` owner? | No. `NEW.ownerId != NULL` is `NULL`, so the `WHEN` clause is false. This is harmless because the invariant triggers are installed after the claim, when no `NULL` owner exists. The verification query for `NULL` owners covers the gap. | Resolved |
+
+---
+
+## 3. Cross-phase risks
+
+| Risk | Impact | Mitigation | Owner |
+| ---- | ------ | ---------- | ----- |
+| A leak ships | Highest. Personal data. | Three structural guards, matrix test, security review, staged release with the upgrade guide recommending a backup. | Phase 2 and 5 |
+| Migration corrupts or loses data | High | `VACUUM INTO` backup, idempotent steps, verification script, migration test on a 1.5.5 fixture and on real copies, rollback rehearsal. | Phase 1 |
+| Migration takes minutes on a large instance | Medium | The claim runs with the FTS and `updatedAt` triggers dropped, then one bulk FTS backfill (233 ms per 50,000 rows). The `vec0` copy is under 1 s per 50,000 rows. Measured, not estimated. Boot logs each step with a duration. | Phase 1 |
+| Migration triggers a paid re-embed | Medium | `updatedAt` is untouched (T11). The migration test asserts `embedBatch` is never called and `updatedAt` is unchanged. | Phase 1 |
+| Performance regression for single-user instances | Medium | Bench baseline in Phase 0, compared at Phase 2i and 5. Indexes proven with plan tests. The `cidTok` trigger fix makes contact updates faster than today. | Phase 5 |
+| `AsyncLocalStorage` overhead | Low | One published HTTP benchmark shows 7 to 10 percent lower throughput on Node 22 and 24. This app spends its time in SQLite and AI calls, not in the router. The Phase 0 baseline measures the real number. | Phase 0 |
+| Purge holds the write lock | Low after T10 | Measured 0.2 s per 5,000 contacts with `cidTok`. If a real database exceeds 2 s per 10,000, chunk the contact delete at 1,000 rows per transaction. | Phase 3 |
+| Scope creep into sharing or SSO | Medium | Both are listed in future work with their prerequisites. | Every phase |
+| Test suite runtime grows | Low | The matrix is one file with two seeded owners. Estimated under 20 s. Today's suite runs 575 tests in 15.5 s. | Phase 2 |
+| The `dedupe/merging.ts` conversion introduces a regression in merge logic | Medium | Existing merge tests run as two owners. Convert last within 2e. | Phase 2e |
+| Operators lose track of the local owner concept | Low | Named "This device" in the UI. Documented in configuration.md. | Phase 4 and 5 |
+| Frontend error mapping misses call sites | Medium | One shared response handler for every API module (T17). A unit test asserts every module imports it. | Phase 4 |
+
+---
+
+## 4. Effort summary
+
+| Phase | Size | Days (one engineer) | Ships | Change from the first draft |
+| ----- | ---- | ------------------- | ----- | --------------------------- |
+| 0 Foundations | M | 5 to 7 | 1.6.0 | +1: route recorder for Express 5, mount-order fix, BM25 offset fix, extra context tests |
+| 1 Storage | L | 7 to 10 | 2.0 branch | +1: `cidTok` triggers, trigger drops around the claim, seed scripts, harness reset |
+| 2 Scoping | XL | 13 to 19 | 2.0 branch | +1: sites found by the review (appendix A, section A2) |
+| 3 Accounts and admin | L | 7 to 10 | 2.0 branch | daily maintenance interval replaces the assumed sweep, no net change |
+| 4 Frontend | L | 8 to 11 | 2.0 branch | +1: shared response handler, lazy settings routes, mobile identity |
+| 5 Hardening and release | M | 5 to 7 | 2.0.0 | none |
+| **Total** | | **45 to 64** | | |
+
+Phases 3 and 4 can overlap once Phase 3 has stubbed the endpoints. Phase 2's
+nine sub-phases are sequential because each converts shared files.
+
+---
+
+## 5. What the review changed
+
+The review compared every document against the `v1.5.5` source, ran the
+scripts in `bench/review-2026-09-08/`, and checked the external claims
+against their sources. Corrections landed in the documents themselves. The
+ones that changed the design:
+
+1. **FTS v2 gets a second indexed token, `cidTok`** (T10). Data model §5, architecture §6.
+2. **The tenancy block runs before the FTS block** and drops the FTS, `updatedAt`, and `action_items_sync_*` triggers around the claim (T11, T12). Data model §10.
+3. **The tenancy helpers live in `server/db.ts`**, not `authService` (T13). Architecture §14.
+4. **Twelve BM25 weights** and a decision on the offset (T14, Q13). Data model §5.4, Phase 0 task 0.10.
+5. **`VACUUM INTO` runs before the transaction opens** (T7). Data model §1.
+6. **Route manifest walker records mount paths** (T3). Phase 0 task 0.3, testing strategy §4.
+7. **SSE handlers capture the scope in the closure** (T4). Phase 2 recipe.
+8. **Per-user limiter mounts after `attachPrincipal`**, request id moves above the AI limiter (T19). Phase 0, Phase 3.9.
+9. **One daily maintenance interval** (T20). Phase 3.8.
+10. **Shared frontend response handler, `CustomEvent` reason, SSE polling fallback** (T17). Phase 4.11.
+11. **Purge and claim targets are measured numbers** (T10, T16). Phase 1 and Phase 3 acceptance.
+12. **Mount order fix** so the MCP action-items route is reachable (Q15). Phase 0.
+
+Counts corrected: 575 tests in 41 files (not 316), 49 tests in
+`api.auth.test.ts` (not 50), eleven FTS triggers (not twelve), 25
+`recordInvocation` call sites (not 27), seven `requireUser` call sites (not
+four), five zero-state statements (not six), three vitest projects (not two).

--- a/docs/multi-tenant-plan/15-additional-v2-features.md
+++ b/docs/multi-tenant-plan/15-additional-v2-features.md
@@ -1,0 +1,498 @@
+# 15. The 2.0 Story: Features Beyond Tenancy
+
+Multi-user is the foundation of 2.0, not the headline. A major version is a
+launch. People read the release notes, and "several people can now share one
+instance" is one line. This document lists the features that make 2.0 worth
+upgrading to for the person who runs Contrack alone today, ranks them, and
+splits them between 2.0 and 2.1.
+
+Four kinds of change live here:
+
+1. **Already folded into the plan** by the review (section 1). Listed so nobody proposes them twice.
+2. **Small extras** that a major release is the right moment for (section 2).
+3. **Ten headline features** ranked by importance (sections 3 to 6).
+4. **Ten performance, accuracy, and stability stories** that make existing features faster, better, and more reliable (section 7).
+
+Rules that apply to everything below:
+
+- A feature lands as its own PR into `v2.0`. Same test and lint bar as a phase. Its own CHANGELOG bullet and its own line in the release notes.
+- A 2.0 feature must be additive. It may not change a table the migration touches, and it may not weaken an isolation guarantee. Every new endpoint gets a manifest row and a matrix test.
+- Nothing new starts after the Phase 5 security review begins. Whatever is not merged by then ships in 2.1.
+- No new runtime dependency unless the feature's row says so.
+- Sizes: XS under half a day. S one to two days. M three to five days. L six to ten days.
+
+---
+
+## 1. Already folded into the plan
+
+| Change | Phase |
+| ------ | ----- |
+| FTS triggers delete by an indexed contact token (`cidTok`) instead of scanning the index | 1 |
+| BM25 weight offset fix, as its own PR | 0 |
+| `GET /api/contacts/action-items` reachable (router mount order) | 0 |
+| `GET /api/query/contacts` excludes trashed and ghost contacts | 2g |
+| Request id on rate-limit `429` responses | 0 |
+| `Retry-After` header on every `429` | 3 |
+| Dedupe and AI Search `429` bodies use the standard error envelope | 2e, 2f |
+| Daily maintenance interval for audit log, sessions, tokens, invitations, invocations | 3 |
+| One shared frontend response handler for every API module | 4 |
+| Admin settings views lazy-loaded | 4 |
+| Docs drift fixed (test counts, project count, table count, duplicate section label) | 0, 5 |
+
+---
+
+## 2. Small extras
+
+| # | Extra | Size | Earliest start |
+| - | ----- | ---- | -------------- |
+| F1 | `Cache-Control: no-store` on auth, admin, stats, and export routes; `private` on uploads | XS | after Phase 3 |
+| F2 | Coverage threshold in CI | XS | end of Phase 4 |
+| F3 | Instance name setting | S | after Phase 4 |
+| F4 | `/healthz` reports schema and sqlite-vec versions | XS | after Phase 1 |
+| F5 | Remove the `AUTH_TOKEN` alias | XS | with Phase 3.12 |
+| F6 | AI stats feed pagination appends instead of replacing | S | after Phase 4 |
+
+**F1.** A shared instance has shared browsers and proxies. `.agent/STATUS.md`
+lists the missing header on the stats endpoints as known issue S-03, and
+`express.static` serves uploads with the default `public, max-age=0`. One
+small `noStore` middleware on four prefixes, plus a `setHeaders` option on
+the static handler. One integration test per prefix.
+
+**F2.** `docs/ci-and-release.md` says coverage is collected but not enforced.
+The matrix and manifest tests are the isolation guarantee, and a threshold
+stops a future PR from deleting them quietly. Set it two points under the
+measured coverage at the end of Phase 4.
+
+**F3.** `SignIn` already notes that an instance name is out of scope. With
+invitations, the join page and the sign-in page should say whose Contrack
+this is. One `app_settings` key, `instance.name`, 1 to 60 characters,
+exposed read-only in `GET /api/auth/status` and editable in the admin
+Instance view. Shown on sign-in, join, the sidebar identity menu, and the
+browser title.
+
+**F4.** Add `schema: { tenancy, fts }` and `vec` to the health payload so an
+operator can confirm the migration ran without opening the database.
+
+**F5.** `AUTH_TOKEN` is the pre-accounts name for `API_TOKEN` and is already
+honored only with a startup warning. A major release is the time to drop it.
+`API_TOKEN` itself stays deprecated until 3.0.
+
+**F6.** `.agent/STATUS.md` known issue B-02. Phase 2f scopes the feed and
+Phase 3.10 adds the admin view, so the file is open twice. The blocker is a
+design decision (append or page), not the code.
+
+---
+
+## 3. The 2.0 story
+
+The person Contrack is built for writes notes about people and expects the
+software to remember, connect, and nudge. 1.x delivered that for one person
+on one machine. 2.0 delivers it for the people around them, and for the AI
+agents they already use.
+
+Release-notes headline, as a draft:
+
+> **Contrack 2.0.** Invite your partner, your co-founder, or your team to the
+> same instance, each with a private CRM and an admin who cannot read it.
+> Connect Claude, Cursor, or any MCP client to your contacts with a personal
+> token. Capture a note from your phone's share sheet and let the AI file it.
+> Get a nudge on Slack or ntfy when a relationship goes quiet. Ask Contrack to
+> draft the message that reconnects you.
+
+Four headline features ship in 2.0 with the multi-user work. Six more follow
+in 2.1, each of them built on something 2.0 lays down.
+
+---
+
+## 4. Ten headline features, ranked
+
+Rank is importance to the product. "Ships in" is timing, which also weighs
+size and risk against the 2.0 migration. A 2.1 feature can outrank a 2.0 one.
+
+| Rank | Feature | One line | Ships in | Size | Builds on |
+| ---- | ------- | -------- | -------- | ---- | --------- |
+| 1 | Contrack MCP server | Your CRM as a tool for any AI agent, with a personal token | 2.0 | M | Personal tokens (Phase 3), the existing machine endpoints |
+| 2 | Quick Capture | Share anything to Contrack from your phone; the AI files it | 2.0 | M | Magic Paste (`parse-contact`), mention extraction, the PWA manifest |
+| 3 | Nudges | Follow-up and quiet-relationship reminders on ntfy, Slack, Discord, or a webhook | 2.0 | S to M | `action_items`, `nextFollowUpAt`, cadence, `user_settings`, the daily interval |
+| 4 | Calendar-aware timeline | Subscribe to a calendar feed; meetings become interactions with the right people | 2.1 | L | Interactions, `contact_emails`, the maintenance interval |
+| 5 | Reconnect drafts | One click turns "reach out to Maya" into a message in your voice | 2.0 | M | Briefings, the timeline, the capability router |
+| 6 | Introductions | Hand a contact to another member of the instance, with provenance | 2.1 | M | Accounts, `contact_sources`, the scoped repository |
+| 7 | Voice notes | Speak a note; Contrack transcribes it, extracts the people, logs it | 2.1 | M to L | Attachments, mention extraction, provider transcription |
+| 8 | Browser clipper | Save a profile page as a contact from a browser extension | 2.1 | M | Magic Paste, personal tokens |
+| 9 | Warm paths | Who in my network can introduce me to this person or company | 2.1 | M | The mention graph, experience and company data, semantic search |
+| 10 | Year in relationships | A yearly review page: who you met, who you kept, who you lost touch with | 2.1 | S to M | Interactions, relationship scores, the dashboard |
+
+Effort for the four 2.0 features together: about 12 to 18 engineer-days on
+top of the tenancy estimate in the risks document. They can start as soon as
+their dependencies land (each entry below names the earliest phase), so much
+of that work runs alongside Phases 3 and 4.
+
+---
+
+## 5. Ships in 2.0
+
+### 1. Contrack MCP server
+
+**Pitch.** "Ask Claude who you met at the conference last spring, and have it
+log the follow-up." 2.0 already gives every user a personal `ctk_` token and
+scopes the machine endpoints to that user. A small MCP server turns those
+endpoints into tools that Claude Desktop, Cursor, and any MCP client can
+call.
+
+**What it is.** A `packages/contrack-mcp` workspace (or `scripts/mcp/`) that
+runs over stdio, reads `CONTRACK_URL` and `CONTRACK_TOKEN`, and exposes
+tools: `find_people` (semantic search), `get_person` (profile plus recent
+timeline), `log_note` (creates an interaction and lets the server extract
+mentions), `add_follow_up`, `catch_me_up` (the existing briefing), and
+`list_follow_ups`. Every call goes through the normal HTTP API with the
+token, so isolation, rate limits, and audit are inherited. Nothing new
+touches the database.
+
+**Why it matters.** The target user already works inside an AI assistant.
+The CRM that is reachable from there is the one that gets used.
+
+**Needs.** One new dependency in the package, the MCP SDK. Personal tokens
+(Phase 3.6). Earliest start: after Phase 3. Size M.
+
+**Done when.** Claude Desktop with the server configured can find a contact,
+log a note that creates a ghost from an @mention, add a follow-up, and get a
+briefing, all as the token's user and nobody else.
+
+### 2. Quick Capture
+
+**Pitch.** "Share it to Contrack." A LinkedIn profile, a text message, a
+meeting note, a business card photo: from the phone's share sheet or a
+keyboard shortcut on the desktop, into a capture inbox where the AI proposes
+a contact or an interaction and the user confirms with one tap.
+
+**What it is.** `share_target` in `public/site.webmanifest` (the manifest
+exists; it has no share target), a `/capture` route in the SPA, and
+`POST /api/capture` that stores raw text or an image under the caller's
+scope and runs the existing `parseContactRecord` and mention extraction
+asynchronously. The inbox lists captures with a proposed action: new contact,
+new interaction for a matched contact, or discard. Accepting creates the
+rows through the existing services. Desktop gets `Cmd+Shift+V` (paste to
+capture) next to today's `Cmd+Shift+I` quick note.
+
+**Why it matters.** "You write the notes, the AI builds the graph" is the
+philosophy. Capture is where the notes come from, and today they come only
+from a desktop browser with the app open.
+
+**Needs.** A `captures` table (`id`, `ownerId`, `kind`, `raw`, `fileUrl`,
+`status`, `proposal` JSON, `createdAt`), owned and scoped from day one.
+Earliest start: after Phase 2a and 2b. Size M.
+
+**Done when.** A shared text from a phone appears in the inbox within a
+second, the AI proposal arrives within the provider's latency, and accepting
+it creates exactly the rows the user saw in the preview.
+
+### 3. Nudges
+
+**Pitch.** "Contrack tells you before you lose touch." Follow-ups that are
+due today, relationships that crossed their cadence, and a birthday this
+week, delivered where the user already looks: ntfy, Slack, Discord, or any
+webhook. Per user, opt-in, outbound only.
+
+**What it is.** A `notifications` section in account settings backed by
+`user_settings` (its first real rows): a destination (ntfy topic URL, Slack
+or Discord incoming webhook URL, or a generic URL), a delivery hour, and
+toggles for due follow-ups, quiet relationships, and birthdays. A per-owner
+job inside the daily maintenance interval (Phase 3.8) builds the digest from
+`action_items`, `nextFollowUpAt`, cadence, and `birthday`, and posts one
+message per owner. Every URL passes the existing `urlSafety` pinning, the
+same way link unfurling does. A "Send test" button.
+
+**Why it matters.** Cadence and follow-ups are the core loop, and today they
+only work if the user opens the app. A self-hosted app has no email, so the
+push has to go to a channel the user already has.
+
+**Needs.** No new dependency. Earliest start: after Phase 2b for the query,
+Phase 3.8 for the interval, Phase 4 for the settings UI. Size S to M.
+
+**Done when.** Two users on one instance receive two different digests at
+their chosen hours, a user with nothing due receives nothing, and a wrong
+URL fails safely with a visible error in settings.
+
+### 5. Reconnect drafts
+
+**Pitch.** "You should reach out to Maya" becomes "Here is what to say." From
+the Pulse at-risk list or a contact page, one click drafts a short message
+grounded in the last interactions, the person's context, and how long it has
+been, in the user's own tone.
+
+**What it is.** A new capability, `reconnectDraft`, in the capability router,
+so it can be assigned to any configured provider. `POST /api/contacts/:id/reconnect`
+returns three variants (short, warm, professional) as text. The prompt reuses
+the briefing context builder. The UI shows the drafts in a `Modal` with copy
+buttons and a "Log that I reached out" action that creates an interaction.
+Tone learning is a later step; 2.0 uses a fixed style guide plus the user's
+display name.
+
+**Why it matters.** The gap between knowing you should reconnect and doing
+it is the whole problem. Removing the blank page is the highest-leverage AI
+feature the product does not have.
+
+**Needs.** No new dependency. Earliest start: after Phase 2b and 2f (cache
+keys per owner). Size M.
+
+**Done when.** The draft names a real recent interaction, respects the
+provider assignment, is cached per owner, and never appears for another
+owner's contact.
+
+---
+
+## 6. Ships in 2.1
+
+### 4. Calendar-aware timeline
+
+**Pitch.** Subscribe to a calendar feed and meetings appear on the right
+people's timelines, before and after they happen.
+
+**What it is.** A per-user ICS subscription URL (or upload) polled by the
+maintenance interval, parsing events with attendees, matching attendee
+emails to `contact_emails`, and proposing interactions of type "meeting".
+Unmatched attendees can become ghosts on confirmation. Pre-meeting, the
+dashboard shows "Today you meet Maya and Jon" with their briefings.
+
+**Needs.** An ICS parser dependency. Earliest start: after 2.0 ships. Size
+L, mostly matching rules and duplicate handling with recurring events.
+
+### 6. Introductions
+
+**Pitch.** "Send Maya to Jon." One member hands a contact to another member
+on the same instance. The receiver gets a copy in their own CRM, with a
+`contact_sources` row that says who introduced it and when. No live sharing,
+no cross-owner reads, no change to isolation.
+
+**What it is.** `POST /api/contacts/:id/introduce` with a target username
+creates a pending introduction; the receiver accepts from an inbox and the
+service copies the contact and its child rows under the receiver's scope.
+The sender never sees what the receiver does with it.
+
+**Needs.** An `introductions` table. Earliest start: after 2.0. Size M. This
+is the first step toward workspaces in the future-work document without
+building them.
+
+### 7. Voice notes
+
+**Pitch.** Talk after the meeting. Contrack writes the note, finds the
+people, and logs it.
+
+**What it is.** Audio attachments (`.m4a`, `.webm`, `.mp3`) on the quick note
+and on Quick Capture, transcribed through a configured provider that
+supports audio (OpenAI and Gemini adapters exist), then run through the
+same mention extraction as typed notes. The audio file is stored under the
+owner's uploads directory; the transcript is the interaction content.
+
+**Needs.** A `transcribe` capability in the router. Earliest start: after
+2.0 and Quick Capture. Size M to L. Local transcription is out of scope
+until a small model is practical in the runtime.
+
+### 8. Browser clipper
+
+**Pitch.** Save a person from any page in one click.
+
+**What it is.** A minimal WebExtension (Chrome and Firefox) that sends the
+page's selected text or main content to `POST /api/capture` with a personal
+token. Everything else is Quick Capture.
+
+**Needs.** A separate `packages/clipper` with its own build. Earliest start:
+after Quick Capture. Size M.
+
+### 9. Warm paths
+
+**Pitch.** "Who can introduce me to Acme?" Contrack answers from your own
+notes.
+
+**What it is.** A query over the mention graph, shared employers in
+`contact_experience`, and semantic similarity, ranked by relationship score,
+producing "You know Jon, who worked at Acme until 2024 and mentioned Priya
+twice." Surfaced in search and on company pages.
+
+**Needs.** No new dependency. Earliest start: after 2.0. Size M.
+
+### 10. Year in relationships
+
+**Pitch.** A page each January: people met, the strongest bonds, the ones
+that went quiet, the notes that mattered.
+
+**What it is.** A read-only view over interactions, relationship scores, and
+`addedAt`, per owner, with an optional AI summary through the existing
+insight capability, and an export as an image.
+
+**Needs.** No new dependency. Earliest start: after 2.0. Size S to M.
+
+---
+
+## 7. Ten performance, accuracy, and stability stories
+
+These do not add a feature. They make an existing one faster, make it
+produce better results, or make it fail less. Each is grounded in a specific
+place in the `v1.5.5` code. Rank is importance; "Ships in" also weighs size
+and risk. Five ship in 2.0, five in 2.1.
+
+| Rank | Story | Kind | Ships in | Size | Today |
+| ---- | ----- | ---- | -------- | ---- | ----- |
+| 1 | CPU-bound work off the main thread | Performance, Stability | 2.1 | L | Local embeddings and dedupe passes run on the event loop |
+| 2 | Search quality gate | Accuracy | 2.0 | S to M | No eval set; ranking changes are unmeasured |
+| 3 | One scan after a bulk import | Performance | 2.0 | S | One incremental check per imported contact |
+| 4 | Filters inside the vector index | Accuracy, Performance | 2.1 | M | Global top 500, then a JavaScript filter |
+| 5 | Verified backups | Stability | 2.0 | S | Snapshot written, never opened |
+| 6 | WAL checkpoint and write health | Stability | 2.0 | S | No checkpoint call anywhere |
+| 7 | Fuzzy mention resolution | Accuracy | 2.1 | M | Exact match on `contacts.name` |
+| 8 | Dedupe precision and recall gate | Accuracy | 2.1 | M | Unit tests per matcher, no pair-level gate |
+| 9 | Admin health panel | Stability | 2.0 | S | Health is `SELECT 1` |
+| 10 | Incremental relationship scoring | Performance | 2.1 | S to M | Hourly full recompute of every contact |
+
+Effort for the five 2.0 stories together: about 6 to 10 engineer-days. They
+touch files the phases already open, so most of them ride along with the
+relevant sub-phase PR or land right after it.
+
+### Ships in 2.0
+
+**2. Search quality gate.** Phase 0 changes the BM25 weights and Phase 2c
+rewrites every search statement. Without a measure, "better" is a guess. Add
+`tests/eval/search.eval.test.ts` with a fixed fixture of about 300 contacts
+and 50 golden queries (name typos, company plus role, location plus
+interest, a nickname, a phrase from a note), each with the expected top
+results. Assert recall at 10 and mean reciprocal rank against a committed
+baseline, with a small tolerance. FTS runs for real; the vector channel uses
+a recorded embedding fixture so the test is deterministic and needs no
+model. The baseline is re-recorded on purpose, with the diff in the PR, when
+a ranking change is intended. Earliest start: Phase 0, before the BM25 PR.
+Fits the "ML / AI Evaluation Thresholds" section that `.agent/TESTING.md`
+already has.
+
+**3. One scan after a bulk import.** The non-stream import path
+(`server/routes/contacts.ts:530-549`) waits 3 s and then runs
+`incrementalDedupeCheck` once per created contact, with concurrency 1. Each
+check normalizes the whole corpus (`dedupe/engine.ts:309`), so an import of
+`n` contacts into a corpus of `m` does about `n × m` work. Replace the loop
+with one scoped scan restricted to the new ids as the left side of every
+pair (`runScan(scope, "incremental-set", ids)`), which normalizes the corpus
+once. Same result, one pass. Earliest start: with Phase 2e.
+
+**5. Verified backups.** `runBackup` (`server/services/backupService.ts:75`)
+writes the snapshot with the online backup API and rotates. Nothing opens
+the file again. After each snapshot: open it read-only, run
+`PRAGMA quick_check`, compare the row counts of the eight owned tables and
+`users` with the live database, and record `{ ok, checkedAt, rows }` next to
+the file (a sidecar JSON, or a row in `app_settings`). The admin Backups view
+shows a verified badge per snapshot. Boot logs a warning when the newest
+verified snapshot is older than two intervals. Earliest start: with Phase 3
+(the backups routes go admin there) and Phase 4 (the view).
+
+**6. WAL checkpoint and write health.** The database runs in WAL mode with
+`busy_timeout = 5000` and no checkpoint call anywhere in `server/` or
+`server.ts`. SQLite auto-checkpoints at 1,000 pages, but a long reader (a
+dedupe scan, an export) can hold the WAL open and let it grow. With more
+writers this matters. In the daily maintenance interval (Phase 3.8): read
+the WAL file size, run `PRAGMA wal_checkpoint(PASSIVE)`, and run
+`wal_checkpoint(TRUNCATE)` when the file exceeds 64 MB and no scan is
+running. Count `SQLITE_BUSY` errors in the error handler and expose both
+numbers on the admin health panel. Earliest start: with Phase 3.8.
+
+**9. Admin health panel.** `/healthz` answers `SELECT 1`. An admin needs more
+when several people depend on one instance. `GET /api/admin/health` returns:
+schema versions (extra F4), database and WAL sizes, last backup and its
+verification, the dedupe and AI Search queue states (running owner, pending
+owners), embedding backfill progress per owner, `aiCache` hit rates (already
+computed for the stats page), provider circuit state, and uptime. One card
+grid under Administration. No secrets. Earliest start: after Phase 3;
+the view with Phase 4.
+
+### Ships in 2.1
+
+**1. CPU-bound work off the main thread.** The Transformers.js embedding
+pipeline (`server/services/search/localEmbeddings.ts:42-44`) and the dedupe
+passes run in the request process. A 2,000-contact embedding backfill or a
+deep scan for one owner stalls every other owner's requests for its
+duration. `recomputeAll` already yields between batches; the embedding and
+scan loops do not have the same escape. Move both to a `worker_threads`
+worker with a small job protocol (start, progress, cancel, result). The
+worker opens its own read connection for scans and returns rows for the main
+thread to write, so the single-writer rule holds. The global run lock
+becomes the worker queue, and the per-owner FIFO from Phase 2e stays. This
+is the biggest multi-user performance risk in the product and the largest
+item here, which is why it is 2.1 and not 2.0.
+
+**4. Filters inside the vector index.** `findSearchNeighbors`
+(`localEmbeddings.ts:236-252`) takes the global top `min(k, 500)` and then
+drops rows that fail the hard filter in JavaScript. Phase 1 scopes the scan
+to one owner's partition, which fixes the cross-owner half of the problem.
+The other half remains: a query with a hard filter that matches few contacts
+can return nothing because none of them made the top 500. sqlite-vec
+supports metadata columns that filter inside the KNN. Add `isGhost`,
+`isArchived`, and `active` (`deletedAt IS NULL`) as metadata columns to both
+`vec0` tables and push those predicates into the `MATCH` query. The
+copy-rebuild from Phase 1 makes the schema change cheap (0.9 s per 50,000
+rows measured). Id-list filters (a specific list, a tag) stay in JavaScript
+but run over a much smaller candidate set.
+
+**7. Fuzzy mention resolution.** `runMentionExtraction`
+(`server/services/interactionService.ts:58-66`) resolves a mentioned name
+with `eq(contacts.name, m.name)`. "Jon" does not find "Jonathan Smith",
+"Maria García" does not find "Maria Garcia", and each miss creates a ghost.
+The dedupe engine already has nickname tables, phonetic hashes, and a name
+normalizer under `server/utils/nlp/`. Use them: resolve within the owner's
+contacts by normalized name, then nickname, then phonetic hash, with the
+company or a co-mentioned person as a tiebreaker. Above a confidence
+threshold, link. Below it, create a "possible mention" suggestion instead of
+a ghost, reviewed in the same queue as dedupe suggestions. Fewer wrong
+ghosts and more real links, which also improves the mention graph that the
+dashboard and warm paths read.
+
+**8. Dedupe precision and recall gate.** `tests/unit/nlp.*.test.ts` cover the
+matchers one at a time. Nothing measures the engine end to end. Build a
+labeled fixture of about 300 contact pairs (true duplicates with typos,
+nicknames, and moved companies; near-misses such as father and son at the
+same firm; clear negatives) and run the deterministic passes over it in CI,
+asserting precision and recall per pass against a committed baseline. The
+fixture doubles as the regression suite for the 2.1 mention work and for
+any threshold preset change.
+
+**10. Incremental relationship scoring.** `recomputeAll`
+(`server/services/relationshipService.ts:289-336`) scores every non-ghost,
+non-archived contact every hour (`server.ts:210-217`), in batches of 200. On
+a 50,000-contact instance that is a lot of work to change nothing. Keep a
+`scoreDirty` flag (or a `lastScoredAt` compared with `updatedAt` and the
+newest interaction) and recompute only dirty contacts hourly, with one full
+pass nightly to catch time decay. The dashboard reads the same column, so
+nothing else changes.
+
+---
+
+## 8. Not planned for 2.x
+
+Kept short. Each is tracked in [11-future.md](11-future.md).
+
+- Reverse-proxy header authentication and OIDC.
+- Passkeys and two-factor.
+- Per-user AI keys and budgets.
+- Moving all DDL into Drizzle migrations.
+- User quotas.
+- A Docker default of `AUTH_REQUIRED=true`. With the local owner account, auth-off is a proper single-user mode, and the non-loopback warning stays.
+
+---
+
+## 9. Decision record
+
+Fill in as decisions are made, so the release PR can list what shipped.
+
+| # | Item | Decision | Date |
+| - | ---- | -------- | ---- |
+| F1 | No-store cache headers | | |
+| F2 | Coverage threshold | | |
+| F3 | Instance name | | |
+| F4 | Health schema versions | | |
+| F5 | Remove `AUTH_TOKEN` | | |
+| F6 | Feed pagination | | |
+| 1 | Contrack MCP server | | |
+| 2 | Quick Capture | | |
+| 3 | Nudges | | |
+| 5 | Reconnect drafts | | |
+| S2 | Search quality gate | | |
+| S3 | One scan after a bulk import | | |
+| S5 | Verified backups | | |
+| S6 | WAL checkpoint and write health | | |
+| S9 | Admin health panel | | |

--- a/docs/multi-tenant-plan/16-implementation-prompts.md
+++ b/docs/multi-tenant-plan/16-implementation-prompts.md
@@ -1,0 +1,1249 @@
+# 16. Implementation Prompts
+
+Twelve prompts that hand the 2.0 work to an implementing model, one prompt
+per pull request (Phase 2 is five PRs, so five prompts). Each prompt names
+what to read, what to build, what not to touch, what to report, and what
+success looks like. The phase documents carry the detail; the prompts point
+into them by section so the model reads what it needs and nothing more.
+
+## How to use this file
+
+1. Run the prompts in order. Each one assumes the previous PR is merged into `v2.0` and starts from a fresh branch off `v2.0`.
+2. Paste **Block A** (the common context) and then the prompt you want, as one message. Block A is written once here so the prompts stay short. Never send a prompt without it. Paste **Block B** (the branch runbook) as well for Prompts 1 and 12, and for any prompt where the model is expected to create branches and open pull requests itself.
+3. Fill the two placeholders in Block A: the absolute repository path and the decision answers from [14-risks-and-open-questions.md](14-risks-and-open-questions.md) section 1 (Q13 to Q16) and [15-additional-v2-features.md](15-additional-v2-features.md) section 9.
+4. When the model finishes, read its final report against the prompt's success checklist before merging. The checklist is the acceptance test for the PR, not a suggestion. Then run the operator checklist at the end of Block B.
+5. If a prompt's work needs two sessions, start the second with Block A, the same prompt, and a line saying what is already done on the branch.
+
+The plan folder must exist in the checkout the model works in. It is
+gitignored on `main`; Prompt 1 commits it on `v2.0`. Until Prompt 1 merges,
+copy the folder into the working tree by hand.
+
+---
+
+## Block A. Common context (paste above every prompt)
+
+```text
+You are implementing part of the Contrack 2.0 multi-tenant project. Work in the
+repository at <ABSOLUTE_PATH_TO_REPO>. Read this block fully before the task.
+
+THE PRODUCT
+Contrack is a local-first, AI-powered personal CRM: Express 5.2.1 API in server/,
+React 19 SPA in src/, one SQLite database through better-sqlite3 (SQLite 3.53.2)
+with the sqlite-vec 0.1.9 extension and FTS5. Drizzle ORM supplies types in
+src/db/schema.ts and two early migrations in drizzle/; most DDL is idempotent raw
+SQL in server/db.ts that runs at import time. TypeScript 6 strict. Vitest 4 with
+three projects: unit (mocked database), integration (a real database in a temp
+DATA_DIR per test file, createApp() under supertest, AI mocked, AUTH_REQUIRED=""
+by default), and contract (real providers, not part of npm test). Node 22.
+
+THE PLAN
+docs/multi-tenant-plan/ holds the design. Read README.md there first (five
+minutes). The documents you will be pointed at:
+  03-architecture.md          decisions, principal model, Scope, guards, names
+  04-data-model-and-migration.md  exact DDL, boot order, verification queries
+  05..10-phase-*.md           one per phase: context, tasks, acceptance, contract
+  12-testing-strategy.md      test inventory, harness, matrix shape
+  13-api-changes.md           every endpoint and error code
+  14-risks-and-open-questions.md  answered questions; decisions Q1..Q16
+  15-additional-v2-features.md    extras and headline features, decision record
+  appendix-a-query-inventory.md   every query site with v1.5.5 line numbers
+  appendix-b-route-manifest.md    every route and its class
+  bench/review-2026-09-08/    measured evidence behind the design
+Line numbers in the plan are from v1.5.5. When one has drifted, search for the
+function name. If the code disagrees with the plan in a way that changes the
+design, stop and report it instead of improvising.
+
+DECISIONS ALREADY MADE (fill in before sending)
+  Q13 BM25 offset:        <fix | preserve today's effective weights>
+  Q14 mentions cache:     <shared | prefixed>
+  Q15 MCP route:          <reorder mount | rename path>
+  Q16 per-user limiter:   <add insight and scan | pattern list only>
+  Accepted extras (F1..F6) and 2.0 stories: <list, or "none yet">
+
+BRANCH AND PR RULES
+- All work lands on the integration branch v2.0. Never push to main. Never
+  force-push v2.0. Branch from a fresh v2.0: git fetch && git checkout -b
+  v2.0/<phase>-<slug> origin/v2.0. The exact git and gh commands for every
+  branch operation are in Block B of this file; follow them as written.
+- One PR per prompt unless the prompt says otherwise, into v2.0, squash-merged
+  by a human. Title: feat(tenancy): <phase>, <what>. Commit subjects use
+  type(area): subject. No AI attribution anywhere: no Co-Authored-By trailers,
+  no "generated with" lines, no session links, in commits or in the PR body.
+- package.json stays at 1.5.5 until the release prompt. Add your CHANGELOG
+  lines under ## [Unreleased] prefixed with the phase.
+- PR body: one plain sentence saying what the PR adds and why; then short
+  sections in this order as they apply: what users or the API see, how it
+  works, operational behavior, guarantees; nested bullets for reviewer
+  context; a Testing section with the exact commands and the raw vitest
+  summary lines. No semicolons. No em-dashes. Short sentences.
+- Before opening the PR: npm run lint, npm test, npm run build, and
+  npm run format:check all pass locally. Paste the vitest summary line
+  (Test Files N passed (N) / Tests N passed (N)) into the PR and into your
+  final report. "Green" without that line is not green.
+
+CODING RULES FOR THIS PROJECT
+- Every repository or service function that reads or writes an owned table
+  takes scope: Scope as its FIRST parameter. A user-supplied id and the scope go
+  in the SAME SQL statement (WHERE id = ? AND ownerId = ?). Never select by id
+  and compare in JavaScript. A miss is NotFoundError (404), identical body for a
+  foreign id and a nonexistent id.
+- Routes call scopeOf(req) once and pass it down. Routes never read ownerId
+  from the body or query string.
+- SSE and NDJSON handlers capture scope in the closure before subscribing or
+  awaiting. Never call currentScope() inside an EventEmitter listener; the
+  listener runs in the emitter's async context, not the request's.
+- Background jobs run per owner inside runWithContext({ scope:
+  scopeForOwnerId(id), principal: null, requestId: "job-..." }, fn).
+- sqlite-vec 0.1.9: filter KNN with AND ownerId = ?; never IN (...) on a
+  partition column; k at most 4096; upserts are DELETE then INSERT; never
+  UPDATE a partition column; never ALTER TABLE RENAME a vec0 table.
+- Statements over owned tables that legitimately carry no owner predicate get
+  // tenant-lint: allow <reason> on the line above, reason one of: instance
+  sweep, owner-checked by caller, boot migration, admin cross-user, derived table.
+- Keep existing patterns: prepared statements in module-level stmts objects,
+  asyncHandler on every route, AppError subclasses, validateBody with zod,
+  log.info/warn/error with a component tag.
+- Do not widen scope. If you find a bug outside the prompt, note it in the
+  report; fix it only if the prompt or the phase document says so.
+
+WHEN TO STOP AND REPORT INSTEAD OF CONTINUING
+- A test in the existing suite fails for a reason you do not understand.
+- A migration step would need to run in a different order than the phase
+  document specifies.
+- A sqlite-vec, FTS5, or Express behavior differs from what the plan states.
+- You would need a new runtime dependency the prompt did not authorize.
+- The work would take a different shape than the phase document's acceptance
+  criteria describe.
+
+FINAL REPORT FORMAT
+1. What you built, in five lines or fewer.
+2. The PR title and the full PR body you propose.
+3. The raw vitest, lint, and build output summaries.
+4. The success checklist from the prompt with each box ticked or explained.
+5. Anything you found that the plan did not anticipate.
+```
+
+---
+
+## Block B. Branch and release operations runbook
+
+For the operator and for the model. Every command is for this repository:
+GitHub `arvarik/contrack`, default branch `main`, `gh` installed and
+authenticated, CI workflow `.github/workflows/ci.yml` with the job
+`build-and-test`. Ordinary PRs are squash-merged. The release PR is merged
+with a merge commit. Nothing is ever force-pushed.
+
+### B.1 Names
+
+| Thing | Convention | Example |
+| ----- | ---------- | ------- |
+| Integration branch | `v2.0` | `v2.0` |
+| Work branch | `v2.0/<phase>-<slug>` | `v2.0/phase-2e-dedupe`, `v2.0/extra-nudges` |
+| PR title | `feat(tenancy): <phase>, <what>` | `feat(tenancy): phase 2e, scope the dedupe engine` |
+| Extras | `feat(<area>): <what>` | `feat(capture): quick capture inbox` |
+| Commit subject | `type(area): subject`, imperative, no trailer | `fix(db): drop FTS triggers around the claim` |
+| Labels | `2.0`, plus `phase-0` to `phase-5` or `extra` | |
+| Release PR | `release: v2.0.0, multi-user Contrack` | |
+| Tag | `v2.0.0` | |
+
+### B.2 One-time setup (operator, before Prompt 1)
+
+```bash
+cd <repo>
+git checkout main && git pull --ff-only
+git checkout -b v2.0
+git push -u origin v2.0
+```
+
+Protect the branch so nothing lands without a PR and a green check. In
+GitHub: Settings, Branches, Add rule for `v2.0`: require a pull request,
+require the `build-and-test` status check, block force pushes. The same
+rule already applies to `main`. Until Prompt 1's first PR merges, CI does
+not run on PRs into `v2.0`, so merge that PR on the strength of a local
+`npm run lint && npm test`.
+
+Optional labels:
+
+```bash
+for l in 2.0 phase-0 phase-1 phase-2 phase-3 phase-4 phase-5 extra release; do
+  gh label create "$l" --color 1d76db --force
+done
+```
+
+### B.3 Starting a prompt's work (model)
+
+```bash
+git fetch origin
+git checkout -b v2.0/<phase>-<slug> origin/v2.0
+git status                      # clean tree, on the new branch
+npm ci                          # only if package-lock changed upstream
+npm test                        # green before you touch anything
+```
+
+Commit in small steps with `type(area): subject`. Never add `Co-Authored-By`,
+`Claude-Session`, or any generated-with line. If a hook adds one, remove it
+with `git commit --amend` before pushing.
+
+### B.4 Opening the PR (model or operator)
+
+```bash
+npm run lint && npm test && npm run build && npm run format:check
+git push -u origin v2.0/<phase>-<slug>
+gh pr create --base v2.0 --head v2.0/<phase>-<slug> \
+  --title "feat(tenancy): <phase>, <what>" \
+  --body-file /tmp/pr-body.md --label 2.0 --label <phase-label>
+gh pr checks --watch            # wait for build-and-test
+```
+
+The body file follows the format in Block A. The Testing section carries
+the raw `Test Files ... / Tests ...` lines. If the PR also ticks acceptance
+boxes or adds `bench/` files, say so in the body.
+
+A PR whose diff passes about 1,500 lines is a candidate for splitting, as
+several prompts note. Split by the prompt's own sub-lists, never by file
+type.
+
+### B.5 Merging a PR (operator only)
+
+```bash
+gh pr view <n> --json title,statusCheckRollup,reviewDecision
+gh pr merge <n> --squash --delete-branch --subject "<PR title> (#<n>)"
+git checkout v2.0 && git pull --ff-only
+```
+
+Rules: the model never merges. Merge only when `build-and-test` is green and
+the report's checklist is satisfied. The squash subject is the PR title, so
+`v2.0` reads as one commit per prompt. After the merge, watch the push to
+`v2.0` run CI once more; it must stay green (see B.9).
+
+### B.6 Keeping `v2.0` current with `main` (operator)
+
+Do this at every phase boundary, whenever a hotfix lands on `main`, and once
+more before the release PR.
+
+```bash
+git checkout v2.0 && git pull --ff-only
+git fetch origin main
+git merge --no-ff origin/main -m "merge: main into v2.0 after <what landed on main>"
+npm ci && npm run lint && npm test && npm run build
+git push origin v2.0
+```
+
+This is a merge commit on `v2.0`, and that is intended: the branch is
+shared, so it is never rebased. If the merge conflicts, see B.7. Never
+resolve a conflict by taking one side wholesale in `server/db.ts` or
+`server/app.ts`.
+
+### B.7 Conflicts in the files that will conflict
+
+| File | Why it conflicts | How to resolve |
+| ---- | ---------------- | -------------- |
+| `server/db.ts` | Section order is load-bearing (tenancy block before FTS, triggers dropped around the claim) | Keep the `v2.0` order. Re-apply the `main` change inside the right section. Run the migration test and `npm run tenancy:verify` on a fresh database before committing. |
+| `server/app.ts` | Middleware order (request id, limiters, `attachPrincipal`, `attachRequestContext`, guards, router mounts) | Keep the `v2.0` order. Re-run `tenancy.routeManifest.test.ts`. |
+| `CHANGELOG.md` | Both sides add under `Unreleased` | Keep both. Phase blocks stay grouped; `main` entries go under their own heading. |
+| `package.json`, `package-lock.json` | Scripts and dependency bumps | Keep both script sets. For the lock file, take `main`'s version bumps, then `npm install` and commit the regenerated lock. |
+| `src/api/*.ts` | Phase 4 migrates every module to the shared handler | Keep the shared handler and re-apply the `main` change on top. |
+| `docs/api-reference.md`, `docs/configuration.md` | Phase 5 rewrites sections | Keep the 2.0 text and fold the `main` change in by hand. |
+| `tests/integration/*.test.ts` | New assertions on both sides | Keep both. Run the file alone, then the suite. |
+
+After any conflict resolution: full `npm test`, plus `npm run tenancy:verify`
+if `server/db.ts` was involved.
+
+### B.8 What may run in parallel
+
+Prompts share files, so most of them are sequential. This is the whole
+allowed overlap:
+
+| Can start | After | Notes |
+| --------- | ----- | ----- |
+| Prompt 2 | Prompt 1 merged | |
+| Prompts 3 to 7 | the previous one merged | Sequential. They share `contactRepository`, `contactService`, the dedupe files, and `aiCache`. |
+| Prompt 8 | Prompt 7 merged | |
+| Prompt 9, PR 1 | Prompt 8's endpoints stubbed or merged | The UI can be built against `13-api-changes.md` shapes. |
+| Prompt 9, PR 2 | Prompt 8 merged | |
+| Prompt 10 items | their listed dependency phase merged | The MCP server needs Phase 3 tokens; Quick Capture needs 2a and 2b; Nudges need 3.8 and Phase 4 for the UI. Extras can run alongside Prompts 8 and 9 on their own branches when they touch no shared file. |
+| Prompt 11 | every accepted item merged | |
+| Prompt 12 | Prompt 11 merged | |
+
+Two work branches open at once must touch disjoint files. If in doubt,
+serialize.
+
+### B.9 When `v2.0` goes red
+
+A push to `v2.0` (a squash merge) can fail CI even though the PR was green,
+usually because two PRs merged close together. Fix forward within the day
+or revert:
+
+```bash
+git checkout v2.0 && git pull --ff-only
+git revert <squash-sha> --no-edit
+git push origin HEAD:refs/heads/revert-<n>      # then open a PR into v2.0
+```
+
+Revert through a PR, not by pushing to `v2.0`. `v2.0` is the base for the
+next prompt, so it must be green before that prompt starts.
+
+### B.10 Hotfixes to 1.5.x during the project
+
+A production bug on `main` is fixed on `main` first, in the normal way:
+
+```bash
+git checkout -b fix/<slug> origin/main
+# fix, test
+gh pr create --base main ...
+# after merge, release a 1.5.x patch per docs/ci-and-release.md if needed
+```
+
+Then merge `main` into `v2.0` (B.6) so the fix is not lost in 2.0. Never
+cherry-pick from `v2.0` to `main` before the release.
+
+### B.11 Running 2.0 locally against real data
+
+Never point a `v2.0` build at the production `DATA_DIR`. The first boot
+migrates the database in place (with a backup) and rewrites upload URLs.
+
+```bash
+cp -R /path/to/production/data /tmp/contrack-2.0-trial
+DATA_DIR=/tmp/contrack-2.0-trial AUTH_REQUIRED=false npm run dev
+# watch the boot log for the tenancy steps and their durations
+DATA_DIR=/tmp/contrack-2.0-trial npm run tenancy:verify
+```
+
+Repeat with `AUTH_REQUIRED=true` on a second copy. Both runs are part of
+the Phase 1 and Phase 5 rehearsals.
+
+### B.12 Recovery
+
+- **A work branch is broken beyond repair.** Delete it and start the prompt again from `origin/v2.0`. Nothing on a work branch is authoritative until it merges.
+- **Someone force-pushed `v2.0`.** Find the last good commit from the merged PRs (`gh pr list --base v2.0 --state merged --json mergeCommit,title`) or from a local `git reflog`, restore it with a normal push from a machine that has it, and re-enable the branch protection rule that should have stopped it.
+- **A merged PR must be undone.** B.9. Never rewrite `v2.0` history.
+- **The plan folder and the code disagree.** The code that merged wins for what exists; fix the document in the next PR that touches that area, and say so in that PR's body.
+
+### B.13 Release and retirement
+
+The full procedure with commands is section 4 of
+[10-phase-5-hardening-release.md](10-phase-5-hardening-release.md) and
+Prompt 12. In one screen:
+
+```bash
+# freeze
+git checkout v2.0 && git pull --ff-only && git merge --no-ff origin/main
+npm run lint && npm test && npm run build && npm run test:contract
+# version PR into v2.0 (squash-merged): npm version major --no-git-tag-version, CHANGELOG [2.0.0]
+# release PR into main, merged with a merge commit by the operator:
+gh pr create --base main --head v2.0 --title "release: v2.0.0, multi-user Contrack" --body-file /tmp/release.md
+gh pr merge <n> --merge --subject "release: v2.0.0"
+# tag and notes, before the workflow's release job:
+git checkout main && git pull --ff-only
+git tag -a v2.0.0 -m "v2.0.0" && git push origin v2.0.0
+gh release create v2.0.0 --title "v2.0.0" --notes-file /tmp/notes.md --verify-tag
+```
+
+After the first patch release or two weeks: delete `v2.0`
+(`git push origin --delete v2.0`), remove `"v2.0"` from
+`.github/workflows/ci.yml` and `docs/ci-and-release.md`, and move
+`docs/multi-tenant-plan/` to `docs/archive/multi-tenant-2.0/`, restoring the
+ignore line. One `chore(ci)` PR.
+
+### B.14 Operator checklist between prompts
+
+- [ ] The model's final report has the vitest, lint, and build summaries, and every checklist box is ticked or explained.
+- [ ] `gh pr checks <n>` shows `build-and-test` green.
+- [ ] The PR body follows the format (no semicolons, no em-dashes, no AI attribution, Testing section with raw summaries).
+- [ ] Acceptance boxes in the phase document are ticked in the PR, and any `bench/` file the prompt required is present.
+- [ ] Squash-merge with the PR title as subject. Confirm the resulting push to `v2.0` is green.
+- [ ] At a phase boundary: merge `main` into `v2.0` (B.6) and confirm green.
+- [ ] Record decisions the model asked for in `14-risks-and-open-questions.md` or the decision record in `15-additional-v2-features.md`.
+- [ ] Start the next prompt from a fresh `origin/v2.0`.
+
+---
+
+## Prompt 1. Phase 0: foundations and safety net
+
+```text
+TASK
+Implement Phase 0 as specified in docs/multi-tenant-plan/05-phase-0-foundations.md.
+This is three PRs, in this order:
+  PR 1  task 0.0 only: the v2.0 branch, CI for it, and the plan folder committed.
+  PR 2  task 0.10 only: the BM25 weight offset fix (skip this PR if Q13 says "preserve").
+  PR 3  everything else in the phase.
+Branches: v2.0/phase-0-branch-ci, v2.0/phase-0-bm25, v2.0/phase-0-foundations.
+
+READ FIRST
+- 05-phase-0-foundations.md, all of it. Section 0.3 lists the v1.5.5 facts the
+  tasks depend on; section 8 lists the names you must use.
+- 03-architecture.md sections 4, 5, and 14.
+- appendix-b-route-manifest.md (the seed for ROUTE_MANIFEST) and its review notes.
+- 12-testing-strategy.md sections 2, 4, and 5.
+- Code: server/app.ts, server/middleware/auth.ts, server/middleware/rateLimit.ts,
+  server/services/authService.ts, server/services/contactService.ts (buildInsertValues),
+  server/services/search/hybridRetrieval.ts:113, tests/integration/helpers.ts,
+  tests/integration-setup.ts, .github/workflows/ci.yml, .gitignore.
+
+FACTS THAT SHAPE THE WORK
+- CI runs only for pull requests into main today. Until PR 1 merges, nothing
+  you open against v2.0 is tested by CI. Verify the build-and-test job runs on
+  PR 1 before merging it.
+- docs/multi-tenant-plan/ is gitignored. PR 1 removes that line and commits the
+  folder. Every later PR ticks acceptance boxes in these documents.
+- Express 5 does not store mount path strings. app.router is a lazy getter,
+  layers have no regexp, and layer.path is set only after layer.match(). The
+  manifest test must record mount paths by wrapping Router.prototype.use and
+  app.use while createApp() runs (task 0.3). Do not try to rebuild prefixes
+  from the stack alone.
+- GET /api/debug/cache-stats is registered in server.ts, outside createApp().
+  Move it inside createApp() behind the same NODE_ENV guard and mark it devOnly.
+- The AI rate limiter mounts before req.requestId is assigned and before
+  attachPrincipal. Move the request id assignment above the limiter (task 0.2).
+- An EventEmitter listener sees the emitter's async context. The context unit
+  test must prove this (task 0.2). A multipart upload with one text field must
+  keep the context in the handler after multer, or the fallback in the phase
+  document applies (multer issue #1111).
+- bm25() weights are positional and include UNINDEXED columns. Task 0.10's
+  unit test pins that rule.
+
+DO THIS, IN ORDER
+1. PR 1: create v2.0 from main; add "v2.0" to on.pull_request.branches and
+   on.push.branches in .github/workflows/ci.yml without touching the image or
+   release job conditions; remove docs/multi-tenant-plan/ from .gitignore and
+   commit the folder. Open the PR, confirm CI ran, stop and report so a human
+   can merge before you continue.
+2. PR 2 (if Q13 is "fix"): task 0.10. Ten weights, position 0 is 0.0. Add the
+   positional unit test. Its own CHANGELOG line marked as a ranking change.
+3. PR 3: tasks 0.1 to 0.9, 0.11, 0.12 in the order the document lists them.
+   Build server/tenancy/scope.ts and requestContext.ts exactly as written
+   (names in section 8). Build the route recorder and the manifest test.
+   Build the tenant lint in report mode and commit its baseline to bench/.
+   Stamp ownership from the request context at every insert site in task 0.5.
+   Build the two-user harness and the it.todo matrix skeleton. Write the
+   benchmark script and commit bench/baseline-phase-0.md. Apply the comment
+   and doc corrections in task 0.9. Reorder the router mounts (task 0.11)
+   and add the reachability test.
+4. Tick the acceptance boxes in section 4 of the phase document in PR 3.
+
+CONSTRAINTS
+- No WHERE ownerId = ? on any read. No change to the Principal union. No
+  schema change. A single-account instance must behave exactly as before.
+- All 575 existing tests must still pass unchanged.
+
+DELIVER
+Three PRs as above, each with the body format from Block A, plus the final
+report.
+
+SUCCESS CHECKLIST
+- [ ] PR 1 merged first; a later PR into v2.0 shows the build-and-test job.
+- [ ] docs/multi-tenant-plan/ is tracked on v2.0, bench/ included.
+- [ ] server/tenancy/scope.ts exports Scope, OwnerId, scopeOf, scopeForUser, scopeForOwnerId, ownerToken, contactToken; the token unit test compares against SQLite's replace().
+- [ ] server/tenancy/requestContext.ts exports runWithContext, getContext, currentScope, currentScopeOrNull, attachRequestContext; mounted after attachPrincipal; req.requestId assigned before the AI limiter; a limiter 429 carries a requestId.
+- [ ] Context tests prove: survives await/setTimeout/setImmediate/Promise.all; emitter rule; NO_SCOPE outside a context; multipart-with-text-field case passes or the fallback is recorded.
+- [ ] tenancy.routeManifest.test.ts passes with every route classified, including the devOnly rows and the USE /uploads static row; the recorder is used, not a naive stack walk.
+- [ ] scripts/tenant-lint.mjs runs in npm run lint in report mode; bench/tenant-lint-baseline.txt committed; the unit test covers flag, allow, unknown reason, non-owned table.
+- [ ] Stamping test: contacts, lists, ghost from a mention, merge log, AI invocation all carry the signed-in user's id with auth on, without a restart.
+- [ ] tests/integration/tenancy/helpers.ts exports createActor, asUser, seedOwner, rowsOwnedBy, resetAccounts.
+- [ ] tenancy.isolation.test.ts has one it.todo per scoped route.
+- [ ] bench/baseline-phase-0.md committed with 1 x 5000 and 10 x 2000, including the PATCH cost.
+- [ ] GET /api/contacts/action-items returns the MCP payload; GET /api/contacts/<uuid> still works.
+- [ ] Corrections applied: auth.ts comments, schema.ts "ten" tables, db.ts second 2a label, ARCHITECTURE.md invariant, TESTING.md three projects, STATUS.md test count.
+- [ ] npm test: all previous 575 tests pass plus the new files; lint, build, format:check green; summaries pasted.
+- [ ] CHANGELOG Unreleased has a Phase 0 block (and a separate BM25 line if PR 2 shipped).
+- [ ] Acceptance boxes in 05-phase-0-foundations.md section 4 are ticked in the PR.
+```
+
+---
+
+## Prompt 2. Phase 1: storage and migration
+
+```text
+TASK
+Implement Phase 1 as specified in docs/multi-tenant-plan/06-phase-1-storage.md.
+One PR from v2.0/phase-1-storage. This PR changes the schema, the boot
+sequence, the principal model, uploads layout, and the FTS triggers. It is
+the riskiest PR of the project. Work in the task order the document gives.
+
+READ FIRST
+- 06-phase-1-storage.md, all of it. Section 0.3 is a map of server/db.ts;
+  section 0.4 lists the verified engine behaviors; section 2 has the exact DDL.
+- 04-data-model-and-migration.md sections 1, 3, 4, 5, 6, 10, 11, 14.
+- 03-architecture.md sections 4.1, 4.2, 6, 7.
+- bench/review-2026-09-08/README.md, and run script 01 as your day-one smoke test.
+- Code: server/db.ts (whole file), server/services/authService.ts,
+  server/services/passwords.ts, server/middleware/auth.ts,
+  server/services/search/localEmbeddings.ts, server/services/dedupe/embeddings.ts,
+  server/utils/paths.ts, server/routes/contacts.ts:60-80,
+  server/routes/interactions.ts:30-55, tests/integration/api.auth.test.ts,
+  scripts/seed.ts, scripts/seedMock.ts, src/db/schema.ts.
+
+FACTS THAT SHAPE THE WORK
+- Order is not negotiable. The tenancy block runs before the FTS block because
+  the FTS backfill references contacts.ownerId and fails at prepare time on a
+  fresh database if the column is missing. Every integration file boots a
+  fresh database, so a wrong order fails the whole suite.
+- The claim UPDATE and the child backfill must run with the eleven FTS
+  triggers, the three _auto_updated_at triggers, and the three
+  action_items_sync_* triggers dropped. Otherwise the claim costs 5 ms per
+  contact and stamps updatedAt on every row, which makes the next deep dedupe
+  scan re-embed the corpus through the paid provider. Sections 3 to 6 of
+  db.ts recreate all seventeen on the same boot.
+- VACUUM INTO fails inside a transaction. The backup runs before
+  sqlite.transaction() opens.
+- authService.ts imports from db.ts, so db.ts cannot import authService.
+  ensureLocalOwner, primaryAdminId, and claimUnownedData live in db.ts as raw
+  SQL and are exported.
+- Every FTS trigger delete becomes MATCH 'cidTok:...'. Never WHERE contactId = ?.
+- dedupe_exclusions has no id column; its fill trigger keys on the composite
+  primary key.
+- vec0: copy-rebuild only. UPDATE of a partition column is refused. An INSERT
+  without ownerId silently gets a NULL partition, so the verify script counts
+  those. vec_version() returns "v0.1.9"; parse the numbers.
+- requireUser becomes requireSession and returns 403 SESSION_REQUIRED (was
+  USER_REQUIRED). Seven call sites in routes/auth.ts. api.auth.test.ts:379
+  asserts the old code.
+- wipeAccounts() in api.auth.test.ts runs DELETE FROM users, which fails once
+  the local owner owns rows. Task 1.13 gives the new reset shape.
+- scripts/seed.ts and seedMock.ts insert contacts with no ownerId and will hit
+  the required trigger (task 1.14).
+
+DO THIS, IN ORDER
+1. Run bench/review-2026-09-08/01-vec-fts-smoke.cjs against node_modules and
+   also run INSERT OR REPLACE against a partitioned vec0 table. Paste both
+   outputs into the PR. If INSERT OR REPLACE fails, the dedupe upsert becomes
+   DELETE then INSERT (task 1.5).
+2. Tasks 1.1 to 1.16 in the document's order. Build the tenancy block with the
+   exact section order in task 1.8's table. Generate the FTS triggers from one
+   template (task 1.4) and snapshot-test the SQL.
+3. Build tests/fixtures/make-v1-database.ts and the migration test (task 1.12)
+   before you consider the migration done. It must assert updatedAt unchanged,
+   embedBatch never called, seventeen triggers present, second boot silent, and
+   the auth-on variant.
+4. Write scripts/tenancy-verify.ts and scripts/tenancy-rollback-uploads.mjs.
+5. Run the full suite with AUTH_REQUIRED="" (default) and once with
+   AUTH_REQUIRED=true set in tests/integration-setup.ts locally, to exercise
+   both principal paths. Report both summaries.
+6. Do the rollback rehearsal on a copy of a real 1.5.5 database if one is
+   available to you, else on the fixture, and write bench/rollback-rehearsal.md.
+7. Tick the acceptance boxes in section 3 of the phase document.
+
+CONSTRAINTS
+- No WHERE ownerId = ? on reads. requireAdmin exists but is mounted nowhere.
+  No /uploads guard yet. Do not drop the single-column owner indexes.
+- No provider API call may happen during boot on the migration fixture.
+
+DELIVER
+One PR with the body format from Block A, the smoke outputs, both suite
+summaries, the boot log of the migration test showing per-step durations,
+and the final report.
+
+SUCCESS CHECKLIST
+- [ ] Fresh database boots; every integration file passes; the boot order matches task 1.8's table.
+- [ ] tenancy.migration.test.ts passes: verification queries 1 to 11 pass, vector counts and the fixed KNN result unchanged, updatedAt byte-identical, embedBatch never called, backup file present and opens with the old shape, second boot logs no change, auth-on variant keeps the real account.
+- [ ] npm run tenancy:verify passes on a fresh database and on the migrated fixture.
+- [ ] Updating 1,000 contacts on a 5,000-contact database takes under 500 ms (trigger cost test).
+- [ ] FTS rebuild time is logged and under 1 s for 10,000 contacts.
+- [ ] Boot refuses to start with a clear message when vec_version() is below 0.1.6 (unit test with a stubbed statement).
+- [ ] Day-one smoke output and the INSERT OR REPLACE result are in the PR.
+- [ ] Uploads: relocated files exist under uploads/u/<ownerId>/..., URLs rewritten, orphans under uploads/orphaned/, multer destinations use req.principal.
+- [ ] Principal union is the four-variant user union; requireSession returns SESSION_REQUIRED; requireAdmin exists; the local owner is the implicit principal when auth is off; a disabled account is refused; the forced-auth boot rule works; "local" username is rejected.
+- [ ] api.auth.test.ts green with the updated assertions; the harness reset survives the local owner.
+- [ ] npm run seed works on a fresh DATA_DIR.
+- [ ] src/db/schema.ts mirrors every new column and table; tsc passes.
+- [ ] bench/rollback-rehearsal.md committed with commands and output.
+- [ ] Both suite runs (auth off, auth on) green; lint, build, format:check green; summaries pasted.
+- [ ] CHANGELOG Unreleased has a Phase 1 block including the SESSION_REQUIRED breaking change and the measured trigger fix.
+- [ ] Acceptance boxes in 06-phase-1-storage.md section 3 ticked.
+```
+
+---
+
+## Prompt 3. Phase 2a: contacts core and the uploads guard
+
+```text
+TASK
+Implement sub-phase 2a from docs/multi-tenant-plan/07-phase-2-scoping.md.
+One PR from v2.0/phase-2a-contacts. This is the first sub-phase that adds
+owner predicates, and it defines the helpers every later sub-phase reuses.
+
+READ FIRST
+- 07-phase-2-scoping.md sections 0.2, 0.3, 0.4, and 2a.
+- 03-architecture.md section 5 (Scope rules) and section 10 (uploads).
+- 12-testing-strategy.md section 3 (matrix shape).
+- appendix-a-query-inventory.md rows for contactService, contactRepository,
+  routes/contacts.ts, and section A2.
+- Code: server/repositories/contactRepository.ts, server/services/contactService.ts,
+  server/routes/contacts.ts, server/utils/avatarProcessor.ts, server/app.ts,
+  server/utils/AppError.ts, tests/integration/api.contacts.test.ts.
+
+FACTS THAT SHAPE THE WORK
+- Add findOwned, findOwnedActive, findManyOwned, requireOwned to
+  contactRepository first. Every later sub-phase calls them.
+- hydrate and hydrateMany do not change, but they read lists and interactions
+  by contact id; those statements get // tenant-lint: allow owner-checked by caller.
+- getSlimContacts is seven statements; pass 2 has an inner
+  SELECT id FROM contacts subselect that needs the owner predicate.
+- hardDeleteContact, the Doc2Query fire-and-forget blocks, and the non-stream
+  bulk import tail were missed by the first inventory; the 2a table lists them
+  with line numbers.
+- The import-time duplicate matching in routes/contacts.ts calls three dedupe
+  functions (normalizeContacts, loadNegativeConstraints, normalizeContactById).
+  Change only those three signatures in this PR so routes/contacts.ts can go
+  strict; the rest of dedupe waits for 2e.
+- explainScore writes relationshipScore; the allow comment covers that UPDATE.
+- The uploads guard is a regex on req.path against req.principal.user.id, no
+  database read, mounted between requireAuth and express.static.
+
+DO THIS
+1. Repository helpers, then contactService functions in the 2a table order,
+   then routes/contacts.ts, then avatarProcessor, then the guard.
+2. Move server/repositories/contactRepository.ts, server/services/contactService.ts,
+   server/routes/contacts.ts, server/utils/avatarProcessor.ts, and
+   server/middleware/uploads.ts into the tenant-lint --strict glob.
+3. Replace every it.todo for routes in server/routes/contacts.ts and for
+   /uploads with real matrix tests per section 0.4. Flip isolated: true for
+   each in ROUTE_MANIFEST.
+4. Run the existing api.contacts, api.lifecycle, api.avatar suites; they run
+   as the local owner and must pass unchanged.
+5. Tick the 2a-relevant items in the phase's acceptance list and add the
+   Phase 2a CHANGELOG line.
+
+CONSTRAINTS
+- Do not convert interactions, lists, search, dashboard, dedupe (beyond the
+  three functions), AI, export, or MCP. Do not mount requireAdmin.
+- invalidateAllCaches may keep the whole-tier flush with a TODO(2f) comment.
+
+SUCCESS CHECKLIST
+- [ ] findOwned, findOwnedActive, findManyOwned, requireOwned exist and are used; no service selects by id then compares in JavaScript.
+- [ ] Every function in the 2a table takes scope first; every owned-table statement in the five files carries ownerId or an allow comment with a listed reason.
+- [ ] tenant-lint --strict passes for the five files.
+- [ ] Matrix tests for every contacts route and /uploads are real and green: foreign id 404 with a body identical to a random UUID's 404; bulk operations affect only the caller's rows and report the right count; A's rows unchanged after B's attempts.
+- [ ] guardUploads: B fetching A's avatar 404, A 200, /uploads/logos/* 200 for both, any other /uploads path 404.
+- [ ] Doc2Query and the bulk-import tail run inside runWithContext with the captured scope; recordInvocation rows from them carry the owner.
+- [ ] Existing contacts, lifecycle, and avatar suites pass unchanged.
+- [ ] isolated: true flipped for every route in this PR.
+- [ ] lint, test, build, format:check green; summaries pasted.
+```
+
+---
+
+## Prompt 4. Phase 2b and 2d: interactions, action items, lists, dashboard, zero-state
+
+```text
+TASK
+Implement sub-phases 2b and 2d from docs/multi-tenant-plan/07-phase-2-scoping.md
+as one PR from v2.0/phase-2b-2d-timeline-dashboard, or two PRs if the diff
+passes 1,500 lines (2b first).
+
+READ FIRST
+- 07-phase-2-scoping.md sections 0.3, 0.4, 2b, and 2d.
+- appendix-a-query-inventory.md rows for interactionService, actionItemService,
+  listService, dashboardService, zeroStateService, relationshipService, and A2.
+- Code: server/services/interactionService.ts, server/services/actionItemService.ts,
+  server/services/listService.ts, server/routes/interactions.ts,
+  server/routes/actionItems.ts, server/routes/lists.ts,
+  server/services/dashboardService.ts, server/services/zeroStateService.ts,
+  server/routes/dashboard.ts, server/utils/aiCache.ts:100-110,
+  tests/integration/api.interactions.test.ts.
+
+FACTS THAT SHAPE THE WORK
+- interactionService has 18 Drizzle calls, not 6. Two mention paths exist: the
+  AI path resolves names with eq(contacts.name, m.name) and writes
+  interactions.mentions JSON; the explicit data-id path inserts client-supplied
+  ids into interaction_mentions with INSERT OR IGNORE and no check. Both need
+  the owner guard. The mention-extraction setTimeout captures scope and runs
+  inside runWithContext.
+- actionItemService keeps its JOIN contacts for the payload columns; only the
+  owner predicate moves to action_items using the composite indexes.
+- listService.createList's MAX(sortOrder) is unscoped; removeMember checks
+  nothing today; bulkAddMembers checks the list only.
+- dashboardService: nine statements in getDashboardPayload (:57-191), six in
+  getInsight (:232-295). The dailyInsight cache key becomes the owner id and
+  its maxEntries goes from 1 to 100.
+- zeroStateService has five statements, not six.
+- relationshipService does not change beyond allow comments (its UPDATE in
+  explainScore included).
+
+DO THIS
+1. 2b in the table order, then 2d.
+2. Move the nine files into the strict glob.
+3. Replace the it.todo entries for every route in routes/interactions.ts,
+   routes/actionItems.ts, routes/lists.ts, and routes/dashboard.ts with real
+   tests; flip isolated: true.
+4. Add the 2d isolation tests: B's dashboard totals are zero after A seeds 50
+   contacts; B's zero-state lists none of A's contacts; B's insight is not A's
+   cached insight.
+5. Existing api.interactions and list tests pass unchanged. CHANGELOG lines.
+
+CONSTRAINTS
+- MCP routes stay for 2g, but mcpService statements for interactions may gain
+  the predicate here only if it keeps the file compiling; otherwise leave
+  mcpService untouched.
+- No changes to search, dedupe, AI Search, export.
+
+SUCCESS CHECKLIST
+- [ ] Every function in the 2b and 2d tables takes scope first with the predicate in the same statement.
+- [ ] Both mention paths guard ownership; a ghost from a mention carries the caller's owner; a client-supplied foreign contact id in data-id is dropped, not linked.
+- [ ] Each owner's lists number from zero; reorder with a foreign id returns 404; removeMember and bulkAddMembers verify both list and contact.
+- [ ] Pending, completed, and urgent action item queries use idx_action_items_owner_due or idx_action_items_owner_done (check with EXPLAIN QUERY PLAN in a quick test).
+- [ ] Dashboard, insight, and zero-state scoped; dailyInsight keyed per owner with maxEntries 100.
+- [ ] tenant-lint --strict passes for all nine files.
+- [ ] Matrix tests real and green for every route in the four route files; isolated flipped.
+- [ ] Existing interaction, action item, list, and dashboard tests pass unchanged.
+- [ ] lint, test, build, format:check green; summaries pasted.
+```
+
+---
+
+## Prompt 5. Phase 2c and 2f: search, embeddings, AI cache, AI stats, AI Search batches
+
+```text
+TASK
+Implement sub-phases 2c and 2f from docs/multi-tenant-plan/07-phase-2-scoping.md
+as one PR from v2.0/phase-2c-2f-search-ai, or two PRs (2c first) if the diff
+passes 1,500 lines.
+
+READ FIRST
+- 07-phase-2-scoping.md sections 0.3 (rules 6, 7, 10 especially), 2c, and 2f.
+- 03-architecture.md sections 6, 7, and 9.
+- appendix-a-query-inventory.md rows for searchService, hybridRetrieval,
+  localEmbeddings, dedupe/embeddings, aiCache, aiStatsService, aiSearch/*, and A2.
+- Code: server/services/searchService.ts, server/services/search/hybridRetrieval.ts,
+  server/services/search/localEmbeddings.ts, server/services/dedupe/embeddings.ts,
+  server/services/dedupe/blocking.ts:160-180, server/services/dedupe/context.ts:69-99,
+  server/routes/search.ts, server/utils/aiCache.ts, server/services/aiStatsService.ts,
+  server/routes/aiStats.ts, server/services/aiSearch/jobQueue.ts,
+  server/services/aiSearch/mergeEngine.ts, server/routes/aiSearch.ts,
+  server/ai/services/searchIntel.ts (cache key sites only).
+
+FACTS THAT SHAPE THE WORK
+- The FTS entry point for GET /api/search is searchService.searchFts, one
+  "<q>"* query with ORDER BY rank; the three-strategy list is in
+  hybridRetrieval.ftsRetrieval. Both get the ownerTok:<token> AND (...) wrapper.
+  BM25_WEIGHTS already has twelve values from Phase 1.
+- The rerank cache key is built in aiCache.getCachedSearch and setCachedSearch,
+  called from seven sites in searchService.ts, not in searchIntel.ts. rerank,
+  synthesis, briefing, dailyInsight get the owner prefix. queryParse, hyde, and
+  mentions stay shared unless Q14 says "prefixed".
+- There are three private contact_embeddings MATCH statements outside
+  _stmts.knn: blocking.addEmbeddingCandidates and context.getEmbeddingSimilarity
+  (both in 2c's table). All KNN statements gain AND ownerId = ?; the
+  preFilterIds JavaScript post-filter stays for the hard-filter case.
+- POST /api/search/semantic streams NDJSON when Accept asks for it and
+  /synthesize always streams. Capture scope before the stream starts. The test
+  asserts recordInvocation rows written during the stream carry the owner.
+- aiSearch: the batch stores ownerId; cooldown becomes per owner; the global
+  lock stays; processBatch wraps the run in runWithContext. The 429 at
+  routes/aiSearch.ts:75-78 bypasses AppError today and becomes
+  next(new RateLimitedError(message, { yours, queued: false, retryAfterSeconds })).
+  Patch src/api/aiSearch.ts:29 to read error.error.message so the UI keeps
+  showing the message; Phase 4 does the rest.
+- mergeEngine.invalidateSearchCache() flushes the whole rerank tier; it becomes
+  an owner-prefix invalidation.
+- 25 recordInvocation call sites do not change; the context does the work.
+  getSummary and getFeed take scope; cacheTiers is omitted for members.
+
+DO THIS
+1. 2c in table order, then 2f. Add ownerKey and invalidateForOwner to aiCache.
+2. Move the listed files into the strict glob (leave the dedupe files other
+   than embeddings.ts for 2e, but the two private MATCH statements in
+   blocking.ts and context.ts gain the predicate now).
+3. Matrix tests: A has "Zebulon Quarrington"; B's GET /api/search, semantic
+   (JSON and NDJSON), and synthesize never return it even when it is the only
+   match. A's cached rerank is a miss for B. B's ai-search status and stream
+   for A's batchId return 404 before any event. B's AI stats count only B's
+   invocations. Flip isolated for the search, ai-search, and ai/stats routes.
+4. Run tests/unit/search.test.ts and the api.aiSearch suite unchanged.
+
+CONSTRAINTS
+- Do not change dedupe scan logic, suggestions, or merging (2e).
+- No new dependencies.
+
+SUCCESS CHECKLIST
+- [ ] Every FTS query wraps the strategy with the owner token; EXPLAIN QUERY PLAN shows only the MATCH index scan.
+- [ ] Every KNN statement (search, dedupe _stmts.knn, addEmbeddingCandidates, getEmbeddingSimilarity) filters by owner; getSearchEmbeddingCount is per owner with an unscoped boot-log variant behind an allow comment.
+- [ ] Candidate hydration uses findManyOwned or findOwned, including buildCompressedCandidates.
+- [ ] rerank, synthesis, briefing, dailyInsight keys are owner-prefixed; invalidateForOwner exists; mergeEngine uses it; Q14 applied to mentions.
+- [ ] NDJSON and SSE handlers capture scope in the closure; the attribution test passes.
+- [ ] aiSearch batches carry ownerId, cooldown is per owner, the lock is global, the 429 uses the standard envelope with details.yours, and the frontend reads the new shape.
+- [ ] AI stats summary and feed are scoped; cacheTiers omitted for members.
+- [ ] tenant-lint --strict passes for every file this PR touches.
+- [ ] Matrix tests real and green; isolated flipped for the routes in this PR.
+- [ ] Existing search and aiSearch suites pass; lint, test, build, format:check green; summaries pasted.
+```
+
+---
+
+## Prompt 6. Phase 2e: dedupe
+
+```text
+TASK
+Implement sub-phase 2e from docs/multi-tenant-plan/07-phase-2-scoping.md. One
+PR from v2.0/phase-2e-dedupe. This is the largest sub-phase. Convert
+merging.ts last.
+
+READ FIRST
+- 07-phase-2-scoping.md sections 0.3, 0.4, and 2e (both rules and the table).
+- 03-architecture.md section 9 (dedupeQueue row) and section 5.4.
+- appendix-a-query-inventory.md rows for every server/services/dedupe/* file,
+  server/routes/dedupe/*, and section A2.
+- Code: every file under server/services/dedupe/ and server/routes/dedupe/,
+  server/services/contactService.ts:61-84 (scheduleIncrementalDedupe),
+  tests/integration/dedupe.test.ts, tests/integration/api.merge.test.ts.
+
+FACTS THAT SHAPE THE WORK
+- Two rules: a scan runs for one owner over that owner's active contacts only,
+  and every merge asserts both contacts share the scope before any child
+  statement runs (so the error is a 404, not a trigger 500).
+- normalizeContacts, loadNegativeConstraints, and normalizeContactById already
+  take scope from 2a; finish their bodies here (the five child-table batch
+  loads join contacts on owner; the interaction_mentions self-join in
+  loadNegativeConstraints joins interactions on owner).
+- Full-mode scan runs DELETE FROM contact_embeddings with no predicate and
+  clearEmbeddingMeta(), which wipes every owner's dedupe index; scope both.
+  Deep mode's findStaleEmbeddings and reEmbedStaleContacts are instance-wide;
+  scope them.
+- incrementalDedupeCheck has no request; it loads the contact's ownerId, builds
+  scopeForOwnerId, and runs inside runWithContext.
+- merging.ts has 59 statements and never inserts a contact. The up-front
+  two-row owner check must run first; parent contacts statements gain
+  AND ownerId = ?; child statements get the allow comment. Re-parenting
+  interactions keeps ownerId unchanged, which the mismatch trigger accepts
+  because both contacts share the owner.
+- dedupeQueue: scans carry ownerId; getScan and getActiveScan filter by owner;
+  the run lock stays global with a per-owner FIFO. The 429 at
+  routes/dedupe/scan.ts:47-49 bypasses AppError and becomes RateLimitedError
+  with details { yours, queued }. Patch src/api/dedupe.ts:40-43 to read
+  error.error.message. GET /stream captures scope before dedupeQueue.on(...)
+  and never reads the context inside the listener.
+- POST /backfill-embeddings is classed admin (mounted in Phase 3); it stays
+  an instance operation. GET /embedding-status returns the owner's counts.
+
+DO THIS
+1. normalization, blocking, context, passes, engine, suggestions, jobQueue,
+   routes, then merging last.
+2. Move all dedupe service and route files into the strict glob.
+3. Isolation tests per the 2e paragraph: identical "Jane Doe" pairs under A
+   and B; A's scan finds one cluster with A's two contacts; B's suggestions are
+   empty; B merging A's ids gets 404; B reading A's scan status gets 404; B
+   undoing A's merge-log id gets 404; a full-mode scan by A leaves B's
+   contact_embeddings count unchanged. Flip isolated for every dedupe and
+   merge route.
+4. Run the existing dedupe.test.ts and api.merge.test.ts unchanged, then run
+   them a second time with two seeded owners to check the merge logic.
+5. CHANGELOG line for the 429 envelope change (breaking shape).
+
+CONSTRAINTS
+- Do not change merge semantics, thresholds, or pass logic. Predicates and
+  signatures only, plus the queue state.
+- No requireAdmin mounting.
+
+SUCCESS CHECKLIST
+- [ ] A scan by one owner reads only that owner's contacts, child rows, exclusions, mention constraints, and embeddings; the normalized maps hold only that owner's rows.
+- [ ] Full-mode and deep-mode scans touch only the scanning owner's embeddings and meta rows.
+- [ ] Every suggestion, exclusion, and merge-log row is inserted with the scope's owner; every read filters by it.
+- [ ] mergeContacts and softMergeContacts reject a pair that is not both owned by the caller with 404 before any child statement; the existing merge tests pass as two owners.
+- [ ] dedupeQueue state is per owner; the FIFO starts the next owner's scan; status, stream, and active return 404 or nothing for a foreign scan; the stream handler never calls currentScope() inside the listener.
+- [ ] The scan 429 uses the standard envelope with details.yours and details.queued; the frontend shows the message.
+- [ ] incrementalDedupeCheck and seedDuplicates carry the right owner.
+- [ ] tenant-lint --strict passes for every dedupe file, with allow comments only on child statements after the owner check.
+- [ ] Matrix and cross-owner dedupe tests real and green; isolated flipped for every dedupe and merge route.
+- [ ] lint, test, build, format:check green; summaries pasted.
+```
+
+---
+
+## Prompt 7. Phase 2g, 2h, 2i: export, MCP, settings classes, background jobs, strict lint, plan tests
+
+```text
+TASK
+Implement sub-phases 2g, 2h, and 2i from docs/multi-tenant-plan/07-phase-2-scoping.md
+as one PR from v2.0/phase-2g-2i-closing. This PR ends Phase 2: the matrix
+has no it.todo left and tenant-lint --strict covers all of server/.
+
+READ FIRST
+- 07-phase-2-scoping.md sections 2g, 2h, 2i, and the acceptance list in section 2.
+- 12-testing-strategy.md sections 4 and 6.
+- 04-data-model-and-migration.md section 8 (the indexes to drop).
+- appendix-b-route-manifest.md (classes for export, backups, settings, ai, mcp).
+- Code: server/services/exportService.ts, server/routes/dataLifecycle.ts,
+  server/services/mcpService.ts, server/routes/mcp.ts, server/routes/aiSettings.ts,
+  server/routes/ai.ts, server/routes/auth.ts (session-policy), server.ts,
+  server/services/search/localEmbeddings.ts:322-408,
+  server/services/dedupe/embeddings.ts:373-450, server/db.ts (tenancy block),
+  scripts/tenant-lint.mjs, package.json.
+
+FACTS THAT SHAPE THE WORK
+- buildFullExport takes no argument today; it becomes buildFullExport(scope)
+  and every table filters by owner (list_members through lists.ownerId).
+- mcpService.queryContacts has no deletedAt or isGhost filter; add both while
+  rewriting the statement and note it in the CHANGELOG as a fix. getTags
+  joins contact_tags to contacts.
+- Backups, AI settings writes, session-policy PUT, ai diagnostics, grounding
+  capacity, and dedupe backfill are classed admin in the manifest here; the
+  middleware is mounted in Phase 3. Set the class, do not mount.
+- Background jobs: backfillSearchEmbeddings and backfillEmbeddings iterate
+  SELECT DISTINCT ownerId FROM contacts and run each owner's batch inside
+  runWithContext, interleaving owners in rounds of 200. Sweeps that do
+  uniform per-row work stay instance-wide with allow comments.
+- 2i drops the four single-column owner indexes with a TENANCY_SCHEMA_VERSION
+  = 2 step (see 2i for the mechanics) after the plan tests prove the
+  composites are used.
+
+DO THIS
+1. 2g in table order, then 2h.
+2. 2i: package.json lint:tenant with --strict "server/**/*.ts" inside npm run
+   lint; tests/integration/tenancy.queryPlans.test.ts with the eleven
+   statements in the 2i table (seed two owners with 500 contacts each, ANALYZE,
+   assert the named index and no SCAN); the manifest assertion that every
+   scoped route is isolated; zero it.todo left; the index-drop step and its
+   migration test case; bench-tenancy at 10 x 2000 committed as bench/phase-2.md.
+3. Tick every box in section 2 of the phase document.
+
+CONSTRAINTS
+- Do not mount requireAdmin. Do not add admin endpoints.
+- The frontend changes only where a response shape changed (export filename
+  is additive; nothing else here).
+
+SUCCESS CHECKLIST
+- [ ] Export JSON and CSV contain only the caller's rows in every table; filename includes the username.
+- [ ] Every mcpService function is scoped; queryContacts excludes trashed and ghost rows; MCP routes work with a personal-token principal inserted directly (Phase 3 adds creation).
+- [ ] Manifest classes set for backups, AI settings writes, session-policy PUT, diagnostics, grounding capacity, backfill-embeddings, and the instance-read routes.
+- [ ] Both embedding backfills run per owner inside a context; recordInvocation rows from a boot backfill carry the owner.
+- [ ] npm run lint includes tenant-lint --strict "server/**/*.ts" and passes.
+- [ ] tenancy.queryPlans.test.ts passes for all eleven statements.
+- [ ] tenancy.isolation.test.ts has zero it.todo; every scoped route has isolated: true; the manifest test asserts it.
+- [ ] The four single-column owner indexes are dropped by the version-2 step; the loop no longer recreates them; the migration test covers a version-1 database.
+- [ ] bench/phase-2.md committed; at 10 x 2000 the slim list p95 is under 40 ms, FTS search under 10 ms, semantic (mock AI) under 30 ms, dashboard under 60 ms, or the deviation is explained with a fix.
+- [ ] Every box in 07-phase-2-scoping.md section 2 is ticked.
+- [ ] lint, test, build, format:check green; summaries pasted.
+```
+
+---
+
+## Prompt 8. Phase 3: accounts, roles, and the admin API
+
+```text
+TASK
+Implement Phase 3 as specified in docs/multi-tenant-plan/08-phase-3-accounts-admin.md.
+One PR from v2.0/phase-3-accounts-admin, or two (accounts and admin routes
+first; tokens, registration, audit, limiter, maintenance interval second).
+
+READ FIRST
+- 08-phase-3-accounts-admin.md, all of it. Section 0.2 lists the exact state
+  and the FK behaviors the purge depends on.
+- 13-api-changes.md sections 1, 3, and 4 (every shape you implement).
+- 03-architecture.md sections 4.3, 4.4, and 5.4.
+- 04-data-model-and-migration.md section 2 (the identity tables you fill).
+- Code: server/middleware/auth.ts, server/middleware/rateLimit.ts,
+  server/routes/auth.ts, server/services/authService.ts, server/services/passwords.ts,
+  server/services/settingsService.ts, server/services/exportService.ts,
+  server/routes/dataLifecycle.ts, server/routes/aiSettings.ts, server/routes/ai.ts,
+  server/routes/dedupe/embeddings.ts, server/routes/aiStats.ts, server.ts,
+  server/utils/validators.ts, server/tenancy/routeManifest.ts.
+
+FACTS THAT SHAPE THE WORK
+- requireAdmin goes on each route at route level, not router.use, so the
+  manifest test can find it in route.stack. It must be a named function.
+- The per-IP AI limiter mounts before attachPrincipal. The new per-user
+  limiter (keyBy on principal.user.id, 30 per minute) mounts after
+  attachPrincipal and attachRequestContext. Apply Q16 to the pattern list.
+  Both limiters set Retry-After.
+- credentialLimiter is module-private to routes/auth.ts; register and
+  accept-invitation live in that file.
+- There is no daily sweep today. Task 3.8 adds one interval in server.ts,
+  gated by DISABLE_BACKGROUND_JOBS, for audit_log, expired sessions, aged
+  revoked tokens, aged dead invitations, and old invocations (move the
+  boot-only cleanupOldInvocations call into it).
+- Purge order in 3.5 is exact. search_embeddings, contact_embeddings,
+  dedupe_embedding_meta, and dedupe_merge_log have no FK and are deleted by
+  hand. vec0 DELETE by partition key works. Acceptance is 10,000 contacts
+  under 2 s; the chunking fallback is described.
+- Deleting an admin cascades their pending invitations (invitedBy CASCADE).
+- The local owner row cannot be disabled or deleted while auth is off.
+- /api/auth/status keeps both existingContacts and deviceContacts in 2.0.
+
+DO THIS
+1. Tasks 3.1 to 3.14 in the document's order. Use validateBody with zod for
+   every admin body. Every admin action writes an audit row through auditService.
+2. Add every new route to ROUTE_MANIFEST with its class. Extend the manifest
+   test to assert requireAdmin in every admin route's stack.
+3. Write tests/integration/api.admin.test.ts covering the whole acceptance
+   list in section 3 with the two-user harness plus a third actor.
+4. Measure the purge on a 10,000-contact owner and record the time in the PR.
+5. Tick the acceptance boxes in section 3.
+
+CONSTRAINTS
+- No UI. No reverse-proxy auth, OIDC, or email. Do not remove
+  PUT /api/auth/session-policy or the environment API_TOKEN.
+- Audit details never contain a password, token, invitation secret, or key.
+
+SUCCESS CHECKLIST
+- [ ] Every admin route returns 403 ADMIN_REQUIRED to a member and 200 to an admin; the manifest test proves requireAdmin is on each one.
+- [ ] Temporary password flow: forced 403 PASSWORD_CHANGE_REQUIRED on every data route (session and token), change succeeds, routes work.
+- [ ] Invitations: single use; used, expired, revoked return 410 with their codes; unknown and malformed tokens return the same 404 body.
+- [ ] Disable revokes sessions and refuses tokens; enable restores tokens only.
+- [ ] Delete without decision returns 409 USER_HAS_DATA with counts; purge removes every owned row, vector row, meta row, FTS row, and the upload directory; other owners' counts unchanged; 10,000 contacts under 2 s (time recorded).
+- [ ] Last-admin and self guards return 409 LAST_ADMIN and 400 CANNOT_TARGET_SELF.
+- [ ] Tokens: work on contacts and every MCP route; refused on /me with SESSION_REQUIRED; revoked, expired, disabled all 401; lastUsedAt at most hourly; eleventh token in an hour 429.
+- [ ] Registration closed by default (403 REGISTRATION_CLOSED); open creates a member.
+- [ ] Every listed audit action produces one row; GET /api/admin/audit paginates; a grep of the test output finds no ctk_ token or seeded password.
+- [ ] Per-user AI limiter: 31st request in a minute is 429 with Retry-After; another user on the same IP unaffected; Q16 routes covered.
+- [ ] Daily maintenance interval sweeps the five tables under an advanced clock and is gated by DISABLE_BACKGROUND_JOBS.
+- [ ] Legacy API_TOKEN maps to the primary admin and warns once; status reports legacyTokenConfigured.
+- [ ] tenant-lint --strict green; manifest green with the new rows; lint, test, build, format:check green; summaries pasted.
+- [ ] CHANGELOG Phase 3 block; acceptance boxes in 08 section 3 ticked.
+```
+
+---
+
+## Prompt 9. Phase 4: frontend
+
+```text
+TASK
+Implement Phase 4 as specified in docs/multi-tenant-plan/09-phase-4-frontend.md.
+Two PRs from v2.0/phase-4-auth-account (tasks 4.1 to 4.6, 4.10, 4.11, 4.12)
+and v2.0/phase-4-admin (tasks 4.7 to 4.9), in that order.
+
+READ FIRST
+- 09-phase-4-frontend.md, all of it. Section 0.2 is a table of the exact
+  frontend facts with v1.5.5 line numbers; read it twice.
+- 13-api-changes.md sections 2, 3, and 4 (the contracts you consume).
+- .agent/STYLE.md, src/components/ui/Modal.tsx, src/components/ui/IconButton.tsx.
+- Code: src/main.tsx, src/components/auth/*, src/api/*.ts, src/lib/appEvents.ts,
+  src/App.tsx, src/views/SettingsView.tsx, src/views/settings/*, src/contexts/*,
+  src/views/dedupe/DedupeView.tsx, src/views/ai-search/*, src/views/ai-stats/*,
+  src/components/layout/Sidebar.tsx, tests/unit/frontend.*.test.ts,
+  scripts/contrast-audit.mjs.
+
+FACTS THAT SHAPE THE WORK
+- AuthContext.Provider wraps children only in the open state today; move it
+  above the screen switch so the new screens can call useAuth().
+- AuthGate mounts outside BrowserRouter. The join state reads window.location,
+  not useLocation, and calls history.replaceState before handleAuthenticated.
+- One rule hides account UI: !authRequired. The client does not need via.
+- Ten of twelve API modules call fetch directly. Task 4.11 adds
+  handleResponse in src/api/client.ts and migrates every module; a unit test
+  scans src/api/ to keep it that way. emitAuthExpired becomes a CustomEvent
+  with detail.reason; a new emitPasswordChangeRequired exists. EventSource
+  streams fall back to status polling after an error event.
+- The sidebar is desktop only; the identity row also renders at the top of
+  SettingsHome for mobile.
+- SettingsView uses static imports; the admin routes become React.lazy inside
+  it. No backups UI exists today; BackupsView is new. /settings/ai-config
+  becomes a Navigate.
+- The "Signed in on" section is where the API tokens section goes; session
+  length moves to the admin Instance view.
+- Dedupe and AI Search 429 bodies are the standard envelope with details.yours
+  since Phase 2; enrichment.ts:67 must stop labelling every 429 as a grounding
+  quota error.
+- Write the bottom-sheet and 44 px rules into .agent/STYLE.md; they exist in
+  the primitives but not in the document.
+
+DO THIS
+1. PR 1: tasks 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.10, 4.11, 4.12. Start with 4.11
+   (the shared handler) because everything else reports errors through it.
+2. PR 2: tasks 4.7, 4.8, 4.9 with src/api/admin.ts following the aiSettings.ts
+   pattern.
+3. Record the manual walkthrough with screenshots in bench/ui-walkthrough.md
+   and the two-browser check.
+4. Run npm run audit:contrast and npm run build; confirm the admin chunk is
+   separate in the build output.
+5. Tick the acceptance boxes in section 3.
+
+CONSTRAINTS
+- Server enforcement is the real gate; RequireAdmin only hides UI.
+- No per-user preferences UI. No instance branding beyond what the features
+  decision record accepted.
+- Follow STYLE.md: surface shifts not borders, pill buttons, glass-panel,
+  the Modal and IconButton primitives.
+
+SUCCESS CHECKLIST
+- [ ] Gate states: setup (with "Secure this instance" when localOwnerPresent), signin with expired and disabled reasons, join from /join?token=, register when open, password-change when forced, open.
+- [ ] useAuth exposes user, authRequired, isAdmin, mustChangePassword, registrationOpen, legacyTokenConfigured, localOwnerPresent, refresh, signOut; available on every screen.
+- [ ] Account UI (identity, tokens, sign-out) hidden when !authRequired everywhere.
+- [ ] Prefetch of ["contacts"] happens after the gate opens; identity change remounts AppScope and clears the query cache.
+- [ ] API tokens section: create shows the token once, list, revoke; legacy banner when legacyTokenConfigured.
+- [ ] tests/unit/frontend.apiClient.test.ts passes: no module under src/api/ except auth.ts and client.ts calls fetch without the shared handler; 401, 403 codes, and 429 details flow to the gate or the UI; EventSource error falls back to polling.
+- [ ] Admin area: Users (with "This device" badge), Create user, Invitations with one-time link display, Instance (registration, session length, AI configuration, SearXNG), Backups (new), Audit with load more; all lazy-loaded; RequireAdmin redirects members; /settings/ai-config redirects.
+- [ ] Delete flow shows counts from the 409 then requires the checkbox and sends decision: "purge"; reset flow shows the temporary password once.
+- [ ] AI stats "Mine / All users" for admins; members see only their own.
+- [ ] Dedupe queued state polls until the owner's scan appears; AI Search cooldown uses retryAfterSeconds; enrichment 429 message is correct.
+- [ ] Mobile: identity row at the top of Settings; admin tables as cards; modals as bottom sheets; 44 px targets.
+- [ ] bench/ui-walkthrough.md with screenshots; two-browser check recorded; audit:contrast passes; build output shows a separate admin chunk.
+- [ ] .agent/STYLE.md gains the two mobile rules; new unit tests for invite link parsing and temporary-password formatting.
+- [ ] lint, test, build, format:check green; summaries pasted; CHANGELOG Phase 4 block; acceptance boxes in 09 section 3 ticked.
+```
+
+---
+
+## Prompt 10. Accepted 2.0 extras and quality stories
+
+```text
+TASK
+Implement the items the decision record in
+docs/multi-tenant-plan/15-additional-v2-features.md section 9 marks as
+accepted for 2.0: any of F1 to F6 (section 2), the 2.0 headline features
+(section 5), and the 2.0 quality stories (section 7). One PR per item, from
+v2.0/extra-<slug>, in the order the decision record lists them. If the
+record is empty, stop and ask which items are accepted.
+
+READ FIRST
+- 15-additional-v2-features.md: the rules at the top, the row and the detail
+  paragraph for each accepted item, and section 9.
+- For a headline feature: 13-api-changes.md (add your endpoints to it),
+  appendix-b-route-manifest.md (add rows), 12-testing-strategy.md section 3.
+- The phase document that owns the code you touch (for example 08 for the
+  admin health panel, 07 section 2e for the import scan, 06 for anything near
+  the migration).
+
+FACTS THAT SHAPE THE WORK
+- An extra must be additive. It may not change a table the migration touches
+  and may not weaken an isolation guarantee. A new table gets ownerId, a
+  required trigger, and a scoped repository from the first commit. Every new
+  endpoint gets a manifest row and a matrix test in the same PR.
+- The MCP server (feature 1) is a separate package that talks to the HTTP API
+  with a personal token; it touches no database code. Its one dependency (the
+  MCP SDK) is authorized by the features document.
+- Quick Capture (feature 2) adds a captures table and a share_target to
+  public/site.webmanifest; proposals are produced by the existing
+  parseContactRecord and mention extraction.
+- Nudges (feature 3) are outbound only, opt-in, per user, stored in
+  user_settings, delivered by the Phase 3 maintenance interval, and every URL
+  passes the existing urlSafety pinning.
+- Reconnect drafts (feature 5) are a new capability in the capability router
+  and are cached per owner.
+- Quality stories name their file and line; do exactly what the paragraph says.
+
+DO THIS
+For each accepted item: read its paragraph, implement it, add tests (matrix
+tests for any endpoint, an eval baseline for the search gate, a timing test
+for the import scan), add its CHANGELOG bullet and its docs/api-reference.md
+section if it has an endpoint, open the PR, and record the outcome in the
+decision record table.
+
+CONSTRAINTS
+- Nothing here may start after the Phase 5 security review begins.
+- No dependency other than the ones the features document names.
+
+SUCCESS CHECKLIST (per item)
+- [ ] The item does exactly what its paragraph in 15 describes; its "done when" line holds.
+- [ ] New tables are owned and scoped; new endpoints have manifest rows and green matrix tests; tenant-lint --strict still passes.
+- [ ] docs/api-reference.md and 13-api-changes.md updated for any endpoint.
+- [ ] CHANGELOG bullet under Unreleased; decision record row filled with the PR number.
+- [ ] lint, test, build, format:check green; summaries pasted.
+```
+
+---
+
+## Prompt 11. Phase 5: hardening, performance, security review, documentation
+
+```text
+TASK
+Implement sections 1, 2, and 3 of docs/multi-tenant-plan/10-phase-5-hardening-release.md
+as one or more PRs from v2.0/phase-5-hardening. Do not perform the release
+(section 4); that is the next prompt.
+
+READ FIRST
+- 10-phase-5-hardening-release.md sections 0 to 3 and 5.
+- 12-testing-strategy.md sections 8 and 9.
+- 14-risks-and-open-questions.md section 3 (the risks this phase closes).
+- bench/baseline-phase-0.md and bench/phase-2.md (the before numbers).
+- Every document in section 3's table, and .agent/PHILOSOPHY.md,
+  .agent/ARCHITECTURE.md, .agent/TESTING.md, .agent/STATUS.md.
+
+FACTS THAT SHAPE THE WORK
+- The benchmark targets are p95 on laptop-class hardware with mock AI; the
+  purge target is 10,000 contacts under 2 s and the boot migration on the
+  10,000-contact fixture under 5 s excluding the backup copy.
+- The concurrency run includes a dedupe scan and a 5,000-contact purge midway
+  and expects zero SQLITE_BUSY 503s. If any appear, shorten the transaction,
+  do not raise busy_timeout.
+- The security checklist has a "Streams" row: grep for currentScope() inside
+  listeners and expect none.
+- docs/configuration.md's forgot-password recipe NULLs ownerId on four tables
+  and deletes users; it cannot work in 2.0. Rewrite it per section 3.
+- docs/upgrade-2.0.md is new and lists every breaking change from section 3,
+  including SESSION_REQUIRED and the 429 envelope, with the measured
+  migration durations.
+
+DO THIS
+1. Section 1: run bench-tenancy at the four shapes, write bench-concurrency
+   and run it, do the index audit and the memory measurement; write
+   bench/phase-5.md. Fix any target miss with an index or a rewrite and record it.
+2. Section 2: run the security-review skill over git diff main...v2.0, then
+   walk the checklist by hand; write bench/security-review.md with a status
+   per row; fix findings in this PR or open follow-ups the release cannot
+   ship without.
+3. Section 3: update every listed document. Read each one end to end after
+   editing; the acceptance criterion is "reviewed by reading, not by grep".
+4. Tick the acceptance boxes in section 5 that belong to sections 1 to 3.
+
+CONSTRAINTS
+- No new features. No version bump. No release steps.
+
+SUCCESS CHECKLIST
+- [ ] bench/phase-5.md: four shapes, every target met or a deviation explained with the fix, contract test summary, final index list, memory numbers.
+- [ ] bench-concurrency: zero 503s with 10 owners, a scan, and a purge; p95 and longest write wait recorded.
+- [ ] bench/security-review.md: every checklist row closed or linked to a fix in this PR.
+- [ ] Every document in section 3 updated, including the new docs/upgrade-2.0.md and the rewritten forgot-password recipe.
+- [ ] CHANGELOG Unreleased blocks are complete and correct for every phase and accepted extra (the release prompt regroups them).
+- [ ] lint, test, build, format:check green; summaries pasted; the section 5 boxes for hardening ticked.
+```
+
+---
+
+## Prompt 12. Release 2.0.0
+
+```text
+TASK
+Perform section 4 of docs/multi-tenant-plan/10-phase-5-hardening-release.md:
+freeze and rehearse on v2.0, the version and notes PR, the release PR into
+main merged with a merge commit, the tag, the hand-written release notes,
+and the post-release plan. Several steps need a human to click merge or to
+confirm; stop at each of those and report, then continue when told.
+
+READ FIRST
+- 10-phase-5-hardening-release.md sections 0.2, 4, and 5.
+- docs/ci-and-release.md (the repository's release mechanics).
+- CHANGELOG.md, package.json, docs/upgrade-2.0.md.
+
+FACTS THAT SHAPE THE WORK
+- CI publishes images on push to main and on v* tags, and creates a GitHub
+  release on a tag only if none exists. Publish the hand-written notes before
+  the workflow's release job runs, or you get an auto-generated commit list.
+- The release PR is the one deliberate exception to squash-merging: merge
+  with a merge commit so each squashed phase commit stays on main.
+- The plan folder is retired in the post-release cleanup PR, not in the
+  release PR, as section 4.5 describes.
+
+DO THIS, STOPPING WHERE MARKED
+1. Freeze: merge origin/main into v2.0, resolve, run lint, test, build,
+   format:check, and test:contract with available keys. Run the upgrade
+   rehearsal on a copy of a real 1.5.5 database in both auth modes and the
+   rollback rehearsal on the final build; append to bench/upgrade-rehearsal.md
+   and bench/rollback-rehearsal.md. STOP and report if any rehearsal step
+   deviates from the documents.
+2. Version and notes PR into v2.0: npm version major --no-git-tag-version;
+   regroup CHANGELOG Unreleased into ## [2.0.0] with Breaking, Added, Changed,
+   Fixed, Migration; add a fresh Unreleased heading; write notes.md
+   (uncommitted). STOP for the human to merge.
+3. Release PR from v2.0 into main with the title and body described in 4.3.
+   Confirm CI is green. STOP for the human to merge with gh pr merge --merge.
+4. After the merge: tag v2.0.0 on main, push the tag, run gh release create
+   with notes.md and --verify-tag before the workflow's release job. Watch the
+   tag run publish 2.0.0 and 2.0 images and the merge-image job confirm both
+   architectures. STOP and report the release URL.
+5. Open the post-release cleanup PR described in 4.5 as a draft (branch
+   deletion, CI trigger cleanup, plan folder retirement), to be merged after
+   the first patch release or two weeks.
+
+CONSTRAINTS
+- Never push to main directly; never force-push. Do not merge anything
+  yourself. Do not delete v2.0 in this prompt.
+
+SUCCESS CHECKLIST
+- [ ] v2.0 contains main; lint, test, build, format:check, and contract tests are green on the frozen branch; summaries recorded.
+- [ ] Upgrade and rollback rehearsals recorded for both auth modes on the final build.
+- [ ] package.json and package-lock.json say 2.0.0; CHANGELOG has a complete [2.0.0] entry and an empty Unreleased.
+- [ ] Release PR merged with a merge commit; main history shows each phase commit.
+- [ ] Tag v2.0.0 exists on the merge commit; GitHub release shows the hand-written notes; images 2.0.0, 2.0, and latest exist for amd64 and arm64.
+- [ ] Draft cleanup PR open with the branch, CI trigger, and plan-folder retirement steps.
+- [ ] Section 5 boxes for the release ticked.
+```

--- a/docs/multi-tenant-plan/README.md
+++ b/docs/multi-tenant-plan/README.md
@@ -1,0 +1,125 @@
+# Contrack Multi-Tenant Implementation Plan
+
+Working design documents for making Contrack multi-user: one self-hosted
+instance, one SQLite database, an administrator, and any number of members,
+each with a private CRM. This folder is gitignored on `main`. Phase 0 task
+0.0 commits it on the `v2.0` branch so every implementer and reviewer has
+it, and Phase 5 retires it to `docs/archive/` at release. It is a plan, not
+shipped documentation. The implementation prompts that drive each PR are in
+[16-implementation-prompts.md](16-implementation-prompts.md).
+
+Written against `v1.5.5` on 2026-09-07. Reviewed against the source, the
+installed engines, and the cited references on 2026-09-08. The review's
+evidence is in [bench/review-2026-09-08/](bench/review-2026-09-08/README.md)
+and its corrections are summarized in
+[14-risks-and-open-questions.md](14-risks-and-open-questions.md) section 5.
+
+---
+
+## Read in this order
+
+| # | Document | What it answers |
+| - | -------- | --------------- |
+| 1 | [01-current-state.md](01-current-state.md) | What exists today, what is missing, how big the job is |
+| 2 | [02-research.md](02-research.md) | How other self-hosted apps do it, and what the plan takes from each, with sources |
+| 3 | [03-architecture.md](03-architecture.md) | The target design and every decision, with reasons |
+| 4 | [04-data-model-and-migration.md](04-data-model-and-migration.md) | Exact DDL, triggers, indexes, FTS and vector rebuilds, the boot migration, verification, rollback |
+| 5 | [05-phase-0-foundations.md](05-phase-0-foundations.md) | Branch and CI setup, scaffolding with no user-visible change, three small 1.5.5 fixes. Lands on `v2.0` |
+| 6 | [06-phase-1-storage.md](06-phase-1-storage.md) | Schema, local owner account, migration |
+| 7 | [07-phase-2-scoping.md](07-phase-2-scoping.md) | Every query, cache, queue, and upload scoped by owner. Nine sub-phases |
+| 8 | [08-phase-3-accounts-admin.md](08-phase-3-accounts-admin.md) | Roles, admin API, invitations, temporary passwords, tokens, audit log |
+| 9 | [09-phase-4-frontend.md](09-phase-4-frontend.md) | Admin area, account tokens, new auth screens, identity in the UI |
+| 10 | [10-phase-5-hardening-release.md](10-phase-5-hardening-release.md) | Benchmarks, security review, docs, 2.0.0 release |
+| 11 | [11-future.md](11-future.md) | Deferred: sharing, proxy auth, OIDC, per-user keys, and more |
+| 12 | [12-testing-strategy.md](12-testing-strategy.md) | The tests that prove isolation and the definition of done |
+| 13 | [13-api-changes.md](13-api-changes.md) | Every endpoint added or changed, and the new error codes |
+| 14 | [14-risks-and-open-questions.md](14-risks-and-open-questions.md) | Decisions to confirm, every technical question with its answer and evidence, effort, what the review changed |
+| 15 | [15-additional-v2-features.md](15-additional-v2-features.md) | The 2.0 story beyond tenancy: ten headline features and ten performance, accuracy, and stability stories, each ranked and split between 2.0 and 2.1, plus the small extras and a decision record |
+| 16 | [16-implementation-prompts.md](16-implementation-prompts.md) | Twelve prompts, one per PR, that hand each phase to an implementing model with its context, its references, and a success checklist, plus the branch and release operations runbook |
+| A | [appendix-a-query-inventory.md](appendix-a-query-inventory.md) | Every query site, shared-state singleton, job, file path, route, and frontend touchpoint with line numbers |
+| B | [appendix-b-route-manifest.md](appendix-b-route-manifest.md) | Every route classified as public, self, scoped, admin, instance-read, or static |
+| bench | [bench/](bench/README.md) | Evidence: the review's scripts and measurements now, benchmark and rehearsal records as the phases produce them |
+
+---
+
+## The design in one paragraph
+
+Keep one SQLite file. Every owned row carries `ownerId`, which is a `users.id`.
+Every repository and service function takes a `Scope` as its first argument,
+and every statement over an owned table filters on it in the same `WHERE`
+clause as the id. An `AsyncLocalStorage` request context carries the scope to
+deep code for attribution. Auth-off mode gets a hidden local owner account so
+`NULL` owners never exist. Full-text search gets an indexed owner token
+column so FTS5 intersects in the index, and an indexed contact-id token so
+the FTS triggers stop scanning the whole index on every contact update. Vector search gets a `vec0` partition
+key so KNN scans only the owner's vectors. Composite indexes lead with
+`ownerId`. Cross-owner ids return `404`. A tenant lint, a route manifest test,
+and a two-user matrix test make a missed filter a red build. Admins manage
+accounts and instance settings and cannot read member data. Machine access
+moves to per-user hashed tokens. The whole thing ships as 2.0.0 with an
+idempotent boot migration that backs up first.
+
+---
+
+## Phases at a glance
+
+| Phase | Lands on | Size | Depends on | Outcome |
+| ----- | -------- | ---- | ---------- | ------- |
+| 0 Foundations | `v2.0` (cherry-pick to `main` as `1.6.0` is optional) | M | | Branch and CI, `Scope`, request context, route manifest with a mount recorder, tenant lint (report), ownership stamped on create, two-user test harness, benchmark baseline, BM25 offset fix, MCP route mount fix |
+| 1 Storage | `v2.0` | L | 0 | New columns and tables, local owner, child `ownerId` with triggers, triggers dropped around the claim, FTS v2 (`ownerTok` and `cidTok`), `vec0` partitions, uploads relocation, composite indexes, backup-then-migrate, verify script, seed scripts |
+| 2 Scoping | `v2.0`, nine PRs | XL | 1 | About 240 owned-table statements scoped, caches and queues per owner, uploads guard, standard `429` envelopes, strict lint, matrix green, plan tests |
+| 3 Accounts and admin | `v2.0` | L | 2 | `requireAdmin`, admin API, invitations, temporary passwords, disable and purge, tokens, registration flag, audit log, daily maintenance interval, per-user rate limits |
+| 4 Frontend | `v2.0` | L | 3 | Admin area (lazy-loaded), tokens UI, join and register and forced-change screens, identity on desktop and mobile, one shared response handler, per-identity cache reset |
+| Extras and 2.0 headline features | `v2.0` | XS to M each | 4 | Accepted rows from [15-additional-v2-features.md](15-additional-v2-features.md) |
+| 5 Hardening and release | `v2.0`, then `main` | M | 1 to 4 | Benchmarks at four shapes, concurrency run, security review, every doc updated, upgrade and rollback rehearsals, release PR merged with a merge commit, `v2.0.0` tagged and published |
+
+Estimated total: 45 to 64 engineer-days for tenancy, plus about 12 to 18 for
+the four 2.0 headline features and 6 to 10 for the five 2.0 quality stories
+in [15-additional-v2-features.md](15-additional-v2-features.md), if all are
+accepted. Details in
+[14-risks-and-open-questions.md](14-risks-and-open-questions.md) section 4.
+
+---
+
+## Decisions that need the owner's confirmation
+
+Listed with alternatives in [14-risks-and-open-questions.md](14-risks-and-open-questions.md) section 1. The three that shape the most work:
+
+1. **Admins cannot read member contacts.** Only an audit-logged offboarding export.
+2. **Auth-off mode uses a hidden local owner account** rather than `NULL` owners.
+3. **The environment `API_TOKEN` maps to the primary admin and is deprecated**, not refused.
+
+---
+
+## Branch and release workflow
+
+- All of this work lands on one integration branch, `v2.0`, created from `main` at the start of Phase 0. The first PR on it adds `v2.0` to the CI workflow's branch lists, because CI runs only for pull requests into `main` today.
+- Each phase (each sub-phase in Phase 2, each accepted extra) is one PR from a `v2.0/<phase>-<slug>` branch into `v2.0`, squash-merged, with the raw vitest summary in the description and no AI attribution.
+- `main` is merged into `v2.0` at every phase boundary. `package.json` stays at `1.5.5` until Phase 5. `CHANGELOG.md` collects one block per phase under `Unreleased`.
+- Phase 5 merges `v2.0` into `main` with a merge commit, tags `v2.0.0`, publishes hand-written release notes before the workflow's release job, and retires the branch after the first patch release. The exact commands are in [10-phase-5-hardening-release.md](10-phase-5-hardening-release.md) section 4.
+
+## How to use this plan
+
+- Each phase document is written to be handed to an implementer on its own. Its section 0 carries the repository facts, the workflow, and the state the previous phases left behind; its last sections carry the acceptance criteria, the contract for the next phase, and what not to do.
+- One PR per phase, or per sub-phase in Phase 2. Each phase document's acceptance criteria are the PR's checklist.
+- Names in code must match [03-architecture.md](03-architecture.md) section 14.
+- Line numbers in appendix A and in the phase documents are from `v1.5.5`. When they drift, search for the function name. Appendix A section A2 lists the sites the review added.
+- Every "green" claim in a PR carries the raw vitest summary, per `.agent/TESTING.md`.
+- Benchmarks, rehearsal logs, and the security checklist are committed under `bench/` in this folder as they are produced.
+
+---
+
+## Glossary
+
+| Term | Meaning |
+| ---- | ------- |
+| Owner | The user who owns a row. The tenant. `ownerId` is a `users.id`. |
+| Scope | The typed object `{ ownerId }` that every data-access function requires. |
+| Local owner | The hidden admin account that owns everything on an instance running with `AUTH_REQUIRED=false`. Converted into a real account by the setup screen. |
+| Owned table | A table with an `ownerId` column. |
+| Derived table | A child table whose owner is its parent contact's owner. Read only through an owner-checked parent id. |
+| Owner token | `'o' + uuid without hyphens`, the indexed FTS5 column that scopes full-text search. |
+| Contact token | `'c' + uuid without hyphens`, the indexed FTS5 column the triggers use to delete one contact's index row without scanning the table. |
+| Partition key | The sqlite-vec `vec0` column that scopes KNN to one owner's vectors. |
+| Manifest | `server/tenancy/routeManifest.ts`, the classified list of every route. |
+| Matrix | `tests/integration/tenancy.isolation.test.ts`, the two-user cross-access test suite. |

--- a/docs/multi-tenant-plan/appendix-a-query-inventory.md
+++ b/docs/multi-tenant-plan/appendix-a-query-inventory.md
@@ -1,0 +1,611 @@
+# Appendix A. Query-Site and Shared-State Inventory
+
+This appendix is the raw inventory of the server as it stands today (v1.5.5).
+It was produced by a full read of `server/`, `src/`, and `tests/`. Line
+numbers refer to the current tree. Phase 2 uses this appendix as its
+checklist. When a line number drifts, search for the function name.
+
+Mount root facts (`server/app.ts`):
+
+- `attachPrincipal` runs globally at `server/app.ts:170`. `requireAuth` gates `["/api", "/uploads"]` at `server/app.ts:176`.
+- `/api/auth` is mounted at `server/app.ts:175`, before the gate.
+- `healthRouter` is mounted at `server/app.ts:166`, outside `/api`.
+- `reconcileOwnership()` is called at `server/app.ts:113`, so it runs on every `createApp()` (production and every test file).
+
+Headline: **zero read or write queries filter or stamp `ownerId`.** The only code that touches the column is DDL (`server/db.ts:865-902`) and the claim and reconcile pair (`server/services/authService.ts:205-215, 661-696`).
+
+---
+
+## A. Query-site inventory by file (under `server/`)
+
+Counts are occurrences of `.prepare(` (better-sqlite3, includes multi-line `sqlite\n.prepare(`), `.exec(`, Drizzle builder calls (`db.select/insert/update/delete(`), `db.query.*`, and `.transaction(`. `db.query.*` is 0 everywhere: the Drizzle relational API is never used.
+
+| file | prepare | exec | drizzle | tx | tables read | tables written | already owner-aware? | receives owner/user/principal/req? |
+|---|---|---|---|---|---|---|---|---|
+| `server/db.ts` | 15 | 24 | 0 | 3 | action_items, contact_emails, contact_experience, contact_interests, contact_phones, contact_tags, contacts, contacts_fts, sessions, sqlite_master | action_items, contact_education, contact_experience, contact_interests, contacts, contacts_fts, interactions, sessions | yes, DDL only (`:865-902` adds `ownerId` + `idx_*_owner` to the 4 OWNED_TABLES) | no (module top-level, runs at import) |
+| `server/repositories/contactRepository.ts` | 20 | 0 | 7 | 1 | contact_addresses, contact_attributes, contact_education, contact_emails, contact_experience, contact_interests, contact_phones, contact_social_links, contact_sources, contact_tags, interactions, list_members, lists | contact_addresses, contact_attributes, contact_interests + Drizzle inserts into contactEducation, contactEmails, contactExperience, contactPhones, contactSocialLinks, contactSources, contactTags | no | no. Module-level `stmts` object at `:93`, `contactRepo` at `:146`. `hydrate()` `:161`, `hydrateMany()` `:212`, `insertChildRecords()` `:496`, `_insertChildRecordsUnsafe()` `:513` all take ids or payloads only |
+| `server/services/contactService.ts` | 33 | 0 | 8 | 6 | contact_emails, contact_embeddings, contact_interests, contact_phones, contact_social_links, contact_tags, contacts, dedupe_embedding_meta, interactions, list_members, lists, search_embeddings | contact_embeddings, contacts, dedupe_embedding_meta, search_embeddings + `db.insert(schema.contacts)` `:208`, `:311`. `db.update(schema.contacts)` `:383`, `:504`, `:543`, `:561`, `:650` | no. `createContact` `:199` builds insert values with no `ownerId` | no |
+| `server/services/dedupe/merging.ts` | 59 | 0 | 2 | 2 | 16 tables incl. contacts, all contact_* children, list_members, interaction_mentions, search_embeddings, contact_embeddings, dedupe_embedding_meta | same 16 plus interactions | no | no |
+| `server/services/dedupe/suggestions.ts` | 24 | 0 | 0 | 4 | contacts, dedupe_merge_log, dedupe_suggestions | contacts, dedupe_exclusions, dedupe_merge_log, dedupe_suggestions | no. `INSERT INTO dedupe_merge_log (...)` at `:128-131` omits `ownerId` even though the table has it | no. Module-level `_stmts` at `:69` |
+| `server/services/authService.ts` | 20 | 0 | 0 | 2 | contacts, sessions, users | sessions, users | YES. `countUnownedContacts()` `:205-215` (`WHERE ownerId IS NULL`), `claimUnownedData()` `:661-681` (`UPDATE ${table} SET ownerId = ?`), `reconcileOwnership()` `:690-696` | takes `userId: string`. Module `stmts` at `:191-201` |
+| `server/services/listService.ts` | 17 | 0 | 0 | 2 | contacts, list_members, lists | list_members, lists | no. `INSERT INTO lists (id, name, icon, sortOrder)` at `:37` omits `ownerId` | no |
+| `server/services/dashboardService.ts` | 15 | 0 | 0 | 0 | contacts, interaction_mentions, interactions | none | no. About 13 unscoped aggregate queries over all contacts, `:58-295` | no |
+| `server/services/actionItemService.ts` | 14 | 0 | 0 | 0 | action_items, contacts | action_items | no | no |
+| `server/services/dedupe/normalization.ts` | 14 | 0 | 0 | 0 | contact_emails, contact_interests, contact_phones, contact_sources, contact_tags, contacts | none | no | no |
+| `server/services/search/localEmbeddings.ts` | 12 | 2 | 0 | 2 | contact_interests, contact_tags, contacts, search_embeddings | search_embeddings | no. `backfillSearchEmbeddings()` `:322` scans all contacts. `findSearchNeighbors()` `:227` is a global KNN | no |
+| `server/services/dedupe/embeddings.ts` | 11 | 2 | 0 | 1 | contact_embeddings, contacts, dedupe_embedding_meta | contact_embeddings, dedupe_embedding_meta | no. `_stmts.knn` at `:278` is a global vector search | no |
+| `server/services/dedupe/engine.ts` | 9 | 0 | 0 | 0 | contact_emails, contact_embeddings, contact_phones, contacts | contact_emails, contact_embeddings, contact_phones, contacts | no | no |
+| `server/routes/contacts.ts` | 8 | 0 | 0 | 0 | contact_emails, contact_phones, contacts | none directly | no. Cross-contact dupe probes at `:276`, `:281`, `:341-347`, `:373`, `:378`, `:411-416`, `:441`, `:446` | yes, has `req` on every handler, uses none of it for ownership |
+| `server/services/exportService.ts` | 7 | 0 | 0 | 0 | action_items, contacts, dedupe_merge_log, interactions, list_members, lists | none | no. `buildFullExport()` `:23` does `SELECT * FROM contacts/interactions/lists/list_members/action_items/dedupe_merge_log` with no WHERE. `buildContactsCsv()` `:59` filters only `deletedAt IS NULL` | no |
+| `server/services/relationshipService.ts` | 7 | 0 | 0 | 1 | contacts, interactions | contacts | no | no |
+| `server/services/aiStatsService.ts` | 6 | 0 | 0 | 0 | ai_invocations | ai_invocations | no. `INSERT INTO ai_invocations (id, operation, model, tokenCount, latencyMs, cached, description, createdAt)` at `:89-90` omits `ownerId`. `summaryStmt` `:93-100` aggregates the whole table | no |
+| `server/services/mcpService.ts` | 6 | 0 | 0 | 0 | contact_tags, contacts, interactions | none | no | no |
+| `server/services/searchService.ts` | 6 | 0 | 0 | 0 | contact_interests, contact_tags, contacts, contacts_fts | none | no | partly: one function takes `res: Response` (`:228`) for NDJSON streaming, never `req` |
+| `server/services/interactionService.ts` | 5 | 0 | 18 | 1 | action_items, contacts, interaction_mentions, interactions | action_items, interaction_mentions + `db.update(schema.contacts)` `:180`,`:278`,`:349`,`:377`. `db.update(schema.interactions)` `:90`. `db.delete(schema.interactions)` `:444` | no | no |
+| `server/services/zeroStateService.ts` | 5 | 0 | 0 | 0 | action_items, contacts, dedupe_suggestions, interaction_mentions | none | no | no |
+| `server/services/dedupe/passes.ts` | 4 | 0 | 0 | 0 | contact_emails, contact_phones, contact_sources, contacts | none | no. `:99`, `:128`, `:166`, `:182` pull whole-table cross products | no |
+| `server/services/dedupe/blocking.ts` | 3 | 0 | 0 | 0 | contact_embeddings, dedupe_exclusions, interaction_mentions | none | no | no |
+| `server/services/dedupe/context.ts` | 3 | 0 | 0 | 0 | contact_embeddings, contact_social_links, contacts | none | no | no |
+| `server/services/search/hybridRetrieval.ts` | 3 | 0 | 0 | 0 | contact_interests, contact_tags, contacts, contacts_fts | none | no. `ACTIVE_GATE_SQL` at `:148` is the only WHERE clause and has no owner term | no |
+| `server/services/settingsService.ts` | 3 | 0 | 0 | 0 | app_settings | app_settings | no. `app_settings` is instance-global by design, no owner column | no |
+| `server/services/aiSearch/mergeEngine.ts` | 2 | 0 | 0 | 1 | (via helpers) | contacts | no | no |
+| `server/services/geocoding/cache.ts` | 2 | 1 | 0 | 0 | geocode_cache | geocode_cache | no. Instance-global cache keyed by normalized location string | no |
+| `server/services/dedupe/clustering.ts` | 1 | 0 | 0 | 0 | interactions | none | no | no |
+| `server/services/geocoding/index.ts` | 1 | 0 | 0 | 0 | contacts | none | no. `startRetroactiveGeocoding()` `:7-25` scans all contacts | no |
+| `server/services/geocoding/queue.ts` | 0 | 0 | 3 | 0 | none | `db.update(schema.contacts)` `:32`, `:121`, `:128` | no | no |
+| `server/routes/dedupe/embeddings.ts` | 1 | 0 | 0 | 0 | contacts | none | no. `:51-54` global COUNT(*) | yes, has `req` |
+| `server/routes/health.ts` | 1 | 0 | 0 | 0 | (`SELECT 1`) | none | n/a | `_req` only |
+| `server/services/backupService.ts` | 0 (uses `sqlite.backup()` `:81`) | 0 | 0 | 0 | whole DB file | whole DB file | no. Snapshots the entire database to one file | no |
+
+Files under `server/ai/**` and `server/utils/**` touch no tables (except `server/utils/aiCache.ts`, which is pure in-memory). All 14 route files receive `req`. None of them read `req.principal` except `server/routes/auth.ts`.
+
+---
+
+## B. Ownership stamping today
+
+Every site that mentions `ownerId`, `currentUser(`, `req.principal`, or `principal` under `server/`:
+
+**`ownerId` sites (only 9 in server code, all in 2 files):**
+
+| file:line | what it does |
+|---|---|
+| `server/db.ts:158` | comment pointing at the OWNERSHIP note in `src/db/schema.ts` |
+| `server/db.ts:865-871` | `export const OWNED_TABLES = ["contacts", "lists", "ai_invocations", "dedupe_merge_log"]` |
+| `server/db.ts:873-902` | boot loop: `pragma table_info(table)`, throws if table missing (`:880`), `ALTER TABLE ${table} ADD COLUMN ownerId TEXT REFERENCES users(id) ON DELETE RESTRICT` (`:892`), then `CREATE INDEX IF NOT EXISTS idx_${table}_owner ON ${table}(ownerId)` (`:900`) |
+| `server/services/authService.ts:205-215` | `countUnownedContacts()`: `SELECT COUNT(*) FROM contacts WHERE ownerId IS NULL AND deletedAt IS NULL AND isGhost = 0`. Feeds the setup screen |
+| `server/services/authService.ts:661-681` | `claimUnownedData(userId)`: transaction looping OWNED_TABLES, `UPDATE ${table} SET ownerId = ? WHERE ownerId IS NULL` (`:666`) |
+| `server/services/authService.ts:690-696` | `reconcileOwnership()`: no-op unless `countUsers() === 1`. Reads the single user id and calls `claimUnownedData` |
+
+**Call sites of the above:**
+
+- `server/services/authService.ts:323`: `if (isFirst) claimUnownedData(id);` inside `createUser`. This is the ONLY place ownership is assigned as a consequence of a user action, and it assigns everything, not per-row.
+- `server/app.ts:113`: `reconcileOwnership();` at app construction.
+
+**No route or service stamps `ownerId` on create.** Confirmed for all four owned tables:
+
+- `contacts`: `server/services/contactService.ts:208` and `:311` (`db.insert(schema.contacts).values(values)`), values built by `buildInsertValues` with no owner field.
+- `lists`: `server/services/listService.ts:37` `INSERT INTO lists (id, name, icon, sortOrder)`.
+- `ai_invocations`: `server/services/aiStatsService.ts:89-90` `INSERT INTO ai_invocations (id, operation, model, tokenCount, latencyMs, cached, description, createdAt)`.
+- `dedupe_merge_log`: `server/services/dedupe/suggestions.ts:128-131` `INSERT INTO dedupe_merge_log (id, primaryId, duplicateId, mergedBy, mergeType, confidence, reasoning, duplicateSnapshot)`.
+
+The comment at `server/middleware/auth.ts:22` ("stamping ownership on new rows already uses it") and at `:225` are inaccurate as of today. Ownership is only assigned in bulk by `claimUnownedData`.
+
+**`principal` / `currentUser` sites:**
+
+| file:line | what it does |
+|---|---|
+| `server/types/express.d.ts:19` | `principal?: Principal` declared on `Express.Request` |
+| `server/middleware/auth.ts:45-51` | `type Principal = {kind:"anonymous"} \| {kind:"user"; user; sessionId} \| {kind:"service"}` |
+| `server/middleware/auth.ts:58-60` | `currentUser(req)` returns `User \| null` |
+| `server/middleware/auth.ts:63-65` | `currentSessionId(req)` |
+| `server/middleware/auth.ts:207-249` | `attachPrincipal`: Bearer to `{kind:"service"}` (`:218`), cookie to `{kind:"user"}` (`:232`), else `{kind:"anonymous"}` when auth is off (`:242`), else leaves `req.principal` unset |
+| `server/middleware/auth.ts:253-255` | `isAuthenticated(req)` = `req.principal !== undefined` |
+| `server/middleware/auth.ts:263-268` | `requireAuth` gate |
+| `server/middleware/auth.ts:278-292` | `requireUser` gate (403 for service tokens) |
+| `server/app.ts:170` | `app.use(attachPrincipal)` |
+| `server/app.ts:176` | `app.use(["/api","/uploads"], requireAuth)` |
+| `server/routes/auth.ts:97` | `GET /api/auth/status` reads `currentUser(req)` for the status payload |
+| `server/routes/auth.ts:193-195` | `GET /me` returns `publicUser(currentUser(req)!)` |
+| `server/routes/auth.ts:202` | `PATCH /me` calls `updateUser(currentUser(req)!.id, ...)` |
+| `server/routes/auth.ts:221,224` | `POST /change-password` uses `currentUser(req)!.id` and `currentSessionId(req)` |
+| `server/routes/auth.ts:236` | `GET /sessions` calls `listSessions(currentUser(req)!.id, currentSessionId(req))` |
+| `server/routes/auth.ts:243-244` | `DELETE /sessions` calls `revokeOtherSessions(currentUser(req)!.id, currentSessionId(req))` |
+| `server/routes/auth.ts:257,266` | session-policy get/put, `requireUser` only, no role check |
+
+That is the complete list. `server/routes/auth.ts` is the only router that reads the principal at all. `role` is never read anywhere in `server/` outside `authService.createUser` (`:313`, sets `"admin"` for the first account).
+
+---
+
+## C. Module-level shared state that leaks across users
+
+| file:line | what it stores | keyed by user? | how exposed via routes |
+|---|---|---|---|
+| `server/services/dedupe/jobQueue.ts:30` | `private scans = new Map<scanId, DedupeScanProgress>()`, including full `clusters: DedupeCluster[]` with contact snapshots | no | `GET /api/dedupe/status?scanId` (`routes/dedupe/scan.ts:119`), `GET /api/dedupe/stream?scanId` SSE (`scan.ts:68`). Any authenticated caller who knows or guesses a scanId reads another user's clusters |
+| `server/services/dedupe/jobQueue.ts:31` | `private processing = false`, the single global scan lock | no | `POST /api/dedupe/scan` returns 429 via `canStartScan()` (`jobQueue.ts:33-40`, route `scan.ts:56`) when any user is scanning. `GET /api/dedupe/active` (`scan.ts:108`) returns the one global in-flight scan to whoever asks |
+| `server/services/dedupe/jobQueue.ts:161` | `export const dedupeQueue = new DedupeJobQueue()` singleton, also an `EventEmitter` whose event names are scanIds | no | SSE subscription `dedupeQueue.on(scanId, handler)` at `scan.ts:100` |
+| `server/services/aiSearch/jobQueue.ts:118` | `private batches = new Map<batchId, AISearchBatch>()` with per-contact job results | no | `GET /api/ai-search/status?batchId` (`routes/aiSearch.ts:117`), `GET /api/ai-search/stream?batchId` SSE (`aiSearch.ts:140`) |
+| `server/services/aiSearch/jobQueue.ts:119` | `private processing` global lock | no | `POST /api/ai-search` returns 429 for everyone while any batch runs (`canStartBatch()` `:126`) |
+| `server/services/aiSearch/jobQueue.ts:120` | `private lastBatchCompletedAt` global cooldown timestamp | no | one user's completed batch imposes the cooldown on every other user |
+| `server/services/aiSearch/jobQueue.ts:368` | `export const jobQueue = new AISearchJobQueue()` singleton | no | as above |
+| `server/utils/aiCache.ts:139` | `const stores = new Map<tier, Map<cacheKey, CacheEntry>>()`, 7 tiers: `briefing` (`:74`), `rerank` (`:81`), `synthesis` (`:88`), `mentions` (`:97`), `dailyInsight` (`:104`), `queryParse` (`:117`), `hyde` (`:131`) | no. Keys are content hashes or query strings only | Read paths: `interactionService.ts:250` briefing, `searchIntel.ts:405` synthesis, `:556` queryParse, `:767` hyde, `mentions.ts:34`. Stats surfaced at `GET /api/ai/stats/summary` (`aiStatsService.ts:217` `cacheTiers`), and `GET /api/debug/cache-stats` (dev only, `server.ts:99`) |
+| `server/services/dashboardService.ts:214` and `:313` | `aiCache.get<DailyInsight>("dailyInsight", "singleton")` / `.set(..., "singleton", ...)` | no, literal key `"singleton"` | `GET /api/dashboard/insight` (`routes/dashboard.ts:21`). One user's AI-generated daily insight about their network is served verbatim to every other user for 24h |
+| `server/utils/aiCache.ts:142` | `const stats = new Map<tier, TierStats>()` hit/miss/eviction counters | no | `GET /api/ai/stats/summary` |
+| `server/utils/aiCache.ts:166` | `let batchRefCount = 0` global ref-counted batch mode | no | one user's bulk import (`beginBatch` at `:392`) defers cache invalidation for all users |
+| `server/utils/aiCache.ts:167` | `const pendingInvalidations = new Set<string>()` | no | as above |
+| `server/services/settingsService.ts:21` | `const cache = new Map<string, unknown>()` of parsed `app_settings` JSON, including provider API keys (`SETTING_KEYS.aiProviderKeys`) and custom endpoint configs | no. `app_settings` is instance-global with no owner column | Written via `PUT /api/settings/ai/providers/:id/key` (`aiSettings.ts:63`), `PUT /endpoints` (`:114`), etc. Cleared only by `clearSettingsCache()` |
+| `server/ai/providerRegistry.ts:69` | `const instances = new Map<fingerprint, {fingerprint, provider}>()`, live AI adapter instances holding API keys | no (fingerprint is `kind\|baseUrl\|apiKey`, `:73`) | Every AI route shares one provider instance per credential |
+| `server/ai/singleton.ts:91` | `sharedProvider` Proxy resolving to the registry's default provider | no | all legacy AI call sites |
+| `server/ai/singleton.ts:100` | `export const isProviderConfigured` computed once at import | no | `GET /api/ai/diagnostics` (`routes/ai.ts:34`). Stale after a settings write |
+| `server/ai/adapters/gemini.ts:176-178, 188-189` | per-adapter `tracker: QuotaTracker`, `router: SmartRouter`, `circuitBreakers = new Set<string>()` | no | `GET /api/ai/grounding-capacity` (`routes/ai.ts:87`) and `gemini.ts:295-297` snapshot. One user exhausting grounding RPD blocks everyone |
+| `server/ai/routing/QuotaTracker.ts:42` | `private usage = new Map<modelId, UsageWindow>()` (RPM/TPM/RPD windows) | no | shared per adapter instance, so globally |
+| `server/ai/routing/QuotaTracker.ts:45` | `private groundingUsage = { dateKey, rpd }` daily grounding counter | no | `GET /api/ai/grounding-capacity` |
+| `server/ai/routing/ParallelQueue.ts:18` | `class ParallelQueue` worker pool (`Array.from({length: workerCount})` at `:68`) | no | instantiated per call site, but concurrency budget is process-wide |
+| `server/ai/adapters/anthropic.ts:110` | `private schemaTooComplex = new Set<string>()` | no (schema names) | low risk, noted for completeness |
+| `server/ai/adapters/openaiCompatible.ts:84` | `private jsonModes = new Map<string, JsonMode>()` | no | low risk |
+| `server/services/geocoding/queue.ts:20` | `const geocodeQueue: GeoTask[] = []` global FIFO of `{contactId, location, normalizedKey}` | no | populated by `queueGeocode()` from `contactService.createContact` and by `startRetroactiveGeocoding()`. `applyCoordinates()` `:117-138` writes lat/lng to every queued contactId sharing a normalizedKey, across users (safe: an address is not user data) |
+| `server/services/geocoding/queue.ts:21` | `let isGeocoding = false` global processing lock | no | serializes geocoding for all users |
+| `server/services/geocoding/cache.ts` (table `geocode_cache`) | persisted location to lat/lng, plus negative-result caching | no owner column | shared, fine, but a negative cache entry from one user suppresses another's lookup for `FAILURE_TTL_DAYS` |
+| `server/services/dedupe/embeddings.ts:363` | `let _backfillRunning = false` | no | `POST /api/dedupe/backfill-embeddings` (`routes/dedupe/embeddings.ts:14`) silently returns 0 when another user's backfill is running |
+| `server/services/dedupe/embeddings.ts:458` | `const _inFlightIds = new Set<string>()` | contactId, not userId | fire-and-forget dedupe embedding |
+| `server/services/dedupe/embeddings.ts:186` | `const _stmts = {...}` incl. `_stmts.knn` (global vector KNN over `contact_embeddings`) | no | dedupe scan and incremental check |
+| `server/services/contactService.ts:38` | `const _dedupeTimers = new Map<contactId, Timeout>()` 5s debounce | contactId | scheduled on every create or update (`scheduleIncrementalDedupe` `:61-84`) |
+| `server/services/search/localEmbeddings.ts:42-44` | `let extractor`, `let modelReady`, `let initPromise` (Transformers.js pipeline) | no | one model instance process-wide. Fine functionally |
+| `server/services/search/localEmbeddings.ts:203` | `const _upsertTxn = sqlite.transaction(...)` | no | low risk |
+| `server/services/dedupe/suggestions.ts:69` | `const _stmts = {...}` incl. `getMergeLog` (`:133-137`) which is `SELECT * FROM dedupe_merge_log ORDER BY mergedAt DESC LIMIT ?` with no WHERE | no | `GET /api/dedupe/merge-log` (`routes/dedupe/suggestions.ts:106`) |
+| `server/middleware/rateLimit.ts:43` | `const windows = new Map<ip, WindowState>()` per limiter closure | by IP, not user | `aiLimiter` at `:93` (60 req/min) applied by `aiEndpointRateLimit` `:99` to 8 path patterns (`AI_COST_PATTERNS` `:80-89`). Users behind one NAT share a bucket |
+| `server/routes/auth.ts:60, 67` | `credentialLimiter`, `setupLimiter` (IP-keyed) | by IP | `POST /api/auth/login`, `POST /api/auth/setup`. Reset seam `__resetAuthRateLimits()` `:74` |
+| `server/routes/logos.ts:12` | `const knownFailedDomains = new Set<string>()` | no | `GET /api/logos/:domain`. Also writes shared files, see E |
+| `server/services/aiStatsService.ts:118` | `const costPerMMap = new Map<modelId, costPerM>()` | no | static pricing table, safe |
+| `server/middleware/auth.ts:92` | `let legacyWarned = false` | no | warning dedupe only |
+| `server/utils/urlSafety.ts:191` | `const pinnedAgent = new Agent({connect:{lookup: guardedLookup}})` | no | shared undici agent, safe |
+| `server/utils/nlp/nicknames.ts:120` | `const _nicknameMap` | no | static data, safe |
+| `server/app.ts:40, 69` | `INLINE_UPLOAD_EXTENSIONS`, `LARGE_JSON_PATHS` | no | static config, safe |
+
+There is no `activeJob` or `currentScan` free variable. The equivalents are `dedupeQueue.processing` (`dedupe/jobQueue.ts:31`, read via `isProcessing()` `:93` and `getActiveScan()` `:82`) and `jobQueue.processing` (`aiSearch/jobQueue.ts:119`).
+
+---
+
+## D. Background jobs and boot-time sweeps that iterate over ALL data
+
+**Boot, in `server.ts` `startServer()`:**
+
+| file:line | what it scans |
+|---|---|
+| `server.ts:153` | `startRetroactiveGeocoding()` in `server/services/geocoding/index.ts:7-25`, 2s delay, `SELECT id, location FROM contacts WHERE location IS NOT NULL AND location != '' AND (lat IS NULL OR lng IS NULL)` across all owners, then enqueues each |
+| `server.ts:156` | `startBackupSchedule()` in `server/services/backupService.ts:104-125`. `setTimeout(run, 15_000)` at `:123` and `setInterval(run, hours*3.6e6)` at `:124`. `runBackup()` `:75-81` snapshots the entire database to `DATA_DIR/backups/` |
+| `server.ts:157-167` | trash purge: `runTrashPurge()` immediately then `setInterval(..., 24h)`. `contactService.purgeExpiredTrash()` `:611-628` selects `SELECT id FROM contacts WHERE deletedAt IS NOT NULL AND deletedAt < ?` (all owners) and hard-deletes each |
+| `server.ts:170-174` | `cleanupOldInvocations()` in `aiStatsService.ts:346`, running `cleanupStmt` (`:110-112`) `DELETE FROM ai_invocations WHERE createdAt < datetime('now','-30 days')` with no owner filter |
+| `server.ts:181-188` | `refreshModelCatalogs()` now and every 24h, calls `aiSettingsService.refreshStaleModelCaches()` `:230`, writes the instance-global `app_settings` model cache |
+| `server.ts:194-205` | `setInterval(() => sqlite.pragma("optimize"), 24h)` |
+| `server.ts:210-217` | `runScoreSweep()` now and hourly, calls `relationshipService.recomputeAll()` `server/services/relationshipService.ts:281-334`: `SELECT id, cadenceDays, lastContactedAt FROM contacts WHERE isGhost = 0 AND (isArchived = 0 OR isArchived IS NULL)` across all owners, batches of 200 with `setImmediate` yield at `:327` |
+| `server.ts:222-253` | `initLocalEmbeddings()` then `ensureEmbeddingStore()` then `backfillSearchEmbeddings()` (`localEmbeddings.ts:322-408`, scans contacts not in `search_embeddings`), then `ensureDedupeEmbeddingStore()` then `backfillEmbeddings()` (`dedupe/embeddings.ts:373-450`, normalizes all active contacts at `:394` then embeds those missing) |
+| `server.ts:289, 306, 335` | `sqlite.pragma("optimize")` / `sqlite.close()` on shutdown paths |
+
+**Import-time, in `server/db.ts` (runs on every `import`, including every test file):**
+
+| file:line | what it scans |
+|---|---|
+| `server/db.ts:147` | `migrate(db, {migrationsFolder: "./drizzle"})` |
+| `server/db.ts:162-186` | `CREATE TABLE IF NOT EXISTS users` / `sessions` + indexes |
+| `server/db.ts:193-195` | `DELETE FROM sessions WHERE expiresAt <= datetime('now')` (all users' sessions) |
+| `server/db.ts:219-262` | dicebear avatar URL migration: `SELECT id, avatarUrl FROM contacts WHERE avatarUrl LIKE 'https://api.dicebear.com/%'` then `UPDATE contacts SET avatarUrl` for each |
+| `server/db.ts:271-290` | `UPDATE contact_interests SET isAiGenerated = 1 WHERE ...` (all rows) |
+| `server/db.ts:293-317` | four `UPDATE contact_experience/contact_education SET ... = NULL WHERE ... = 'null'` |
+| `server/db.ts:369-541` | FTS5 rebuild and backfill (`FTS_SCHEMA_VERSION` `:369`), triggers `contacts_au` `:413` etc., "Backfill FTS for any contacts not yet indexed" `:534` |
+| `server/db.ts:562-598` | `updatedAt` triggers on contacts / interactions / action_items |
+| `server/db.ts:630-655` | `nextFollowUpAt` sync triggers driven off `action_items` |
+| `server/db.ts:679-703` | legacy follow-up backfill: `SELECT id, nextFollowUpAt FROM contacts WHERE nextFollowUpAt IS NOT NULL AND id NOT IN (...)`, inserts an action_item per row |
+| `server/db.ts:873-902` | §9i ownership DDL loop (see B) |
+| `server/db.ts:913-930` | §9h hot-path index creation (15 indexes) |
+| `server/db.ts:932` | `sqlite.pragma("optimize")` |
+| `server/db.ts:943-965` | §10 phonetic hash backfill: `SELECT id, name FROM contacts WHERE phoneticHash IS NULL AND name IS NOT NULL`, `UPDATE contacts SET phoneticHash` per row |
+| `server/app.ts:113` | `reconcileOwnership()` (see B) |
+
+**Request-triggered background work that touches all data:**
+
+- `server/services/contactService.ts:61-84` `scheduleIncrementalDedupe` calls `dedupeService.incrementalDedupeCheck` (cross-contact, all owners). Suppressed by `DISABLE_BACKGROUND_JOBS=true` at `:64`.
+- `server/services/interactionService.ts:216` `setTimeout(...)` fire-and-forget mention extraction.
+- `server/routes/dedupe/embeddings.ts:31` `POST /api/dedupe/backfill-embeddings` fires the whole-corpus backfill from an HTTP request.
+- `server/routes/dedupe/scan.ts:58` `POST /api/dedupe/scan` calls `dedupeService.runScan` over all contacts.
+
+---
+
+## E. Filesystem writes
+
+Path construction is centralized in `server/utils/paths.ts`:
+
+- `:14` `DATA_DIR = process.env.DATA_DIR ?? process.cwd()`
+- `:16` `UPLOADS_DIR = DATA_DIR/uploads`
+- `:17` `AVATARS_DIR = UPLOADS_DIR/avatars`
+- `:18` `LOGOS_DIR = UPLOADS_DIR/logos`
+- `:21` `ensureDir(dir)`
+- `:36-43` `resolveUploadPath(urlPath)` containment check against `UPLOADS_DIR`
+- `server/services/backupService.ts:21` `BACKUPS_DIR = DATA_DIR/backups`
+- `server/db.ts:24-25` `DB_PATH = DATA_DIR/curator.db`
+- `server/services/search/localEmbeddings.ts:71-76` model cache in `DATA_DIR/.cache`
+
+**There is no per-user segmentation anywhere.** All filenames are timestamp + random, in one flat directory per kind:
+
+| writer | file:line | filename pattern | per-user? |
+|---|---|---|---|
+| contact avatar upload (multer diskStorage) | `server/routes/contacts.ts:63-77`, dest `avatarDir` (`:49-50`) | `avatar-${Date.now()}-${rand}${ext}` (`:67-68`), 10 MB cap, raster MIME allowlist `:55-61` | no |
+| interaction attachment upload (multer diskStorage) | `server/routes/interactions.ts:34-53`, dest `uploadDir` = `UPLOADS_DIR` (`:15-16`) | `${fieldname}-${Date.now()}-${rand}${ext}` (`:37-39`), 50 MB cap, extension allowlist `:21-33` | no |
+| company logo cache | `server/routes/logos.ts:34` `path.join(logosDir, ${sanitizedDomain}.png)`, written at `:61` | `<domain>.png`, deterministic and shared across all users | no (and should stay shared) |
+| generated avatar processing | `server/utils/avatarProcessor.ts:17, 38` `mkdirSync(AVATAR_DIR)` | writes into the same flat avatars dir | no |
+| DB backups | `server/services/backupService.ts:39, 75-81` `sqlite.backup(dest)`, `dest = BACKUPS_DIR/filename` (`:78`). Rotation `readdirSync` `:41`, `unlinkSync` `:59` | whole-instance snapshot. `BACKUP_KEEP` `:33`, `BACKUP_INTERVAL_HOURS` `:107` | no, and cannot be |
+| avatar deletion | `server/services/contactService.ts:647` `fs.unlinkSync(oldPath)` via `resolveUploadPath` | | |
+| attachment deletion | `server/services/interactionService.ts:439-441` `fs.unlinkSync(filePath)` via `resolveUploadPath` | | |
+| export (in-memory, no file) | `server/services/exportService.ts:23` `buildFullExport()`, `:59` `buildContactsCsv()` | streamed as `Content-Disposition: attachment` from `routes/dataLifecycle.ts:108-141` | no owner filter |
+
+**Serving:** `server/app.ts:180-196` mounts `express.static(UPLOADS_DIR)` at `/uploads`, with `X-Content-Type-Options: nosniff` and forced `Content-Disposition: attachment` for anything not in `INLINE_UPLOAD_EXTENSIONS` (`app.ts:40-47`). It sits after `requireAuth` (`app.ts:176`), so it is gated as a whole, but any authenticated user can fetch any other user's `/uploads/...` file given the URL. Filenames are guessable (`avatar-<ms>-<0..1e6>.<ext>`).
+
+Also `server/routes/logos.ts:38` serves `res.sendFile(filePath)` from the shared logo cache, and `server/routes/avatar.ts:38` generates avatars deterministically with no storage at all (safe).
+
+---
+
+## F. Routes inventory
+
+Prefixes from `server/app.ts:180-200`. `router.<method>` line numbers are the definition line.
+
+### `/api/auth`: `server/routes/auth.ts` (mounted app.ts:175, PRE-AUTH)
+
+| method | path | line | notes |
+|---|---|---|---|
+| GET | `/api/auth/status` | 95 | pre-auth. Reports `existingContacts` count during setup |
+| POST | `/api/auth/setup` | 119 | pre-auth, `setupLimiter`. Creates first admin + claims all data |
+| POST | `/api/auth/login` | 151 | pre-auth, `credentialLimiter` |
+| POST | `/api/auth/logout` | 182 | pre-auth |
+| GET | `/api/auth/me` | 193 | `requireUser` |
+| PATCH | `/api/auth/me` | 197 | `requireUser` |
+| POST | `/api/auth/change-password` | 215 | `requireUser` |
+| GET | `/api/auth/sessions` | 234 | `requireUser` |
+| DELETE | `/api/auth/sessions` | 241 | `requireUser` |
+| GET | `/api/auth/session-policy` | 257 | `requireUser`, instance setting |
+| PUT | `/api/auth/session-policy` | 266 | `requireUser`, instance setting, no role check |
+
+### root: `server/routes/health.ts` (mounted app.ts:166, OUTSIDE gate)
+
+| GET | `/healthz` | 19 | unauthenticated by design |
+
+### `/api`: `server/routes/avatar.ts`
+
+| GET | `/api/avatar/:style` | 38 | stateless renderer |
+
+### `/api/link-preview`: `server/routes/linkPreview.ts`
+
+| GET | `/api/link-preview/unfurl` | 9 | outbound fetch, rate limited |
+
+### `/api/search`: `server/routes/search.ts`
+
+| GET | `/api/search/` | 11 | |
+| POST | `/api/search/semantic` | 40 | NDJSON streaming when `Accept: application/x-ndjson` (`:56-63`), rate limited |
+| POST | `/api/search/synthesize` | 101 | NDJSON streaming (`:135-153`), rate limited |
+
+### `/api/lists`: `server/routes/lists.ts`
+
+| GET | `/api/lists/` | 15 | |
+| POST | `/api/lists/` | 25 | writes owned table `lists`, no ownerId |
+| PUT | `/api/lists/reorder` | 38 | bulk |
+| PATCH | `/api/lists/:id` | 52 | |
+| GET | `/api/lists/:id/contacts` | 64 | |
+| DELETE | `/api/lists/:id` | 77 | |
+| POST | `/api/lists/:id/members` | 102 | |
+| DELETE | `/api/lists/:id/members/:contactId` | 116 | |
+| POST | `/api/lists/:id/members/bulk` | 132 | bulk |
+
+### `/api`: `server/routes/contacts.ts`
+
+| GET | `/api/contacts/map` | 81 | |
+| GET | `/api/contacts/archived` | 91 | |
+| GET | `/api/contacts` | 101 | |
+| GET | `/api/contacts/:id` | 122 | |
+| GET | `/api/contacts/:id/score` | 142 | |
+| POST | `/api/contacts` | 151 | writes owned table `contacts`, no ownerId |
+| POST | `/api/contacts/bulk` | 167 | bulk, 50 MB JSON (`app.ts:69` `LARGE_JSON_PATHS`), SSE streaming when `Accept: text/event-stream` (`:172-189`), yields with `setImmediate` `:243`, sleeps 3s `:532` |
+| POST | `/api/parse-contact` | 556 | rate limited (AI) |
+| POST | `/api/contacts/bulk-delete` | 571 | bulk |
+| PUT | `/api/contacts/bulk-update` | 585 | bulk |
+| PUT | `/api/contacts/:id` | 607 | |
+| PATCH | `/api/contacts/:id` | 625 | |
+| DELETE | `/api/contacts/:id` | 663 | soft delete to trash |
+| POST | `/api/contacts/:id/avatar` | 674 | multer upload (`uploadAvatar`, `:70`) |
+| POST | `/api/contacts/:id/enrich` | 704 | rate limited (AI) |
+
+### `/api`: `server/routes/interactions.ts`
+
+| GET | `/api/contacts/:id/timeline` | 58 | |
+| POST | `/api/contacts/:id/interactions` | 66 | |
+| POST | `/api/contacts/:id/briefing` | 83 | rate limited (AI), reads global `briefing` cache tier |
+| POST | `/api/contacts/:id/promote` | 100 | |
+| POST | `/api/contacts/:id/attachments` | 112 | multer upload (`upload`, `:42`) |
+| PATCH | `/api/interactions/:id` | 128 | |
+| DELETE | `/api/interactions/:id` | 145 | unlinks attachment file |
+| GET | `/api/contacts/:id/relationships` | 157 | |
+
+### `/api`: `server/routes/mcp.ts` (machine or API-token surface)
+
+| GET | `/api/query/contacts` | 9 | |
+| GET | `/api/contacts/action-items` | 34 | |
+| GET | `/api/tags` | 48 | |
+| GET | `/api/industries` | 56 | |
+| GET | `/api/interactions/search` | 64 | |
+| GET | `/api/timeline` | 82 | |
+
+### `/api`: `server/routes/dedupe/*` (composed in `dedupe/index.ts`)
+
+| POST | `/api/dedupe/scan` | scan.ts:13 | global lock, 429 across users |
+| GET | `/api/dedupe/stream` | scan.ts:68 | SSE |
+| GET | `/api/dedupe/active` | scan.ts:108 | returns the one global in-flight scan |
+| GET | `/api/dedupe/status` | scan.ts:119 | reads global scan map by id |
+| POST | `/api/dev/seed-duplicates` | scan.ts:139 | non-production only (`NODE_ENV !== "production"` guard `:138`) |
+| POST | `/api/contacts/merge` | merge.ts:12 | writes owned `dedupe_merge_log` |
+| POST | `/api/contacts/merge-batch` | merge.ts:34 | bulk |
+| POST | `/api/contacts/merge-cluster` | merge.ts:94 | bulk |
+| POST | `/api/contacts/merge-clusters` | merge.ts:144 | bulk |
+| GET | `/api/dedupe/suggestions` | suggestions.ts:19 | |
+| GET | `/api/dedupe/suggestions/count` | suggestions.ts:28 | |
+| GET | `/api/dedupe/suggestion-for/:contactId` | suggestions.ts:38 | |
+| POST | `/api/dedupe/suggestions/:id/dismiss` | suggestions.ts:47 | |
+| POST | `/api/dedupe/suggestions/:id/merge` | suggestions.ts:59 | |
+| GET | `/api/dedupe/merge-log` | suggestions.ts:106 | unscoped `SELECT * FROM dedupe_merge_log` |
+| POST | `/api/dedupe/merge-log/:id/undo` | suggestions.ts:115 | |
+| POST | `/api/dedupe/backfill-embeddings` | embeddings.ts:14 | rate limited, whole-corpus job, global `_backfillRunning` lock |
+| GET | `/api/dedupe/embedding-status` | embeddings.ts:47 | global COUNT(*) |
+
+### `/api`: `server/routes/actionItems.ts`
+
+| GET | `/api/action-items` | 30 | |
+| GET | `/api/action-items/completed` | 40 | |
+| GET | `/api/action-items/count` | 53 | |
+| PATCH | `/api/action-items/:id` | 65 | |
+| PATCH | `/api/action-items/:id/complete` | 80 | |
+| DELETE | `/api/action-items/:id` | 94 | |
+| GET | `/api/contacts/:id/action-items` | 110 | |
+| POST | `/api/contacts/:id/action-items` | 123 | |
+
+### `/api`: `server/routes/dashboard.ts`
+
+| GET | `/api/dashboard` | 9 | about 13 unscoped aggregates |
+| GET | `/api/dashboard/insight` | 21 | serves the `"singleton"`-keyed AI insight |
+| GET | `/api/command-palette/zero-state` | 39 | |
+
+### `/api`: `server/routes/aiSearch.ts`
+
+| POST | `/api/ai-search` | 45 | rate limited, global batch lock + cooldown |
+| GET | `/api/ai-search/status` | 117 | reads global batch map by id |
+| GET | `/api/ai-search/stream` | 140 | SSE |
+
+### `/api`: `server/routes/dataLifecycle.ts`
+
+| GET | `/api/trash` | 24 | |
+| POST | `/api/trash/:id/restore` | 31 | |
+| POST | `/api/trash/bulk-restore` | 53 | bulk |
+| DELETE | `/api/trash/:id` | 72 | hard purge |
+| GET | `/api/backups` | 89 | admin, lists whole-instance snapshots |
+| POST | `/api/backups` | 96 | admin, snapshots the whole DB |
+| GET | `/api/export/json` | 108 | dumps 6 tables unfiltered |
+| GET | `/api/export/csv` | 127 | dumps all contacts |
+
+### `/api/settings/ai`: `server/routes/aiSettings.ts` (instance-global `app_settings`)
+
+| GET | `/api/settings/ai/` | 37 |
+| GET | `/api/settings/ai/models/:capability` | 45 |
+| PUT | `/api/settings/ai/providers/:id/key` | 63 | writes shared API key |
+| DELETE | `/api/settings/ai/providers/:id/key` | 86 |
+| POST | `/api/settings/ai/providers/:id/refresh-models` | 94 |
+| PUT | `/api/settings/ai/endpoints` | 114 |
+| DELETE | `/api/settings/ai/endpoints/:id` | 126 |
+| PUT | `/api/settings/ai/capabilities/:capability` | 142 |
+| PUT | `/api/settings/ai/searxng` | 205 |
+
+### `/api/ai/stats`: `server/routes/aiStats.ts`
+
+| GET | `/api/ai/stats/summary` | 32 | whole-table aggregate + global cache tier stats |
+| GET | `/api/ai/stats/feed` | 52 | paginated `ai_invocations`, no owner filter |
+
+### `/api/ai`: `server/routes/ai.ts`
+
+| GET | `/api/ai/diagnostics` | 34 | reports configured providers |
+| GET | `/api/ai/grounding-capacity` | 87 | global QuotaTracker snapshot |
+
+### `/api/logos`: `server/routes/logos.ts`
+
+| GET | `/api/logos/:domain` | 14 | writes to shared logo cache dir |
+
+### dev-only, added in `server.ts`
+
+| GET | `/api/debug/cache-stats` | server.ts:99 | `NODE_ENV !== "production"` only. Dumps all aiCache tier stats |
+
+---
+
+## G. Frontend touchpoints
+
+| file | what it renders or decides |
+|---|---|
+| `src/main.tsx` | React root. Mounts `<QueryClientProvider>` then `<AuthGate>` (`:70-72`) then `<App/>`. Global QueryClient defaults at `:17-26` (staleTime 30s, gcTime 10min, retry 1, no refetchOnWindowFocus). Cold-boot prefetch of `queryKey: ["contacts"]` at `:54` runs before the gate resolves, so on a gated instance it returns 401 |
+| `src/components/auth/AuthGate.tsx` | The single source of session truth. `GateState = "checking" \| "setup" \| "signin" \| "open" \| "unreachable"` (`:59`). Calls `fetchAuthStatus()` in `check()` (`:70-88`), renders `<SetupWizard>` when `setupRequired`, `<SignIn>` when gated and unauthenticated, else `<AuthContext.Provider>` + children. Exposes `useAuth()` at `:57` returning `{user, authRequired, refresh, signOut}`. Calls `queryClient.clear()` on sign-in (`:99`), sign-out (`:113`), and 401 expiry (`:127`) |
+| `src/components/auth/SignIn.tsx` | Single identifier + password form. `reason?: "expired"` prop (`:19-21`) explains why it appeared |
+| `src/components/auth/SetupWizard.tsx` | First-run account creation. Mirrors server validation: `USERNAME_PATTERN` `:20`, `EMAIL_PATTERN` `:21`, `MIN_PASSWORD_LENGTH = 8` `:22`. Takes `existingContacts` to tell the user how much data they are about to claim |
+| `src/components/auth/AuthShell.tsx` | Shared frame for the two full-screen auth pages |
+| `src/api/auth.ts` | Auth client. Bypasses `apiFetch` and uses raw `fetch` via `authFetch()` (`:66-87`) because these endpoints sit outside the gate. Exports `AccountUser` (`:18-26`, includes `role: string`), `AuthStatus` (`:28-39`, includes `existingContacts`), `SessionPolicy`, `SessionSummary`, plus `fetchAuthStatus` `:89`, `setupAccount` `:95`, `signIn` `:109`, `signOut` `:117`, `updateProfile` `:121`, `changePassword` `:132`, `fetchSessions` `:141`, `revokeOtherSessions` `:146`, `fetchSessionPolicy` `:151`, `updateSessionPolicy` `:156` |
+| `src/api/client.ts` | `API_BASE = "/api"` (`:9`), `NetworkError` (`:26`), `apiFetch()` (`:46`). `if (res.status === 401) emitAuthExpired()` at `:64` is the whole session-expiry mechanism |
+| `src/lib/appEvents.ts` | Names the window events. `AUTH_EXPIRED_EVENT` is dispatched by `client.ts:64` and listened to only in `AuthGate.tsx:131` |
+| `src/App.tsx` | Router shell (react-router `BrowserRouter`), route table, command palette, modals. Does not read `useAuth()` at all |
+| `src/components/layout/Sidebar.tsx` | Icon nav. Reads `useUrgentActionItemCount()` and `useDedupeCount()` (`:26`). Does not read `useAuth()`. No account avatar or identity anywhere in the nav |
+| `src/views/settings/SettingsHome.tsx` | Settings landing. `const { user, authRequired } = useAuth()` at `:297`. Uses it to decide whether the Account row is meaningful |
+| `src/views/settings/AccountSettings.tsx` | Profile, password, devices. `useAuth()` at `:148` (`{user, refresh}`) and `:481` (`{user, authRequired, signOut}`). Owns the only two auth-namespaced query keys: `["auth","sessions"]` (`:312`, invalidated `:320`) and `["auth","session-policy"]` (`:386`, invalidated `:394`) |
+| `src/contexts/SessionContext.tsx` | Not an auth context. Despite the name it holds `lastContactId` (RecentContext) and the AI-search transcript (`lastAISearchQuery`, `lastAISearchData`, `lastAISearchPhase`). `useSession()` at `:126` is a compatibility shim over both |
+
+**How the client learns `role`:** only through `AuthStatus.user.role` / `AccountUser.role` returned by `GET /api/auth/status` and `GET /api/auth/me` (`src/api/auth.ts:24`). Nothing in `src/` ever reads `user.role`. Every `.role` hit in the frontend is `contact.role` (job title), for example `src/components/command-palette/AiComponents.tsx:83`, `src/hooks/useInstantSearch.ts:126`. There is no admin-only UI, no role gating, no conditional rendering on role.
+
+**React Query keys:** no key anywhere includes a user id. The namespaces are flat and content-addressed only:
+
+- `["contacts"]`, `["contacts", id]`, `["contacts","map"]`, `["contacts","archived"]`, `["contacts","search",q]`, `["contacts", contactId, "score"]`: `src/api/contacts.ts:45,69,108,132,147,160`, `src/api/search.ts:24`, `src/components/ScoreBreakdown.tsx:54`
+- `["timeline", contactId]`: `src/api/interactions.ts:18`
+- `["lists"]`: `src/api/lists.ts:18`
+- `["trash"]`: `src/api/contacts.ts:253`
+- `["actionItems","completed"]`, `["actionItems","urgentCount"]`: `src/api/actionItems.ts:8,19`
+- `["dashboard"]`: invalidated at `src/api/actionItems.ts:51,69`
+- `["ai-search-status", batchId]`: `src/api/aiSearch.ts:99`
+- `["ai-settings"]` / `["ai-settings","models",capability]`: `src/api/aiSettings.ts:87,98`
+- `suggestionKeys.*` (`pending`, `count`, `mergeLog`, `forContact(id)`): `src/api/suggestions.ts:38,51,65,79`
+- `enrichmentKeys.groundingCapacity`: `src/api/enrichment.ts:30`
+- `["zero-state"]`: invalidated `src/api/enrichment.ts:86`
+- `["weather", lat, lng]`: `src/components/LocalTimeWeather.tsx:143`
+- `["auth","sessions"]`, `["auth","session-policy"]`: `src/views/settings/AccountSettings.tsx:312,386`
+
+`src/lib/queryConfig.ts` holds only `STALE_TIMES` (`:34-83`) and a debug logger (`logCacheEvent` `:129`). It does not build keys and has no notion of a principal. The current mitigation for cross-user cache bleed is the `queryClient.clear()` in `AuthGate` (3 call sites listed above). `src/lib/queryConfig.ts:38-40` explicitly reasons from "single-user app".
+
+---
+
+## H. Tests
+
+### `tests/integration-setup.ts` (vitest setupFile for the integration project)
+
+- `:29` `vi.unmock("../server/db.ts")`. Integration tests use the real DB. The unit project's `tests/setup.ts` mocks it.
+- `:31` `process.env.DATA_DIR = mkdtempSync(path.join(tmpdir(), "contrack-int-"))`. One fresh temp DATA_DIR (and therefore one fresh `curator.db`, uploads dir, migrations, FTS index) per test file, because vitest isolates module state per file.
+- `:38-44` forces AI mock mode by setting `AI_PROVIDER=gemini` and `GEMINI_API_KEY`/`OPENAI_API_KEY`/`ANTHROPIC_API_KEY`/`MAPBOX_API_KEY` to `""` (empty, not deleted, so dotenv cannot repopulate them).
+- `:43-44` `AUTH_TOKEN = ""`, `AUTH_REQUIRED = ""`. Auth is OFF by default. Individual test files opt in.
+- `:49` `DISABLE_BACKGROUND_JOBS = "true"`. Suppresses geocoding fetches and the 5s dedupe debounce.
+
+### `tests/integration/helpers.ts`
+
+- Single export: `makeTestApp(): http.Server` (`:38`).
+- `:40-47` asserts `sqlite.open` is truthy, failing loudly if the unit-project DB mock leaked in.
+- `:49` `createApp({ disableRateLimit: true })`, then `app.use(notFoundHandler)` `:50`, then `http.createServer(finalizeApp(app))` `:55`.
+- `:56-57` `server.listen(0, "127.0.0.1")` + `server.unref()`. Returns an already-listening server (one bind per file) rather than an Express app, to avoid supertest's per-request listen/close port recycling.
+- Because `createApp()` calls `reconcileOwnership()` (`server/app.ts:113`), every test file re-runs the ownership reconcile at construction.
+
+### `tests/integration/api.auth.test.ts` (the only auth coverage)
+
+Local helpers: `wipeAccounts()` `:32` (`DELETE FROM sessions; DELETE FROM users;`), `setupAccount()` `:48`, `signIn()` `:57`, `cookieFrom()` `:73`. `beforeAll` sets `AUTH_REQUIRED = "true"` (`:76-78`). Imports the reset seams `__resetAuthRateLimits` (`:18`), `__resetAuthWarnings` (`:19`), `clearSettingsCache` (`:20`).
+
+describe and it names:
+
+`describe("first-run setup")` `:94`
+
+- `:97` reports setupRequired when gated with no accounts
+- `:109` refuses every other request until an account exists
+- `:115` creates the first account, makes it admin, and signs it in
+- `:135` lowercases the username and email so sign-in is case-insensitive
+- `:148` closes setup once an account exists
+- `:160` rejects a short password
+- `:169` rejects an invalid username
+- `:179` rejects an invalid email
+
+`describe("sign in")` `:190`
+
+- `:197` accepts the right password
+- `:206` rejects the wrong password
+- `:212` gives the same answer for an unknown account, so accounts can't be enumerated
+- `:219` records lastLoginAt
+- `:233` rate-limits repeated failures
+
+`describe("gating")` `:254`
+
+- `:264` rejects unauthenticated API requests
+- `:270` gates /uploads too
+- `:275` gates writes
+- `:282` accepts a valid session cookie
+- `:287` rejects a forged session cookie
+- `:294` leaves everything open when AUTH_REQUIRED is off
+- `:310` does not push an ungated instance through setup even with no accounts
+
+`describe("API token")` `:324`
+
+- `:337` admits a bearer token without any account existing
+- `:344` rejects a wrong bearer token
+- `:351` enforces auth on its own, without AUTH_REQUIRED
+- `:361` still honours the deprecated AUTH_TOKEN name
+- `:374` cannot reach account endpoints, there is no account behind a token
+
+`describe("the signed-in account")` `:385`
+
+- `:396` returns the current account
+- `:402` updates the profile
+- `:415` rejects an invalid profile update without partially applying it
+- `:426` changes the password and invalidates the old one
+- `:445` refuses a password change without the current password
+- `:456` refuses a new password that is too short
+- `:464` needs a credential
+
+`describe("sessions")` `:472`
+
+- `:483` lists the current session and marks it current
+- `:492` signs out, and the cookie stops working
+- `:502` stores only the hash of the session secret, never the secret
+- `:514` revokes other sessions while keeping the current one
+- `:539` ends every other session when the password changes
+- `:558` rejects an expired session
+
+`describe("data ownership")` `:574` (the only ownership tests that exist)
+
+- `:581` claims pre-existing unowned contacts for the first account (inserts `contacts` with `ownerId` NULL at `:586`, asserts it becomes the user id at `:595-597`)
+- `:602` claims unowned lists as well (`:605`, `:611-613`)
+- `:618` carries ownership on every table that has it (iterates OWNED_TABLES asserting the `ownerId` column exists, `:629-630`)
+
+`describe("session policy")` `:644`
+
+- `:662` defaults to 30 days and reports its range
+- `:670` changes the lifetime of sessions created afterwards
+- `:692` leaves existing sessions alone, so a change cannot lock you out
+- `:713` rejects values outside the supported range
+- `:728` needs an account, not just a token
+
+`describe("setup reports what is waiting")` `:743`
+
+- `:750` counts unowned contacts so the setup screen can name them (`:752-753` inserts two NULL-owner contacts)
+- `:761` excludes trashed and ghost contacts from that count
+- `:771` reports zero once an account exists
+
+**Gap:** there is not a single test that creates two accounts and asserts isolation, because `authService.createUser` is the only creation path and no endpoint exposes it after the first account. Every other integration file (`api.contacts`, `api.lifecycle`, `api.merge`, `api.aiSearch`, `api.avatar`, `api.interactions`, `api.hardening`, `dedupe`, `geocoding`) runs fully un-gated with `req.principal = {kind:"anonymous"}`.
+
+---
+
+## A2. Sites added by the 2026-09-08 review
+
+The first inventory missed these. Each touches owned data or shared state
+and has a home in [07-phase-2-scoping.md](07-phase-2-scoping.md).
+
+| file:line | What it does | Sub-phase |
+|---|---|---|
+| `server/services/contactService.ts:155-163` | `hardDeleteContact`, `db.delete(schema.contacts)`. Called from `:602` and `:626`. The Drizzle count for this file is 8, not 7 | 2a |
+| `server/services/contactService.ts:704-740` | `getSlimContacts` pass 2: six statements with an inner `SELECT id FROM contacts WHERE isArchived = 0 ...` subselect | 2a |
+| `server/services/contactService.ts:239-265`, `:465-479` | Doc2Query fire-and-forget: AI call, then `UPDATE contacts SET searchExpansion = ? WHERE id = ?`, then `embedContact` | 2a |
+| `server/routes/contacts.ts:521-550` | Non-stream bulk import tail: `generateAndStoreBulkEmbeddings` (`:523`) and a 3 s-delayed `ParallelQueue.process(createdIds, 1, incrementalDedupeCheck)` (`:530-549`) | 2a |
+| `server/routes/contacts.ts:233-234`, `:246` | Import-time duplicate matching calls `loadNegativeConstraints()`, `normalizeContacts()`, `normalizeContactById()` across the whole instance. The six `SELECT * FROM contacts WHERE id = ?` probes only hydrate already-matched pairs | 2a, 2e |
+| `server/services/relationshipService.ts:250-252` | `explainScore` writes `UPDATE contacts SET relationshipScore` (not read-only) | 2a, 2d |
+| `server/repositories/contactRepository.ts:122-130`, `:381-401` | `hydrate` reads `lists` and `interactions` (owned tables) by contact id | 2a (allow comments) |
+| `server/services/interactionService.ts:166-177` | Explicit `data-id` mention path inserts client-supplied ids into `interaction_mentions` with `INSERT OR IGNORE` and no check. The AI path (`:55-93`) writes `interactions.mentions` JSON and resolves names at `:60-64` with no owner filter. Drizzle count for this file is 18, not 6 | 2b |
+| `server/services/listService.ts:29-31` | `SELECT MAX(sortOrder) FROM lists` unscoped | 2b |
+| `server/services/listService.ts:138-149` | `removeMember` checks nothing; `bulkAddMembers` checks the list only | 2b |
+| `server/services/searchService.ts:122-126` | `buildCompressedCandidates`, one `SELECT ... FROM contacts WHERE id = ?` per candidate | 2c |
+| `server/utils/aiCache.ts:519-533` | `getCachedSearch` / `setCachedSearch` build the `rerank` key; called from `searchService.ts:234, 333, 378, 391, 417, 459, 493`. The read path list in section C should include this | 2c |
+| `server/services/dedupe/blocking.ts:168-175` | `addEmbeddingCandidates` compiles its own `contact_embeddings MATCH` statement; it does not use `_stmts.knn` | 2c, 2e |
+| `server/services/dedupe/context.ts:69-99` | `getEmbeddingSimilarity`, a third private `MATCH` statement (`:79-88`) | 2c, 2e |
+| `server/services/dedupe/blocking.ts:227-237` | `loadNegativeConstraints` also runs an instance-wide `interaction_mentions` self-join | 2e |
+| `server/services/dedupe/engine.ts:108-110` | Full-mode scan runs `DELETE FROM contact_embeddings` with no predicate and `clearEmbeddingMeta()`, wiping every owner's dedupe index | 2e |
+| `server/services/dedupe/embeddings.ts:298-357` | `findStaleEmbeddings` and `reEmbedStaleContacts`, run by every deep scan (`engine.ts:137`), instance-wide and provider-billed | 2e |
+| `server/services/dedupe/engine.ts:584-585` | `seedDuplicates` (dev) inserts contacts with no `ownerId` | 0, 2e |
+| `server/services/dedupe/clustering.ts:48-50` | The interactions count statement (the appendix's `:1` is the prepare count, not the line) | 2e |
+| `server/services/aiSearch/mergeEngine.ts:298` | `invalidateSearchCache()` flushes the whole `rerank` tier (`aiCache.ts:539-541`) | 2f |
+| `server/services/mcpService.ts:13` | `queryContacts` has no `deletedAt IS NULL` or `isGhost` filter | 2g |
+| `server/services/search/localEmbeddings.ts:179-191`, `server/services/dedupe/embeddings.ts:48-60` | Both rebuild helpers emit `vec0(contactId TEXT PRIMARY KEY, embedding FLOAT[n])` with no partition key; a model change after 2.0 would drop it | Phase 1 |
+| `server/db.ts:679-703` | Legacy follow-up backfill inserts `action_items` without `ownerId` (the fill trigger covers it once the boot order is right) | Phase 1 |
+| `scripts/seed.ts:18`, `:105`; `scripts/seedMock.ts:385`, `:499` | Seed scripts insert contacts and interactions with no `ownerId` | Phase 1 |
+| `server/services/interactionService.ts:70-80`, `server/services/dedupe/engine.ts:584-585` | Two more `INSERT INTO contacts` sites (ghost and seed), missing from section B's list | 0 |
+
+Corrections to counts in this appendix: `recordInvocation` has 25 call
+sites (a plain grep counts two comment lines in `aiStatsService.ts` and
+gives 27). There are eleven FTS triggers, not twelve. `zeroStateService` has
+five prepared statements. `dashboardService` splits as nine statements in
+`getDashboardPayload` (`:57-191`) and six in `getInsight` (`:232-295`).
+`searchService.search` does not exist; the FTS entry point is
+`searchService.searchFts` (`:193-208`).
+
+Line drift within a few lines, no action needed: `app.ts` healthRouter `:165`
+(not `:166`), `dedupe/jobQueue` `canStartScan` `:34-42`, `scan.ts`
+`canStartScan` `:46` and `runScan` `:57`, `relationshipService.recomputeAll`
+`:289-336`, `authService.countUnownedContacts` `:208`,
+`backupService.startBackupSchedule` `:100`, `dedupe/embeddings`
+`normalizeContacts` call `:393`.

--- a/docs/multi-tenant-plan/appendix-b-route-manifest.md
+++ b/docs/multi-tenant-plan/appendix-b-route-manifest.md
@@ -1,0 +1,170 @@
+# Appendix B. Route Manifest (Initial Classification)
+
+This is the seed for `server/tenancy/routeManifest.ts` in Phase 0. Classes are
+defined in [03-architecture.md](03-architecture.md) section 5.3 and
+[05-phase-0-foundations.md](05-phase-0-foundations.md) task 0.3.
+
+| Class | Meaning |
+| ----- | ------- |
+| `public` | reachable with no credential |
+| `session-self` | the caller's own account, needs a browser session |
+| `scoped` | owned data for the caller's scope |
+| `admin` | `requireAdmin` |
+| `instance-read` | any authenticated caller, no owned data touched |
+
+`isolated` starts `false` for every `scoped` route and flips in Phase 2. A
+sixth class, `static`, marks the `/uploads` `express.static` layer, which is
+a middleware layer and not a route. Rows marked `devOnly` are registered only
+when `NODE_ENV !== "production"`.
+
+Notes from the 2026-09-08 review, all verified against `server/app.ts` and
+the route files:
+
+- `GET /api/contacts/action-items` is **unreachable in 1.5.5**: `contactsRouter` mounts at `server/app.ts:202`, `mcpRouter` at `:204`, and `GET /contacts/:id` (`routes/contacts.ts:122`) captures the path with `id = "action-items"`. Phase 0 mounts `mcpRouter` first.
+- `GET /api/debug/cache-stats` is registered in `server.ts:97-102`, outside `createApp()`, so a supertest app never has it. Phase 0 moves it inside `createApp()` behind the same `NODE_ENV` guard and marks it `devOnly`.
+- `POST /api/dev/seed-duplicates` is registered only when `NODE_ENV !== "production"` (`routes/dedupe/scan.ts:138`). Marked `devOnly`.
+- `GET /uploads/*` is the `express.static` layer (`layer.name === "serveStatic"`, no `route`). Its manifest row is `USE /uploads`, class `static`; `guardUploads` (Phase 2a) is what scopes it.
+- `PUT /api/auth/session-policy` has `requireUser` only today (`routes/auth.ts:266-268`): every member can change the instance session lifetime. The `admin` class below is the target, enforced in Phase 3.
+- `guardUploads` does not exist in 1.5.5. The `scoped (via guardUploads)` class is a Phase 2 target.
+- Express 5 does not keep mount path strings, so the manifest test records them with a `use` wrapper (Phase 0 task 0.3).
+
+## Existing routes
+
+| Method | Path | Class | Phase 2 sub-phase |
+| ------ | ---- | ----- | ----------------- |
+| GET | `/healthz` | public | |
+| GET | `/api/auth/status` | public | |
+| POST | `/api/auth/setup` | public | |
+| POST | `/api/auth/login` | public | |
+| POST | `/api/auth/logout` | public | |
+| GET | `/api/auth/me` | session-self | |
+| PATCH | `/api/auth/me` | session-self | |
+| POST | `/api/auth/change-password` | session-self | |
+| GET | `/api/auth/sessions` | session-self | |
+| DELETE | `/api/auth/sessions` | session-self | |
+| GET | `/api/auth/session-policy` | session-self | |
+| PUT | `/api/auth/session-policy` | admin | 2g |
+| GET | `/api/avatar/:style` | instance-read | |
+| GET | `/api/link-preview/unfurl` | instance-read | |
+| GET | `/api/logos/:domain` | instance-read | |
+| GET | `/api/search/` | scoped | 2c |
+| POST | `/api/search/semantic` | scoped | 2c |
+| POST | `/api/search/synthesize` | scoped | 2c |
+| GET | `/api/lists/` | scoped | 2b |
+| POST | `/api/lists/` | scoped | 2b |
+| PUT | `/api/lists/reorder` | scoped | 2b |
+| PATCH | `/api/lists/:id` | scoped | 2b |
+| GET | `/api/lists/:id/contacts` | scoped | 2b |
+| DELETE | `/api/lists/:id` | scoped | 2b |
+| POST | `/api/lists/:id/members` | scoped | 2b |
+| DELETE | `/api/lists/:id/members/:contactId` | scoped | 2b |
+| POST | `/api/lists/:id/members/bulk` | scoped | 2b |
+| GET | `/api/contacts/map` | scoped | 2a |
+| GET | `/api/contacts/archived` | scoped | 2a |
+| GET | `/api/contacts` | scoped | 2a |
+| GET | `/api/contacts/:id` | scoped | 2a |
+| GET | `/api/contacts/:id/score` | scoped | 2a |
+| POST | `/api/contacts` | scoped | 2a |
+| POST | `/api/contacts/bulk` | scoped | 2a |
+| POST | `/api/parse-contact` | instance-read | |
+| POST | `/api/contacts/bulk-delete` | scoped | 2a |
+| PUT | `/api/contacts/bulk-update` | scoped | 2a |
+| PUT | `/api/contacts/:id` | scoped | 2a |
+| PATCH | `/api/contacts/:id` | scoped | 2a |
+| DELETE | `/api/contacts/:id` | scoped | 2a |
+| POST | `/api/contacts/:id/avatar` | scoped | 2a |
+| POST | `/api/contacts/:id/enrich` | scoped | 2a |
+| GET | `/api/contacts/:id/timeline` | scoped | 2b |
+| POST | `/api/contacts/:id/interactions` | scoped | 2b |
+| POST | `/api/contacts/:id/briefing` | scoped | 2b |
+| POST | `/api/contacts/:id/promote` | scoped | 2b |
+| POST | `/api/contacts/:id/attachments` | scoped | 2b |
+| PATCH | `/api/interactions/:id` | scoped | 2b |
+| DELETE | `/api/interactions/:id` | scoped | 2b |
+| GET | `/api/contacts/:id/relationships` | scoped | 2b |
+| GET | `/api/query/contacts` | scoped | 2g |
+| GET | `/api/contacts/action-items` | scoped (unreachable until the Phase 0 mount-order fix) | 2g |
+| GET | `/api/tags` | scoped | 2g |
+| GET | `/api/industries` | scoped | 2g |
+| GET | `/api/interactions/search` | scoped | 2g |
+| GET | `/api/timeline` | scoped | 2g |
+| POST | `/api/dedupe/scan` | scoped | 2e |
+| GET | `/api/dedupe/stream` | scoped | 2e |
+| GET | `/api/dedupe/active` | scoped | 2e |
+| GET | `/api/dedupe/status` | scoped | 2e |
+| POST | `/api/dev/seed-duplicates` | scoped, `devOnly` | 2e |
+| POST | `/api/contacts/merge` | scoped | 2e |
+| POST | `/api/contacts/merge-batch` | scoped | 2e |
+| POST | `/api/contacts/merge-cluster` | scoped | 2e |
+| POST | `/api/contacts/merge-clusters` | scoped | 2e |
+| GET | `/api/dedupe/suggestions` | scoped | 2e |
+| GET | `/api/dedupe/suggestions/count` | scoped | 2e |
+| GET | `/api/dedupe/suggestion-for/:contactId` | scoped | 2e |
+| POST | `/api/dedupe/suggestions/:id/dismiss` | scoped | 2e |
+| POST | `/api/dedupe/suggestions/:id/merge` | scoped | 2e |
+| GET | `/api/dedupe/merge-log` | scoped | 2e |
+| POST | `/api/dedupe/merge-log/:id/undo` | scoped | 2e |
+| POST | `/api/dedupe/backfill-embeddings` | admin | 2g |
+| GET | `/api/dedupe/embedding-status` | scoped | 2e |
+| GET | `/api/action-items` | scoped | 2b |
+| GET | `/api/action-items/completed` | scoped | 2b |
+| GET | `/api/action-items/count` | scoped | 2b |
+| PATCH | `/api/action-items/:id` | scoped | 2b |
+| PATCH | `/api/action-items/:id/complete` | scoped | 2b |
+| DELETE | `/api/action-items/:id` | scoped | 2b |
+| GET | `/api/contacts/:id/action-items` | scoped | 2b |
+| POST | `/api/contacts/:id/action-items` | scoped | 2b |
+| GET | `/api/dashboard` | scoped | 2d |
+| GET | `/api/dashboard/insight` | scoped | 2d |
+| GET | `/api/command-palette/zero-state` | scoped | 2d |
+| POST | `/api/ai-search` | scoped | 2f |
+| GET | `/api/ai-search/status` | scoped | 2f |
+| GET | `/api/ai-search/stream` | scoped | 2f |
+| GET | `/api/trash` | scoped | 2a |
+| POST | `/api/trash/:id/restore` | scoped | 2a |
+| POST | `/api/trash/bulk-restore` | scoped | 2a |
+| DELETE | `/api/trash/:id` | scoped | 2a |
+| GET | `/api/backups` | admin | 2g |
+| POST | `/api/backups` | admin | 2g |
+| GET | `/api/export/json` | scoped | 2g |
+| GET | `/api/export/csv` | scoped | 2g |
+| GET | `/api/settings/ai/` | instance-read | |
+| GET | `/api/settings/ai/models/:capability` | instance-read | |
+| PUT | `/api/settings/ai/providers/:id/key` | admin | 2g |
+| DELETE | `/api/settings/ai/providers/:id/key` | admin | 2g |
+| POST | `/api/settings/ai/providers/:id/refresh-models` | admin | 2g |
+| PUT | `/api/settings/ai/endpoints` | admin | 2g |
+| DELETE | `/api/settings/ai/endpoints/:id` | admin | 2g |
+| PUT | `/api/settings/ai/capabilities/:capability` | admin | 2g |
+| PUT | `/api/settings/ai/searxng` | admin | 2g |
+| GET | `/api/ai/stats/summary` | scoped | 2f |
+| GET | `/api/ai/stats/feed` | scoped | 2f |
+| GET | `/api/ai/diagnostics` | admin | 2g |
+| GET | `/api/ai/grounding-capacity` | admin | 2g |
+| GET | `/api/debug/cache-stats` | admin, `devOnly` (moved inside `createApp()` in Phase 0) | 2g |
+| USE | `/uploads` | static (scoped by `guardUploads` from 2a) | 2a |
+
+## Routes added in Phase 3
+
+| Method | Path | Class |
+| ------ | ---- | ----- |
+| POST | `/api/auth/register` | public |
+| POST | `/api/auth/accept-invitation` | public |
+| GET | `/api/auth/tokens` | session-self |
+| POST | `/api/auth/tokens` | session-self |
+| DELETE | `/api/auth/tokens/:id` | session-self |
+| GET | `/api/admin/users` | admin |
+| POST | `/api/admin/users` | admin |
+| GET | `/api/admin/users/:id` | admin |
+| PATCH | `/api/admin/users/:id` | admin |
+| POST | `/api/admin/users/:id/reset-password` | admin |
+| POST | `/api/admin/users/:id/disable` | admin |
+| POST | `/api/admin/users/:id/enable` | admin |
+| GET | `/api/admin/users/:id/export` | admin |
+| DELETE | `/api/admin/users/:id` | admin |
+| GET | `/api/admin/invitations` | admin |
+| POST | `/api/admin/invitations` | admin |
+| DELETE | `/api/admin/invitations/:id` | admin |
+| GET | `/api/admin/settings` | admin |
+| PUT | `/api/admin/settings` | admin |
+| GET | `/api/admin/audit` | admin |

--- a/docs/multi-tenant-plan/bench/README.md
+++ b/docs/multi-tenant-plan/bench/README.md
@@ -1,0 +1,17 @@
+# bench/
+
+Evidence produced while executing the plan. Expected files, by phase:
+
+- `baseline-phase-0.md`: Phase 0 benchmark at `1 × 5000` and `10 × 2000`, including today's per-update FTS trigger cost.
+- `tenant-lint-baseline.txt`: Phase 0 lint report.
+- `rollback-rehearsal.md`: Phase 1.
+- `phase-2.md`: benchmark after scoping.
+- `ui-walkthrough.md` and screenshots: Phase 4.
+- `phase-5.md`, `security-review.md`, `upgrade-rehearsal.md`: Phase 5.
+
+Already present:
+
+- `review-2026-09-08/`: the scripts and measurements from the plan review
+  against `v1.5.5`. They back the answers in
+  [14-risks-and-open-questions.md](../14-risks-and-open-questions.md) and the
+  `cidTok` change in the data model document.

--- a/docs/multi-tenant-plan/bench/review-2026-09-08/01-vec-fts-smoke.cjs
+++ b/docs/multi-tenant-plan/bench/review-2026-09-08/01-vec-fts-smoke.cjs
@@ -1,0 +1,58 @@
+const Database = require("better-sqlite3");
+const sqliteVec = require("sqlite-vec");
+const db = new Database(":memory:");
+sqliteVec.load(db);
+console.log("vec_version:", db.prepare("select vec_version() as v").get().v);
+console.log("sqlite_version:", db.prepare("select sqlite_version() as v").get().v);
+console.log("fts5:", db.prepare("select fts5(?)").pluck().get("version") ?? "n/a");
+// partition key smoke
+db.exec(`CREATE VIRTUAL TABLE t USING vec0(contactId TEXT PRIMARY KEY, ownerId TEXT PARTITION KEY, embedding FLOAT[4])`);
+const ins = db.prepare("INSERT INTO t(contactId, ownerId, embedding) VALUES (?, ?, ?)");
+const f = (a) => Buffer.from(new Float32Array(a).buffer);
+ins.run("a1", "owner-a-uuid", f([1,0,0,0]));
+ins.run("a2", "owner-a-uuid", f([0.9,0.1,0,0]));
+ins.run("b1", "owner-b-uuid", f([1,0,0,0]));
+ins.run("b2", "owner-b-uuid", f([0.99,0.01,0,0]));
+const knn = db.prepare("SELECT contactId, distance FROM t WHERE embedding MATCH ? AND k = 10 AND ownerId = ? ORDER BY distance").all(f([1,0,0,0]), "owner-a-uuid");
+console.log("knn owner-a:", JSON.stringify(knn));
+const knnB = db.prepare("SELECT contactId, distance FROM t WHERE embedding MATCH ? AND k = 10 AND ownerId = ? ORDER BY distance").all(f([1,0,0,0]), "owner-b-uuid");
+console.log("knn owner-b:", JSON.stringify(knnB));
+// sqlite_master sql
+console.log("master sql:", db.prepare("select sql from sqlite_master where name='t'").get().sql);
+// delete by partition key
+try { const r = db.prepare("DELETE FROM t WHERE ownerId = ?").run("owner-a-uuid"); console.log("delete by partition ok, changes:", r.changes); } catch (e) { console.log("delete by partition ERR:", e.message); }
+console.log("count after:", db.prepare("select count(*) as c from t").get().c);
+// count with partition filter
+try { console.log("count by partition:", db.prepare("select count(*) as c from t where ownerId = ?").get("owner-b-uuid").c); } catch (e) { console.log("count by partition ERR:", e.message); }
+// bare select with partition filter (non-KNN)
+try { console.log("select by partition:", JSON.stringify(db.prepare("select contactId from t where ownerId = ?").all("owner-b-uuid"))); } catch (e) { console.log("select by partition ERR:", e.message); }
+// update partition key?
+try { db.prepare("UPDATE t SET ownerId = ? WHERE contactId = ?").run("owner-c", "b1"); console.log("update partition ok"); } catch (e) { console.log("update partition ERR:", e.message); }
+// ALTER TABLE RENAME on vec0
+try { db.exec("ALTER TABLE t RENAME TO t2"); console.log("rename vec0 ok"); } catch (e) { console.log("rename vec0 ERR:", e.message); }
+// FTS5 owner token test
+db.exec(`CREATE VIRTUAL TABLE fts USING fts5(contactId UNINDEXED, name, company, ownerTok)`);
+const fi = db.prepare("INSERT INTO fts(contactId, name, company, ownerTok) VALUES (?,?,?,?)");
+fi.run("a1", "John Smith", "Acme", "o3f2c1d0e9a84b7c8d6e5f4a3b2c1d0e9");
+fi.run("b1", "John Smith", "Acme", "oaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+const q = (m) => { try { return JSON.stringify(db.prepare("SELECT contactId, bm25(fts, 10.0, 5.0, 0.0) AS s FROM fts WHERE fts MATCH ? ORDER BY s").all(m)); } catch (e) { return "ERR " + e.message; } };
+console.log("fts and-wrap:", q('ownerTok:o3f2c1d0e9a84b7c8d6e5f4a3b2c1d0e9 AND ("john smith")'));
+console.log("fts prefix strategy:", q('ownerTok:o3f2c1d0e9a84b7c8d6e5f4a3b2c1d0e9 AND ("john"* OR "smith"*)'));
+console.log("fts column-set:", q('ownerTok:o3f2c1d0e9a84b7c8d6e5f4a3b2c1d0e9 AND ({name company} : (john OR acme))'));
+console.log("fts NOT strategy:", q('ownerTok:o3f2c1d0e9a84b7c8d6e5f4a3b2c1d0e9 AND (john NOT acme)'));
+console.log("fts wrong owner:", q('ownerTok:oaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa AND ("john smith")'));
+// token tokenization test: does unicode61 keep 'o3f2...' as one token?
+console.log("fts token as-is:", q('ownerTok:o3f2c1d0e9a84b7c8d6e5f4a3b2c1d0e9'));
+// explain query plan for fts
+console.log("eqp fts:", JSON.stringify(db.prepare("EXPLAIN QUERY PLAN SELECT contactId FROM fts WHERE fts MATCH ?").all('ownerTok:x AND (john)')));
+// ALTER TABLE ADD COLUMN with REFERENCES while foreign_keys on
+db.exec("PRAGMA foreign_keys = ON");
+db.exec("CREATE TABLE users(id TEXT PRIMARY KEY)");
+db.exec("CREATE TABLE inter(id TEXT PRIMARY KEY, contactId TEXT)");
+try { db.exec("ALTER TABLE inter ADD COLUMN ownerId TEXT REFERENCES users(id) ON DELETE RESTRICT"); console.log("add fk column ok"); } catch (e) { console.log("add fk column ERR:", e.message); }
+try { db.exec("ALTER TABLE users ADD COLUMN status TEXT NOT NULL DEFAULT 'active'"); console.log("add not null default ok"); } catch (e) { console.log("add not null default ERR:", e.message); }
+try { db.exec("ALTER TABLE users ADD COLUMN createdBy TEXT REFERENCES users(id) ON DELETE SET NULL"); console.log("add self fk ok"); } catch (e) { console.log("add self fk ERR:", e.message); }
+// VACUUM INTO on memory db
+try { db.exec("VACUUM INTO '/tmp/contrack-review/vac.db'"); console.log("vacuum into ok"); } catch (e) { console.log("vacuum into ERR:", e.message); }
+// fs.statfs
+const fs = require("fs"); console.log("fs.statfsSync:", typeof fs.statfsSync);

--- a/docs/multi-tenant-plan/bench/review-2026-09-08/02-sqlite-triggers-tx.cjs
+++ b/docs/multi-tenant-plan/bench/review-2026-09-08/02-sqlite-triggers-tx.cjs
@@ -1,0 +1,62 @@
+const Database = require("better-sqlite3");
+const sqliteVec = require("sqlite-vec");
+const path = "/tmp/contrack-review/tx.db";
+const fs = require("fs"); for (const f of [path, path+"-wal", path+"-shm", path+".bak"]) { try { fs.unlinkSync(f) } catch {} }
+const db = new Database(path); sqliteVec.load(db);
+db.pragma("journal_mode = WAL"); db.pragma("foreign_keys = ON");
+db.exec("CREATE TABLE users(id TEXT PRIMARY KEY, createdAt TEXT DEFAULT CURRENT_TIMESTAMP)");
+db.exec("CREATE TABLE contacts(id TEXT PRIMARY KEY, name TEXT, ownerId TEXT REFERENCES users(id) ON DELETE RESTRICT)");
+db.exec("CREATE TABLE interactions(id TEXT PRIMARY KEY, contactId TEXT REFERENCES contacts(id) ON DELETE CASCADE, updatedAt TEXT)");
+db.exec("INSERT INTO users(id) VALUES ('u1'),('u2')");
+db.exec("INSERT INTO contacts VALUES ('c1','A','u1'),('c2','B','u2')");
+// 1. VACUUM INTO inside a transaction?
+const tx = db.transaction(() => { db.exec(`VACUUM INTO '${path}.bak'`); });
+try { tx(); console.log("VACUUM INTO inside transaction: ok"); } catch (e) { console.log("VACUUM INTO inside transaction ERR:", e.message); }
+try { db.exec(`VACUUM INTO '${path}.bak'`); console.log("VACUUM INTO outside transaction: ok"); } catch (e) { console.log("VACUUM INTO outside ERR:", e.message); }
+// 2. DROP/CREATE vec0 inside transaction
+db.exec("CREATE VIRTUAL TABLE se USING vec0(contactId TEXT PRIMARY KEY, embedding FLOAT[4])");
+db.prepare("INSERT INTO se(contactId, embedding) VALUES (?,?)").run("c1", Buffer.from(new Float32Array([1,0,0,0]).buffer));
+db.prepare("INSERT INTO se(contactId, embedding) VALUES (?,?)").run("c2", Buffer.from(new Float32Array([0,1,0,0]).buffer));
+const rebuild = db.transaction(() => {
+  const rows = db.prepare("SELECT e.contactId, c.ownerId, e.embedding FROM se e JOIN contacts c ON c.id = e.contactId").all();
+  db.exec("DROP TABLE se");
+  db.exec("CREATE VIRTUAL TABLE se USING vec0(contactId TEXT PRIMARY KEY, ownerId TEXT PARTITION KEY, embedding FLOAT[4])");
+  const ins = db.prepare("INSERT INTO se(contactId, ownerId, embedding) VALUES (?,?,?)");
+  for (const r of rows) ins.run(r.contactId, r.ownerId, r.embedding);
+  return rows.length;
+});
+try { console.log("vec0 rebuild in tx ok, rows:", rebuild()); } catch (e) { console.log("vec0 rebuild in tx ERR:", e.message); }
+console.log("vec0 sql now:", db.prepare("select sql from sqlite_master where name='se'").get().sql);
+console.log("vec0 partition detect (LIKE):", db.prepare("select sql LIKE '%PARTITION KEY%' AS p from sqlite_master where name='se'").get().p);
+// embedding column read back as blob? 
+const r = db.prepare("SELECT contactId, ownerId, embedding FROM se").all(); console.log("readback:", r.map(x => [x.contactId, x.ownerId, x.embedding && x.embedding.length]));
+// 3. AFTER INSERT fill trigger + updatedAt trigger interplay
+db.exec("ALTER TABLE interactions ADD COLUMN ownerId TEXT REFERENCES users(id) ON DELETE RESTRICT");
+db.exec(`CREATE TRIGGER interactions_updated AFTER UPDATE ON interactions BEGIN UPDATE interactions SET updatedAt = 'touched' WHERE id = NEW.id; END`);
+db.exec(`CREATE TRIGGER interactions_owner_fill AFTER INSERT ON interactions WHEN NEW.ownerId IS NULL BEGIN UPDATE interactions SET ownerId = (SELECT ownerId FROM contacts WHERE id = NEW.contactId) WHERE id = NEW.id; END`);
+db.exec(`CREATE TRIGGER interactions_owner_check BEFORE INSERT ON interactions WHEN NEW.ownerId IS NOT NULL AND NEW.ownerId != (SELECT ownerId FROM contacts WHERE id = NEW.contactId) BEGIN SELECT RAISE(ABORT, 'interactions.ownerId does not match contact owner'); END`);
+db.prepare("INSERT INTO interactions(id, contactId) VALUES ('i1','c1')").run();
+console.log("fill trigger:", db.prepare("SELECT ownerId, updatedAt FROM interactions WHERE id='i1'").get());
+try { db.prepare("INSERT INTO interactions(id, contactId, ownerId) VALUES ('i2','c1','u2')").run(); console.log("mismatch insert: ALLOWED (bad)"); } catch (e) { console.log("mismatch insert rejected:", e.message); }
+// 4. propagate trigger
+db.exec(`CREATE TRIGGER contacts_owner_propagate AFTER UPDATE OF ownerId ON contacts WHEN NEW.ownerId IS NOT OLD.ownerId BEGIN UPDATE interactions SET ownerId = NEW.ownerId WHERE contactId = NEW.id; END`);
+db.exec("UPDATE contacts SET ownerId = 'u2' WHERE id = 'c1'");
+console.log("propagate:", db.prepare("SELECT ownerId FROM interactions WHERE id='i1'").get());
+// 5. ON DELETE RESTRICT user with data; cascades fire child triggers?
+try { db.exec("DELETE FROM users WHERE id='u2'"); console.log("delete owner with data: ALLOWED (bad)"); } catch (e) { console.log("delete owner with data rejected:", e.message); }
+let fired = 0; db.function("bump", () => { fired++; return 1; });
+db.exec("CREATE TRIGGER inter_ad AFTER DELETE ON interactions BEGIN SELECT bump(); END");
+db.exec("DELETE FROM contacts WHERE id='c1'");
+console.log("cascade fired child AFTER DELETE trigger times:", fired, "remaining interactions:", db.prepare("select count(*) c from interactions").get().c);
+// 6. user_version
+console.log("user_version:", db.pragma("user_version", { simple: true }));
+// 7. nested transaction => savepoint
+const inner = db.transaction(() => { db.exec("INSERT INTO users(id) VALUES ('u3')"); throw new Error("rollback inner"); });
+const outer = db.transaction(() => { db.exec("INSERT INTO users(id) VALUES ('u4')"); try { inner(); } catch {} });
+outer(); console.log("users after nested:", db.prepare("select group_concat(id) g from users").get().g);
+// 8. FTS with porter tokenizer: does hex owner token survive stemming consistently?
+db.exec("CREATE VIRTUAL TABLE f2 USING fts5(name, ownerTok, tokenize='porter unicode61')");
+db.prepare("INSERT INTO f2 VALUES (?,?)").run("John", "o3f2c1d0e9a84b7c8d6e5f4a3b2c1d0aed");
+console.log("porter token match:", db.prepare("SELECT count(*) c FROM f2 WHERE f2 MATCH ?").get("ownerTok:o3f2c1d0e9a84b7c8d6e5f4a3b2c1d0aed").c);
+console.log("porter vocab:", (() => { db.exec("CREATE VIRTUAL TABLE f2v USING fts5vocab(f2, 'row')"); return db.prepare("select term from f2v").all().map(r=>r.term); })());
+db.close();

--- a/docs/multi-tenant-plan/bench/review-2026-09-08/03-als-multer-sse.cjs
+++ b/docs/multi-tenant-plan/bench/review-2026-09-08/03-als-multer-sse.cjs
@@ -1,0 +1,49 @@
+const { AsyncLocalStorage } = require("node:async_hooks");
+const express = require("express");
+const multer = require("multer");
+const http = require("http");
+const { EventEmitter } = require("events");
+const os = require("os"); const path = require("path"); const fs = require("fs");
+const als = new AsyncLocalStorage();
+const app = express();
+app.use((req, res, next) => { als.run({ id: req.headers["x-id"] }, () => next()); });
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), "alsm-"));
+const seen = {};
+const upload = multer({ storage: multer.diskStorage({
+  destination(req, file, cb) { seen.destination = als.getStore()?.id ?? null; cb(null, dir); },
+  filename(req, file, cb) { seen.filename = als.getStore()?.id ?? null; cb(null, "f.bin"); },
+})});
+app.post("/up", upload.single("file"), (req, res) => { seen.handler = als.getStore()?.id ?? null; res.json(seen); });
+const em = new EventEmitter();
+app.get("/sse", (req, res) => {
+  res.setHeader("Content-Type", "text/event-stream");
+  const listener = () => { res.write(`data: ${als.getStore()?.id ?? "null"}\n\n`); res.end(); };
+  em.once("tick", listener);
+  setTimeout(() => em.emit("tick"), 10); // emitted from within the request's async chain
+});
+app.get("/sse-external", (req, res) => {
+  res.setHeader("Content-Type", "text/event-stream");
+  em.once("ext", () => { res.write(`data: ${als.getStore()?.id ?? "null"}\n\n`); res.end(); });
+  // emitter fired from a timer created OUTSIDE any request context
+});
+app.get("/stream", async (req, res) => {
+  // NDJSON-style: await then write
+  await new Promise(r => setImmediate(r));
+  await Promise.all([new Promise(r => setTimeout(r, 5))]);
+  res.json({ afterAwait: als.getStore()?.id ?? null });
+});
+const server = http.createServer(app).listen(0, async () => {
+  const port = server.address().port;
+  const base = `http://127.0.0.1:${port}`;
+  const fd = new FormData(); fd.append("file", new Blob([Buffer.alloc(1024*64, 1)]), "x.bin");
+  const r1 = await fetch(base + "/up", { method: "POST", headers: { "x-id": "user-A" }, body: fd });
+  console.log("multer:", await r1.text());
+  const r2 = await fetch(base + "/sse", { headers: { "x-id": "user-B" } });
+  console.log("sse (emit from request chain):", (await r2.text()).trim());
+  const p3 = fetch(base + "/sse-external", { headers: { "x-id": "user-C" } });
+  setTimeout(() => em.emit("ext"), 50); // fired from top-level, outside any ALS.run
+  console.log("sse (emit from outside):", (await (await p3).text()).trim());
+  const r4 = await fetch(base + "/stream", { headers: { "x-id": "user-D" } });
+  console.log("ndjson-style after await:", await r4.text());
+  server.close();
+});

--- a/docs/multi-tenant-plan/bench/review-2026-09-08/04-fts-vec-purge-bench.cjs
+++ b/docs/multi-tenant-plan/bench/review-2026-09-08/04-fts-vec-purge-bench.cjs
@@ -1,0 +1,126 @@
+const Database = require("better-sqlite3");
+const sqliteVec = require("sqlite-vec");
+const crypto = require("crypto");
+const p = "/tmp/contrack-review/bench.db";
+const fs = require("fs"); for (const f of [p, p+"-wal", p+"-shm"]) { try { fs.unlinkSync(f) } catch {} }
+const db = new Database(p); sqliteVec.load(db);
+db.pragma("journal_mode = WAL"); db.pragma("synchronous = NORMAL"); db.pragma("foreign_keys = ON"); db.pragma("cache_size = -65536");
+const OWNERS = 10, PER = 5000, N = OWNERS * PER;
+const owners = Array.from({length: OWNERS}, () => crypto.randomUUID());
+const tok = (o) => "o" + o.replace(/-/g, "");
+const vocab = ["john","smith","acme","design","engineer","berlin","london","director","studio","labs","maria","garcia","chen","wei","product","marketing","founder","partner","analyst","architect","paris","tokyo","nexus","atlas","orbit","quantum","vertex","harbor","summit","prism"];
+const pick = () => vocab[Math.floor(Math.random()*vocab.length)];
+db.exec(`
+CREATE TABLE users(id TEXT PRIMARY KEY);
+CREATE TABLE contacts(id TEXT PRIMARY KEY, name TEXT, company TEXT, role TEXT, about TEXT, deletedAt TEXT, ownerId TEXT REFERENCES users(id) ON DELETE RESTRICT);
+CREATE TABLE contact_emails(id INTEGER PRIMARY KEY, contactId TEXT NOT NULL REFERENCES contacts(id) ON DELETE CASCADE, email TEXT);
+CREATE INDEX idx_contact_emails_contact ON contact_emails(contactId);
+CREATE INDEX idx_contacts_owner_deleted ON contacts(ownerId, deletedAt);
+CREATE VIRTUAL TABLE contacts_fts USING fts5(contactId UNINDEXED, name, company, role, about, extras, ownerTok);
+CREATE TRIGGER contacts_ai AFTER INSERT ON contacts BEGIN
+  INSERT INTO contacts_fts(contactId,name,company,role,about,extras,ownerTok) VALUES (new.id,new.name,new.company,new.role,new.about,
+    COALESCE((SELECT GROUP_CONCAT(email,' ') FROM contact_emails WHERE contactId=new.id),''), 'o'||replace(new.ownerId,'-',''));
+END;
+CREATE TRIGGER contacts_ad AFTER DELETE ON contacts BEGIN DELETE FROM contacts_fts WHERE contactId=old.id; END;
+CREATE TRIGGER contacts_au AFTER UPDATE ON contacts BEGIN
+  DELETE FROM contacts_fts WHERE contactId=old.id;
+  INSERT INTO contacts_fts(contactId,name,company,role,about,extras,ownerTok) SELECT new.id,new.name,new.company,new.role,new.about,
+    COALESCE((SELECT GROUP_CONCAT(email,' ') FROM contact_emails WHERE contactId=new.id),''), 'o'||replace(new.ownerId,'-','') WHERE new.deletedAt IS NULL;
+END;
+CREATE TRIGGER fts_emails_ai AFTER INSERT ON contact_emails BEGIN
+  DELETE FROM contacts_fts WHERE contactId=new.contactId;
+  INSERT INTO contacts_fts(contactId,name,company,role,about,extras,ownerTok) SELECT c.id,c.name,c.company,c.role,c.about,
+    COALESCE((SELECT GROUP_CONCAT(email,' ') FROM contact_emails WHERE contactId=c.id),''), 'o'||replace(c.ownerId,'-','') FROM contacts c WHERE c.id=new.contactId AND c.deletedAt IS NULL;
+END;
+CREATE TRIGGER fts_emails_ad AFTER DELETE ON contact_emails BEGIN
+  DELETE FROM contacts_fts WHERE contactId=old.contactId;
+  INSERT INTO contacts_fts(contactId,name,company,role,about,extras,ownerTok) SELECT c.id,c.name,c.company,c.role,c.about,
+    COALESCE((SELECT GROUP_CONCAT(email,' ') FROM contact_emails WHERE contactId=c.id),''), 'o'||replace(c.ownerId,'-','') FROM contacts c WHERE c.id=old.contactId AND c.deletedAt IS NULL;
+END;
+-- post-filter variant for comparison (no triggers, populated directly)
+CREATE VIRTUAL TABLE fts_unindexed USING fts5(contactId UNINDEXED, name, company, role, about, extras, ownerId UNINDEXED);
+CREATE VIRTUAL TABLE se USING vec0(contactId TEXT PRIMARY KEY, ownerId TEXT PARTITION KEY, embedding FLOAT[384]);
+CREATE VIRTUAL TABLE se_flat USING vec0(contactId TEXT PRIMARY KEY, embedding FLOAT[384]);
+`);
+const t0 = Date.now();
+db.transaction(() => { for (const o of owners) db.prepare("INSERT INTO users VALUES (?)").run(o); })();
+const insC = db.prepare("INSERT INTO contacts(id,name,company,role,about,ownerId) VALUES (?,?,?,?,?,?)");
+const insE = db.prepare("INSERT INTO contact_emails(contactId,email) VALUES (?,?)");
+const insU = db.prepare("INSERT INTO fts_unindexed(contactId,name,company,role,about,extras,ownerId) VALUES (?,?,?,?,?,?,?)");
+const ids = [];
+db.transaction(() => {
+  for (let i = 0; i < N; i++) {
+    const id = crypto.randomUUID(), o = owners[i % OWNERS];
+    const name = pick()+" "+pick(), company = pick()+" "+pick(), role = pick(), about = Array.from({length:8},pick).join(" ");
+    insC.run(id, name, company, role, about, o);
+    insE.run(id, pick()+"@"+pick()+".com"); insE.run(id, pick()+"@example.com");
+    insU.run(id, name, company, role, about, "", o);
+    ids.push([id, o]);
+  }
+})();
+console.log(`seeded ${N} contacts + ${2*N} emails with FTS triggers in ${Date.now()-t0} ms`);
+const vec = () => Buffer.from(Float32Array.from({length:384}, () => Math.random()-0.5).buffer);
+const t1 = Date.now();
+db.transaction(() => { const a = db.prepare("INSERT INTO se(contactId,ownerId,embedding) VALUES (?,?,?)"), b = db.prepare("INSERT INTO se_flat(contactId,embedding) VALUES (?,?)"); for (const [id,o] of ids) { const v = vec(); a.run(id,o,v); b.run(id,v); } })();
+console.log(`seeded ${N} x 384-dim vectors into partitioned + flat vec0 in ${Date.now()-t1} ms`);
+db.exec("ANALYZE");
+function bench(label, fn, iters = 100) { const t = []; for (let i = 0; i < iters; i++) { const s = process.hrtime.bigint(); fn(); t.push(Number(process.hrtime.bigint()-s)/1e6); } t.sort((a,b)=>a-b); console.log(`${label.padEnd(58)} p50 ${t[Math.floor(iters*0.5)].toFixed(2).padStart(7)} ms  p95 ${t[Math.floor(iters*0.95)].toFixed(2).padStart(7)} ms`); }
+const o0 = owners[0];
+const qTok = db.prepare("SELECT contactId, bm25(contacts_fts,10.0,5.0,3.0,1.0,1.0,0.0) AS s FROM contacts_fts WHERE contacts_fts MATCH ? ORDER BY s LIMIT 50");
+const qUn = db.prepare("SELECT contactId, bm25(fts_unindexed,10.0,5.0,3.0,1.0,1.0) AS s FROM fts_unindexed WHERE fts_unindexed MATCH ? AND ownerId = ? ORDER BY s LIMIT 50");
+const qJoin = db.prepare("SELECT f.contactId, bm25(fts_unindexed,10.0,5.0,3.0,1.0,1.0) AS s FROM fts_unindexed f JOIN contacts c ON c.id = f.contactId WHERE fts_unindexed MATCH ? AND c.ownerId = ? ORDER BY s LIMIT 50");
+const qGlobal = db.prepare("SELECT contactId, bm25(fts_unindexed,10.0,5.0,3.0,1.0,1.0) AS s FROM fts_unindexed WHERE fts_unindexed MATCH ? ORDER BY s LIMIT 50");
+for (const q of ['"john"', '"john"* OR "smith"*', 'design OR studio OR labs']) {
+  console.log(`\nFTS query: ${q}   (owner rows matched: ${qTok.all(`ownerTok:${tok(o0)} AND (${q})`).length}, global matched: ${qGlobal.all(q).length} of limit 50)`);
+  bench(`  indexed ownerTok AND (...)`, () => qTok.all(`ownerTok:${tok(o0)} AND (${q})`));
+  bench(`  UNINDEXED ownerId post-filter`, () => qUn.all(q, o0));
+  bench(`  JOIN contacts c.ownerId`, () => qJoin.all(q, o0));
+  bench(`  no owner filter (today)`, () => qGlobal.all(q));
+}
+console.log("\nEQP indexed:", db.prepare("EXPLAIN QUERY PLAN SELECT contactId FROM contacts_fts WHERE contacts_fts MATCH ?").all(`ownerTok:${tok(o0)} AND (john)`).map(r=>r.detail).join(" | "));
+console.log("EQP unindexed:", db.prepare("EXPLAIN QUERY PLAN SELECT contactId FROM fts_unindexed WHERE fts_unindexed MATCH ? AND ownerId = ?").all("john", o0).map(r=>r.detail).join(" | "));
+console.log("");
+const qv = vec();
+const kP = db.prepare("SELECT contactId, distance FROM se WHERE embedding MATCH ? AND k = 50 AND ownerId = ? ORDER BY distance");
+const kF = db.prepare("SELECT contactId, distance FROM se_flat WHERE embedding MATCH ? AND k = 50 ORDER BY distance");
+const kFbig = db.prepare("SELECT contactId, distance FROM se_flat WHERE embedding MATCH ? AND k = 500 ORDER BY distance");
+bench(`vec0 KNN k=50 partitioned (owner has ${PER} of ${N})`, () => kP.all(qv, o0), 30);
+bench(`vec0 KNN k=50 flat (today, global over ${N})`, () => kF.all(qv), 30);
+bench(`vec0 KNN k=500 flat then JS filter (today's preFilter path)`, () => kFbig.all(qv).filter(r => true), 30);
+// how many of the global top-100 belong to owner 0? (correctness claim)
+const top100 = db.prepare("SELECT contactId FROM se_flat WHERE embedding MATCH ? AND k = 100").all(qv).map(r=>r.contactId);
+const ownerSet = new Set(ids.filter(([,o])=>o===o0).map(([id])=>id));
+console.log(`global top-100 rows belonging to owner 0 (expected ~10): ${top100.filter(id=>ownerSet.has(id)).length}`);
+console.log("");
+// FTS rebuild timing
+let s = Date.now();
+db.exec("DELETE FROM contacts_fts"); db.exec(`INSERT INTO contacts_fts(contactId,name,company,role,about,extras,ownerTok) SELECT c.id,c.name,c.company,c.role,c.about,COALESCE((SELECT GROUP_CONCAT(email,' ') FROM contact_emails WHERE contactId=c.id),''),'o'||replace(c.ownerId,'-','') FROM contacts c WHERE c.deletedAt IS NULL`);
+console.log(`FTS full backfill of ${N} rows (with email subselect): ${Date.now()-s} ms`);
+// claim re-index cost: UPDATE ownerId on one owner's rows (fires contacts_au per row)
+s = Date.now(); db.exec(`UPDATE contacts SET ownerId = '${o0}' WHERE ownerId = '${o0}'`); console.log(`UPDATE contacts SET ownerId on ${PER} rows (contacts_au re-index per row): ${Date.now()-s} ms`);
+// vec0 copy-rebuild timing
+s = Date.now();
+db.transaction(() => { const rows = db.prepare("SELECT e.contactId, c.ownerId, e.embedding FROM se_flat e JOIN contacts c ON c.id = e.contactId").all(); db.exec("DROP TABLE se_flat"); db.exec("CREATE VIRTUAL TABLE se_flat USING vec0(contactId TEXT PRIMARY KEY, ownerId TEXT PARTITION KEY, embedding FLOAT[384])"); const ins = db.prepare("INSERT INTO se_flat(contactId,ownerId,embedding) VALUES (?,?,?)"); for (const r of rows) ins.run(r.contactId, r.ownerId, r.embedding); })();
+console.log(`vec0 copy-rebuild of ${N} x 384-dim rows: ${Date.now()-s} ms`);
+// purge one owner
+s = Date.now();
+const purge = db.transaction((o) => {
+  db.prepare("DELETE FROM se WHERE ownerId = ?").run(o);
+  const r = db.prepare("DELETE FROM contacts WHERE ownerId = ?").run(o);
+  return r.changes;
+});
+const n = purge(o0);
+console.log(`purge one owner: ${n} contacts (+${2*n} cascaded emails, FTS triggers firing): ${Date.now()-s} ms`);
+console.log("fts rows left:", db.prepare("SELECT COUNT(*) c FROM contacts_fts").get().c, " contacts left:", db.prepare("SELECT COUNT(*) c FROM contacts").get().c, " vec rows left:", db.prepare("SELECT COUNT(*) c FROM se").get().c);
+// purge variant: delete FTS rows in one statement first? (FTS5 delete via MATCH)
+const o1 = owners[1];
+s = Date.now();
+const purge2 = db.transaction((o) => {
+  db.prepare("DELETE FROM se WHERE ownerId = ?").run(o);
+  db.prepare("DELETE FROM contact_emails WHERE contactId IN (SELECT id FROM contacts WHERE ownerId = ?)").run(o);
+  const r = db.prepare("DELETE FROM contacts WHERE ownerId = ?").run(o);
+  return r.changes;
+});
+const n2 = purge2(o1);
+console.log(`purge variant (children explicitly first): ${n2} contacts: ${Date.now()-s} ms`);
+db.close();

--- a/docs/multi-tenant-plan/bench/review-2026-09-08/05-fts-delete-cidtok.cjs
+++ b/docs/multi-tenant-plan/bench/review-2026-09-08/05-fts-delete-cidtok.cjs
@@ -1,0 +1,42 @@
+const Database = require("better-sqlite3");
+const db = new Database("/tmp/contrack-review/bench.db");
+const n = db.prepare("SELECT COUNT(*) c FROM contacts_fts").get().c;
+const ids = db.prepare("SELECT contactId FROM contacts_fts LIMIT 200").all().map(r => r.contactId);
+function bench(label, fn, iters) { const t = []; for (let i = 0; i < iters; i++) { const s = process.hrtime.bigint(); fn(i); t.push(Number(process.hrtime.bigint()-s)/1e6); } t.sort((a,b)=>a-b); console.log(`${label.padEnd(64)} p50 ${t[Math.floor(iters*0.5)].toFixed(3).padStart(8)} ms  (fts rows: ${n})`); }
+// 1. today's trigger shape: DELETE by UNINDEXED contactId (read-only probe: SELECT with same predicate)
+bench("SELECT rowid FROM contacts_fts WHERE contactId = ?  (UNINDEXED, today's trigger)", (i) => db.prepare("SELECT rowid FROM contacts_fts WHERE contactId = ?").all(ids[i % ids.length]), 50);
+console.log("EQP:", db.prepare("EXPLAIN QUERY PLAN SELECT rowid FROM contacts_fts WHERE contactId = ?").all("x").map(r=>r.detail).join(" | "));
+// 2. build a v2-style table with an indexed cidTok column
+db.exec("DROP TABLE IF EXISTS fts2");
+db.exec("CREATE VIRTUAL TABLE fts2 USING fts5(contactId UNINDEXED, name, company, role, about, extras, ownerTok, cidTok)");
+let s = Date.now();
+db.exec("INSERT INTO fts2(contactId,name,company,role,about,extras,ownerTok,cidTok) SELECT c.id,c.name,c.company,c.role,c.about,'','o'||replace(c.ownerId,'-',''),'c'||replace(c.id,'-','') FROM contacts c WHERE c.deletedAt IS NULL");
+console.log(`bulk backfill with cidTok: ${Date.now()-s} ms`);
+bench("SELECT rowid FROM fts2 WHERE fts2 MATCH 'cidTok:...'  (indexed token)", (i) => db.prepare("SELECT rowid FROM fts2 WHERE fts2 MATCH ?").all("cidTok:c" + ids[i % ids.length].replace(/-/g,"")), 50);
+// 3. real DELETE cost both ways inside a transaction (rolled back)
+const del1 = db.transaction(() => { const st = db.prepare("DELETE FROM contacts_fts WHERE contactId = ?"); const t0 = process.hrtime.bigint(); for (let i = 0; i < 50; i++) st.run(ids[i]); console.log(`50x DELETE FROM contacts_fts WHERE contactId=? : ${(Number(process.hrtime.bigint()-t0)/1e6).toFixed(1)} ms total`); throw new Error("rollback"); });
+try { del1(); } catch {}
+const del2 = db.transaction(() => { const st = db.prepare("DELETE FROM fts2 WHERE fts2 MATCH ?"); const t0 = process.hrtime.bigint(); for (let i = 0; i < 50; i++) st.run("cidTok:c" + ids[i].replace(/-/g,"")); console.log(`50x DELETE FROM fts2 WHERE fts2 MATCH 'cidTok:...' : ${(Number(process.hrtime.bigint()-t0)/1e6).toFixed(1)} ms total`); throw new Error("rollback"); });
+try { del2(); } catch {}
+// 4. bulk owner delete from FTS via MATCH on ownerTok
+const owner = db.prepare("SELECT ownerId FROM contacts LIMIT 1").get().ownerId;
+const del3 = db.transaction(() => { const t0 = process.hrtime.bigint(); const r = db.prepare("DELETE FROM fts2 WHERE fts2 MATCH ?").run("ownerTok:o" + owner.replace(/-/g,"")); console.log(`DELETE FROM fts2 WHERE MATCH 'ownerTok:...' removed ${r.changes} rows in ${(Number(process.hrtime.bigint()-t0)/1e6).toFixed(1)} ms`); throw new Error("rollback"); });
+try { del3(); } catch {}
+// 5. purge simulation with cidTok-style triggers: replace triggers to use MATCH on cidTok, then delete one owner
+db.exec(`
+DROP TRIGGER IF EXISTS contacts_ad; DROP TRIGGER IF EXISTS contacts_au; DROP TRIGGER IF EXISTS contacts_ai; DROP TRIGGER IF EXISTS fts_emails_ai; DROP TRIGGER IF EXISTS fts_emails_ad;
+DROP TABLE contacts_fts; ALTER TABLE fts2 RENAME TO contacts_fts;
+CREATE TRIGGER contacts_ad AFTER DELETE ON contacts BEGIN DELETE FROM contacts_fts WHERE contacts_fts MATCH 'cidTok:c' || replace(old.id,'-',''); END;
+CREATE TRIGGER fts_emails_ad AFTER DELETE ON contact_emails BEGIN
+  DELETE FROM contacts_fts WHERE contacts_fts MATCH 'cidTok:c' || replace(old.contactId,'-','');
+  INSERT INTO contacts_fts(contactId,name,company,role,about,extras,ownerTok,cidTok) SELECT c.id,c.name,c.company,c.role,c.about,COALESCE((SELECT GROUP_CONCAT(email,' ') FROM contact_emails WHERE contactId=c.id),''),'o'||replace(c.ownerId,'-',''),'c'||replace(c.id,'-','') FROM contacts c WHERE c.id=old.contactId AND c.deletedAt IS NULL;
+END;
+CREATE TRIGGER contacts_au AFTER UPDATE ON contacts BEGIN
+  DELETE FROM contacts_fts WHERE contacts_fts MATCH 'cidTok:c' || replace(old.id,'-','');
+  INSERT INTO contacts_fts(contactId,name,company,role,about,extras,ownerTok,cidTok) SELECT new.id,new.name,new.company,new.role,new.about,COALESCE((SELECT GROUP_CONCAT(email,' ') FROM contact_emails WHERE contactId=new.id),''),'o'||replace(new.ownerId,'-',''),'c'||replace(new.id,'-','') WHERE new.deletedAt IS NULL;
+END;`);
+const owners = db.prepare("SELECT DISTINCT ownerId FROM contacts").all().map(r=>r.ownerId);
+s = Date.now(); db.exec(`UPDATE contacts SET ownerId = '${owners[0]}' WHERE ownerId = '${owners[0]}'`); console.log(`UPDATE ownerId on 5000 rows with cidTok triggers: ${Date.now()-s} ms`);
+s = Date.now(); const r = db.prepare("DELETE FROM contacts WHERE ownerId = ?").run(owners[1]); console.log(`purge ${r.changes} contacts (+cascades) with cidTok triggers: ${Date.now()-s} ms`);
+console.log("fts rows:", db.prepare("SELECT COUNT(*) c FROM contacts_fts").get().c, "contacts:", db.prepare("SELECT COUNT(*) c FROM contacts").get().c);
+db.close();

--- a/docs/multi-tenant-plan/bench/review-2026-09-08/06-live-db-inventory.cjs
+++ b/docs/multi-tenant-plan/bench/review-2026-09-08/06-live-db-inventory.cjs
@@ -1,0 +1,18 @@
+const Database = require("better-sqlite3");
+const db = new Database("/Users/arvind/Documents/github/contrack/curator.db", { readonly: true, fileMustExist: true });
+const tables = db.prepare("SELECT name, type, sql FROM sqlite_master WHERE type IN ('table','view') AND name NOT LIKE 'sqlite_%' ORDER BY name").all();
+console.log("TABLES (" + tables.length + "):");
+for (const t of tables) {
+  if (/^(contacts_fts_|search_embeddings_|contact_embeddings_)/.test(t.name)) continue; // shadow tables
+  let cols = "";
+  try { cols = db.prepare(`PRAGMA table_info("${t.name}")`).all().map(c => c.name + (c.notnull ? "!" : "") + (c.pk ? "*" : "")).join(","); } catch {}
+  const fks = (() => { try { return db.prepare(`PRAGMA foreign_key_list("${t.name}")`).all().map(f => `${f.from}->${f.table}.${f.to} del:${f.on_delete}`).join("; "); } catch { return ""; } })();
+  console.log(`  ${t.name}: [${cols}]` + (fks ? `\n      FK: ${fks}` : ""));
+}
+console.log("\nINDEXES:");
+for (const i of db.prepare("SELECT name, tbl_name, sql FROM sqlite_master WHERE type='index' AND sql IS NOT NULL ORDER BY tbl_name, name").all()) console.log("  " + i.name + " ON " + i.sql.replace(/^.*ON\s+/i, ""));
+console.log("\nTRIGGERS:");
+for (const t of db.prepare("SELECT name, tbl_name FROM sqlite_master WHERE type='trigger' ORDER BY tbl_name, name").all()) console.log("  " + t.name + " ON " + t.tbl_name);
+console.log("\nuser_version:", db.pragma("user_version", { simple: true }), " foreign_keys:", db.pragma("foreign_keys", { simple: true }), " journal_mode:", db.pragma("journal_mode", { simple: true }));
+console.log("row counts:", ["users","contacts","lists","interactions","action_items","dedupe_suggestions","dedupe_exclusions","dedupe_merge_log","ai_invocations","app_settings"].map(t => { try { return t + "=" + db.prepare(`SELECT COUNT(*) c FROM ${t}`).get().c } catch { return t + "=?" } }).join(" "));
+try { console.log("app_settings keys:", db.prepare("SELECT key FROM app_settings").all().map(r => r.key).join(", ")); } catch {}

--- a/docs/multi-tenant-plan/bench/review-2026-09-08/README.md
+++ b/docs/multi-tenant-plan/bench/review-2026-09-08/README.md
@@ -1,0 +1,78 @@
+# Review evidence, 2026-09-08
+
+Scripts and measurements produced while reviewing the plan against `v1.5.5`.
+Run each script from the repository root with the project's `node_modules`
+on the path:
+
+```bash
+mkdir -p /tmp/contrack-review
+NODE_PATH=$PWD/node_modules node docs/multi-tenant-plan/bench/review-2026-09-08/<script>.cjs
+```
+
+Machine: Apple Silicon laptop. Node v22.23.2, better-sqlite3 12.11.1 (SQLite
+3.53.2), sqlite-vec v0.1.9, Express 5.2.1, multer 2.2.0.
+
+| Script | What it proves |
+| ------ | -------------- |
+| `01-vec-fts-smoke.cjs` | `TEXT PARTITION KEY` works on 0.1.9. KNN with `ownerId = ?` returns one owner's rows. `DELETE`, `SELECT`, and `COUNT` by partition key work. `UPDATE` of a partition key fails. The 33-character owner token is one FTS5 token. `ownerTok:X AND (...)` wraps all three strategies. `ALTER TABLE ADD COLUMN ... REFERENCES` works with `foreign_keys = ON`. `VACUUM INTO` works. `fs.statfsSync` exists. |
+| `02-sqlite-triggers-tx.cjs` | `VACUUM INTO` fails inside a transaction. A `vec0` drop-and-recreate works inside a transaction. The fill, mismatch, and propagate triggers behave as specified. `ON DELETE RESTRICT` refuses to delete an owner with data. FK cascades fire child-table triggers. Nested `sqlite.transaction` is a savepoint. Porter stemming (not used today) would still match the owner token. |
+| `03-als-multer-sse.cjs` | `AsyncLocalStorage` context survives multer `destination` and `filename`, `await`, `setTimeout`, and `Promise.all`. An `EventEmitter` listener sees the emitter's context, not the subscriber's: an emit from outside any request context yields `null`. |
+| `04-fts-vec-purge-bench.cjs` | The numbers in the table below. 50,000 contacts across 10 owners, two emails each, 384-dim vectors. |
+| `05-fts-delete-cidtok.cjs` | `DELETE FROM contacts_fts WHERE contactId = ?` scans the whole FTS table (`contactId` is `UNINDEXED`). An indexed `cidTok` column with `MATCH` is about 400 times faster. Re-runs the claim and the purge with the fixed triggers. |
+| `06-live-db-inventory.cjs` | Dumps every table, column, foreign key, index, and trigger from the development database. Read-only. |
+
+## Measurements (script 04 and 05)
+
+Seed: 50,000 contacts, 100,000 emails, 10 owners of 5,000 contacts each.
+
+| Measurement | Result |
+| ----------- | ------ |
+| Seed 50,000 contacts + 100,000 emails through today's FTS triggers | 271 s (5.4 ms per contact, see the trigger finding below) |
+| FTS bulk backfill `INSERT ... SELECT` of 50,000 rows | 233 ms |
+| `vec0` copy-rebuild of 50,000 × 384-dim rows into a partitioned table | 923 ms |
+| `UPDATE contacts SET ownerId` on 5,000 rows, today's `contacts_au` trigger | 27.1 s |
+| `UPDATE contacts SET ownerId` on 5,000 rows, triggers using `cidTok` | 230 ms |
+| Purge one owner (5,000 contacts, 10,000 cascaded emails), today's triggers | 77.1 s |
+| Purge one owner, triggers using `cidTok` | 198 ms |
+| `DELETE FROM contacts_fts WHERE contacts_fts MATCH 'ownerTok:...'` (5,000 rows) | 17 ms |
+
+FTS query latency, owner of 5,000 among 50,000, `LIMIT 50`, p50 / p95:
+
+| Query | Indexed `ownerTok AND (...)` | `UNINDEXED` post-filter | `JOIN contacts` | No owner filter (today) |
+| ----- | ---------------------------- | ----------------------- | --------------- | ----------------------- |
+| `"john"` | 1.03 / 1.07 ms | 4.96 / 5.17 ms | 10.70 / 11.44 ms | 3.33 / 3.42 ms |
+| `"john"* OR "smith"*` | 2.69 / 2.77 ms | 9.35 / 9.87 ms | 18.66 / 19.68 ms | 6.78 / 7.05 ms |
+| `design OR studio OR labs` | 2.42 / 2.57 ms | 11.31 / 11.97 ms | 22.18 / 23.31 ms | 8.36 / 8.56 ms |
+
+Vector search, `k = 50`, p50 / p95:
+
+| Query | Result |
+| ----- | ------ |
+| Partitioned KNN, owner has 5,000 of 50,000 | 1.02 / 1.12 ms |
+| Flat KNN over 50,000 (today) | 10.43 / 10.92 ms |
+| Flat KNN `k = 500` then JavaScript filter (today's `preFilterIds` path) | 23.54 / 26.13 ms |
+| Rows of the global top 100 that belong to the queried owner (expected about 10) | 4 |
+
+The last row is the correctness problem the plan describes in the
+architecture document, section 7: a small owner's contacts fall out of the
+global top-k.
+
+## The trigger finding
+
+Every FTS trigger in `server/db.ts` begins with
+`DELETE FROM contacts_fts WHERE contactId = old.id`. The `contactId` column is
+`UNINDEXED`, so FTS5 cannot use its index and SQLite scans every row of the
+virtual table. At 40,000 rows that scan costs about 4 ms, and it runs once per
+contact update and once per child-row insert or delete. The measured
+consequences at 50,000 contacts:
+
+- A contact update costs about 5 ms of FTS work.
+- The ownership claim in the migration costs 5.4 ms per contact.
+- An owner purge costs about 15 ms per contact (one scan for the contact row
+  and one per cascaded child row).
+
+The fix is the same technique the plan already uses for the owner: an indexed
+`cidTok` column holding `'c' || replace(id, '-', '')`, and
+`DELETE FROM contacts_fts WHERE contacts_fts MATCH 'cidTok:' || ...` in every
+trigger. Measured: 0.011 ms per delete instead of 4 ms. The data model document
+section 5 adopts this.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,11 @@ export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    ignores: ["dist/", "node_modules/", "drizzle/"],
+    // docs/multi-tenant-plan/ holds the 2.0 design documents and the
+    // benchmark scripts behind them. The scripts are CommonJS and run under
+    // `node` by hand, not through the app build, so they read as undefined
+    // globals here. They are reference material, not source.
+    ignores: ["dist/", "node_modules/", "drizzle/", "docs/multi-tenant-plan/"],
   },
   // Standalone Node tooling (audit scripts, codegen). These run under `node`
   // directly rather than through the app's TS build, so they need Node globals


### PR DESCRIPTION
This is task 0.0 of Phase 0. It makes CI run for the `v2.0` integration branch and puts the multi-tenant design documents in the repository, so every later 2.0 pull request is tested and every reviewer can follow the references it makes.

This PR contains no application code and no schema change. It is the first of three Phase 0 pull requests.

## How it works

- `.github/workflows/ci.yml` adds `"v2.0"` to `on.push.branches` and to `on.pull_request.branches`.
  - The `if:` conditions on `build-image` and `release` are **unchanged**. They still test `github.ref` against `refs/heads/main` and `refs/tags/v`, so a push to `v2.0` runs the tests and publishes nothing.
- `docs/multi-tenant-plan/` is removed from `.gitignore` and the whole folder is committed, including the six benchmark scripts under `bench/review-2026-09-08/`.

## Operational behavior

Committing the plan folder broke two of the four local gates. Both needed an explicit ignore, and the reasons differ.

- **Prettier reads `.gitignore` by default.** The folder passed `format:check` only because it was ignored by git. Removing that line put 25 files into the check and 25 failed. A new `.prettierignore` skips the folder.
- **ESLint never read `.gitignore`.** The six `bench/` scripts are CommonJS and use `require`, `process`, and `console`, so `npm run lint` already reported 156 errors for anyone who had copied the folder into their tree by hand. CI did not see this, because a fresh clone had no such folder. Committing the folder would have turned it into a real CI failure. `eslint.config.mjs` now lists the folder in `ignores`.

The intent is that the design documents stay exactly as written. **Verified:** 19 markdown files were not Prettier clean before this change and the same 19 are not Prettier clean after it, so nothing in the folder was reformatted.

## Guarantees

- No application code, no schema change, and no dependency change.
- The test count is unchanged at 679.

## Testing

```
npm run lint          exit 0
npm run format:check  exit 0
npm test              exit 0
npm run build         exit 0
```

Raw vitest summary:

```
 Test Files  53 passed (53)
      Tests  679 passed (679)
```

## CI on this pull request

The workflow change verifies itself. GitHub reads the workflow file from the head branch for a `pull_request` event, so the new `v2.0` filter already applied to this PR.

Run [34393610356](https://github.com/arvarik/contrack/actions/runs/34393610356):

```
build-and-test (22.x)   pass       1m15s
build-image             skipping
merge-image             skipping
release                 skipping
```

That is the acceptance evidence for task 0.0. The test job runs for `v2.0`, and the three publishing jobs skip, which confirms the `if:` conditions were left intact.
