### PR TITLE
feat(tenancy): phase 0, pin the positional BM25 weight rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   request makes. Prettier and ESLint skip that folder, so the design
   documents and their benchmark scripts stay exactly as written.
 
+### Added
+
+- **Phase 0.** A unit test pins the BM25 weighting rule. `bm25()` reads its
+  weights by column position and counts `UNINDEXED` columns, so
+  `contacts_fts` needs one weight per column and `contactId` needs a zero.
+  Search ranking does not change, because the offset this guards against was
+  already corrected in 1.5.5. Phase 1 adds two more columns to that table,
+  and this test fails if the weight list is not extended with them.
+
 ## [1.5.5] — 2026-08-09
 
 Corrections from an independent review of the v1.5.4 release, run with fresh

--- a/server/services/search/ftsIndex.ts
+++ b/server/services/search/ftsIndex.ts
@@ -5,7 +5,8 @@ export const ACTIVE_CONTACT_SQL = `c.isGhost = 0 AND COALESCE(c.isArchived, 0) =
   AND c.canonicalId IS NULL AND c.deletedAt IS NULL`;
 
 const VERSION = 2;
-const COLUMNS =
+/** Every contacts_fts column, in order. Position 0 is the UNINDEXED contactId. */
+export const COLUMNS =
   "contactId, name, company, role, headline, location, about, industry, extras, searchExpansion";
 const VALUES = `c.id, c.name, c.company, c.role, c.headline, c.location, c.about, c.industry,
   COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM contact_tags WHERE contactId = c.id), '') || ' ' ||

--- a/server/services/search/lexical.ts
+++ b/server/services/search/lexical.ts
@@ -2,7 +2,8 @@ import { sqlite } from "../../db.ts";
 import { ACTIVE_CONTACT_SQL } from "./ftsIndex.ts";
 
 // The first FTS column is the unindexed contactId. It still consumes a weight.
-const WEIGHTS = "0, 10, 5, 3, 2, 2, 1, 1, 1, 0.5";
+// bm25() reads weights by column position, so one weight per column in COLUMNS.
+export const WEIGHTS = "0, 10, 5, 3, 2, 2, 1, 1, 1, 0.5";
 
 /** Treat user text as literal Unicode tokens, never as FTS operators. */
 export function searchTokens(query: string): string[] {

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -6,7 +6,10 @@
 // =============================================================================
 
 import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
 import { reciprocalRankFusion } from "../../server/services/search/hybridRetrieval.ts";
+import { WEIGHTS } from "../../server/services/search/lexical.ts";
+import { COLUMNS } from "../../server/services/search/ftsIndex.ts";
 
 const RRF_K = 15; // Must match the constant in hybridRetrieval.ts
 
@@ -117,5 +120,54 @@ describe("Reciprocal Rank Fusion (k=15)", () => {
 
     const result = reciprocalRankFusion([fts]);
     expect(result).toHaveLength(50);
+  });
+});
+
+// =============================================================================
+// Unit Tests — BM25 column weights are positional
+// =============================================================================
+// bm25() reads its weights by column position and counts UNINDEXED columns.
+// A list that omits the UNINDEXED column shifts every weight one column to
+// the left, so "name" silently receives the weight meant for contactId. That
+// was the state in v1.5.5. Phase 1 extends this list again when it adds
+// ownerTok and cidTok, so the rule is pinned here rather than in a comment.
+// =============================================================================
+
+describe("BM25 column weights", () => {
+  it("applies weights by column position, including the UNINDEXED column", () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE VIRTUAL TABLE t USING fts5(id UNINDEXED, a, b)");
+    const insert = db.prepare("INSERT INTO t(id, a, b) VALUES (?, ?, ?)");
+    insert.run("in-a", "needle", "filler");
+    insert.run("in-b", "filler", "needle");
+
+    // bm25() returns a negative score, so ascending order is best-first.
+    const best = (weights: string) =>
+      (
+        db
+          .prepare(
+            `SELECT id FROM t WHERE t MATCH 'needle' ORDER BY bm25(t, ${weights})`,
+          )
+          .all() as { id: string }[]
+      )[0].id;
+
+    // Position 0 is the UNINDEXED id, position 1 is a, position 2 is b.
+    expect(best("0.0, 10.0, 1.0")).toBe("in-a");
+    expect(best("0.0, 1.0, 10.0")).toBe("in-b");
+    db.close();
+  });
+
+  it("declares one contacts_fts weight per column, and zero for contactId", () => {
+    const weights = WEIGHTS.split(",").map((w) => Number(w.trim()));
+    const columns = COLUMNS.split(",").map((c) => c.trim());
+
+    expect(weights).toHaveLength(columns.length);
+    expect(weights.every((w) => Number.isFinite(w))).toBe(true);
+    // contactId is UNINDEXED and can never match, so it must not score.
+    expect(columns[0]).toBe("contactId");
+    expect(weights[0]).toBe(0);
+    // name is the most informative column and outranks the rest.
+    expect(columns[1]).toBe("name");
+    expect(Math.max(...weights)).toBe(weights[1]);
   });
 });


### PR DESCRIPTION
This adds the regression test from Phase 0 task 0.10, which pins the rule that BM25 weights are positional and count `UNINDEXED` columns. It changes no search ranking, because the offset that task 0.10 set out to fix is already corrected in the tree.

## What task 0.10 asked for, and what was actually there

Task 0.10 and decision Q13 both describe `BM25_WEIGHTS` in `server/services/search/hybridRetrieval.ts:113` as nine values for a ten-column table, which gives `name` the weight meant for `contactId`. That was true of v1.5.5:

```
const BM25_WEIGHTS = "10.0, 5.0, 3.0, 2.0, 2.0, 1.0, 1.0, 1.0, 1.0";
```

Commit `eb8c220`, `fix(search): harden indexing and retrieval freshness (#18)`, moved lexical search into `server/services/search/lexical.ts` and corrected the string on the way:

```
const WEIGHTS = "0, 10, 5, 3, 2, 2, 1, 1, 1, 0.5";
```

Ten values for ten columns, zero in position 0, and a comment stating the rule. **The weights are therefore unchanged by this PR.**

- The plan's target string differs from the tree in one place. It gives `searchExpansion` 1.0 where the tree gives it 0.5. `searchExpansion` holds AI generated query expansion text, and #18 deliberately ranks it below the real profile fields. Raising it back to 1.0 would be a ranking regression with nothing behind it, so this PR leaves it alone.

## How it works

The durable half of task 0.10 was the test, and that was missing. Two tests are added to `tests/unit/search.test.ts`.

- The first builds a real `fts5(id UNINDEXED, a, b)` table in memory, exactly as the task specifies. It asserts that `0.0, 10.0, 1.0` ranks the row matching in `a` first and `0.0, 1.0, 10.0` ranks the row matching in `b` first, which pins the positional rule and proves the `UNINDEXED` column consumes a weight.
- The second asserts the real constant: one weight per `contacts_fts` column, zero for `contactId`, and `name` weighted highest.
  - `COLUMNS` in `ftsIndex.ts` and `WEIGHTS` in `lexical.ts` are now exported so the invariant can be asserted against the real values rather than a copy. That is the only production change.

## Guarantees

The guard was verified against the v1.5.5 string rather than assumed to work. Substituting it makes the test fail:

```
AssertionError: expected [ 10, 5, 3, 2, 2, 1, 1, 1, 1 ] to have a length of 10 but got 9
```

Phase 1 adds `ownerTok` and `cidTok` to `contacts_fts`. Because the test reads the column list from `COLUMNS`, it fails if that phase extends the table without extending the weights, which is the mistake this guards against.

## Testing

```
npm run lint          exit 0
npm run format:check  exit 0
npm test              exit 0
npm run build         exit 0
```

Raw vitest summary, 679 before and 681 after:

```
 Test Files  53 passed (53)
      Tests  681 passed (681)
```
