### PR TITLE
feat(tenancy): phase 0, scope and request context primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   request makes. Prettier and ESLint skip that folder, so the design
   documents and their benchmark scripts stay exactly as written.
 
+### Fixed
+
+- **Phase 0.** `GET /api/contacts/action-items` works again. `contactsRouter`
+  mounted before `mcpRouter`, so `GET /contacts/:id` captured `action-items`
+  as a contact id and answered `404`. The route was unreachable, so no
+  working client changes behavior. The MCP router now mounts first.
+
 ### Added
 
+- **Phase 0.** The request context, `server/tenancy/scope.ts` and
+  `server/tenancy/requestContext.ts`. A request now carries who is asking
+  through the async call tree, which later phases use to stamp ownership.
+  Nothing reads it on the data path yet, so behavior is unchanged.
 - **Phase 0.** A unit test pins the BM25 weighting rule. `bm25()` reads its
   weights by column position and counts `UNINDEXED` columns, so
   `contacts_fts` needs one weight per column and `contactId` needs a zero.

--- a/server/app.ts
+++ b/server/app.ts
@@ -30,6 +30,7 @@ import { aiSettingsRouter } from "./routes/aiSettings.ts";
 import { avatarRouter } from "./routes/avatar.ts";
 import { errorHandler, notFoundHandler } from "./middleware/errorHandler.ts";
 import { attachPrincipal, requireAuth } from "./middleware/auth.ts";
+import { attachRequestContext } from "./tenancy/requestContext.ts";
 import { authRouter } from "./routes/auth.ts";
 import { healthRouter } from "./routes/health.ts";
 import { reconcileOwnership } from "./services/authService.ts";
@@ -169,6 +170,12 @@ export function createApp(options: CreateAppOptions = {}): express.Express {
   // know even for callers that are nobody.
   app.use(attachPrincipal);
 
+  // Carry who is asking through the async call tree, so an insert can stamp
+  // ownerId without threading a parameter through every signature. Mounted
+  // after attachPrincipal because it reads req.principal. Attribution only:
+  // reads and writes of owned data take an explicit Scope.
+  app.use(attachRequestContext);
+
   // Auth endpoints must stay reachable pre-auth (status, setup, login);
   // everything mounted after requireAuth — uploads and all other /api routes —
   // is gated when AUTH_REQUIRED or API_TOKEN is configured.
@@ -199,9 +206,12 @@ export function createApp(options: CreateAppOptions = {}): express.Express {
   app.use("/api/link-preview", linkPreviewRouter);
   app.use("/api/search", searchRouter);
   app.use("/api/lists", listsRouter);
+  // mcpRouter first: it registers the literal GET /contacts/action-items,
+  // which contactsRouter's GET /contacts/:id would otherwise capture as an
+  // id and answer with a 404. Express matches in mount order.
+  app.use("/api", mcpRouter);
   app.use("/api", contactsRouter);
   app.use("/api", interactionsRouter);
-  app.use("/api", mcpRouter);
   app.use("/api", dedupeRouter);
   app.use("/api", actionItemsRouter);
   app.use("/api", dashboardRouter);

--- a/server/tenancy/requestContext.ts
+++ b/server/tenancy/requestContext.ts
@@ -1,0 +1,63 @@
+// =============================================================================
+// Request context — AsyncLocalStorage for attribution
+// =============================================================================
+// The context carries who is asking so an insert can stamp ownerId without
+// threading a parameter through every signature. It is NOT the isolation
+// mechanism. Reads and writes of owned data take an explicit Scope, because
+// a context can be lost across a library boundary and a lost context must
+// never widen what a query returns.
+//
+// One rule matters most. An EventEmitter listener runs in the async context
+// of whoever calls emit(), not the context that subscribed. Every SSE and
+// NDJSON handler therefore captures its Scope in the closure before it
+// subscribes, and never calls currentScope() inside a listener.
+// =============================================================================
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { Request, Response, NextFunction } from "express";
+import { AppError } from "../utils/AppError.ts";
+import type { Principal } from "../middleware/auth.ts";
+import { scopeForUser, type Scope } from "./scope.ts";
+
+export interface RequestContext {
+  requestId: string;
+  principal: Principal | null;
+  scope: Scope | null;
+}
+
+const als = new AsyncLocalStorage<RequestContext>();
+
+export function runWithContext<T>(ctx: RequestContext, fn: () => T): T {
+  return als.run(ctx, fn);
+}
+
+export function getContext(): RequestContext | null {
+  return als.getStore() ?? null;
+}
+
+/** The current scope, or a programmer error if there is none. */
+export function currentScope(): Scope {
+  const s = getContext()?.scope;
+  if (!s)
+    throw new AppError("No owner scope on this code path", 500, {
+      code: "NO_SCOPE",
+    });
+  return s;
+}
+
+/** The current scope, or null. Used by inserts that may run unowned. */
+export function currentScopeOrNull(): Scope | null {
+  return getContext()?.scope ?? null;
+}
+
+export function attachRequestContext(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  const p = req.principal ?? null;
+  const scope = p?.kind === "user" ? scopeForUser(p.user) : null;
+  runWithContext({ requestId: req.requestId, principal: p, scope }, () =>
+    next(),
+  );
+}

--- a/server/tenancy/scope.ts
+++ b/server/tenancy/scope.ts
@@ -1,0 +1,51 @@
+// =============================================================================
+// Scope — the owner a request or a job acts for
+// =============================================================================
+// Every repository and service function that reads or writes an owned table
+// takes a Scope as its first argument, and puts the owner in the same SQL
+// statement as the id. The request context in requestContext.ts carries a
+// Scope for attribution only. It is never the isolation mechanism.
+//
+// Phase 0 builds these names so Phase 1 and Phase 2 have one place to change.
+// Nothing on the data path calls scopeOf yet.
+// =============================================================================
+
+import type { Request } from "express";
+import { AppError } from "../utils/AppError.ts";
+import type { User } from "../services/authService.ts";
+
+declare const ownerIdBrand: unique symbol;
+
+/** A `users.id`. Branded so a bare string cannot be passed as an owner. */
+export type OwnerId = string & { readonly [ownerIdBrand]: true };
+
+export interface Scope {
+  readonly ownerId: OwnerId;
+}
+
+export function scopeForUser(user: Pick<User, "id">): Scope {
+  return Object.freeze({ ownerId: user.id as OwnerId });
+}
+
+/** Background jobs only. Never called from a route. */
+export function scopeForOwnerId(id: string): Scope {
+  return Object.freeze({ ownerId: id as OwnerId });
+}
+
+export function scopeOf(req: Request): Scope {
+  const p = req.principal;
+  if (p?.kind === "user") return scopeForUser(p.user);
+  // Phase 0: anonymous and service principals have no owner yet. Phase 1
+  // removes both kinds. Until then, callers that need a scope get a 401.
+  throw new AppError("Authentication required", 401, { code: "UNAUTHORIZED" });
+}
+
+/** FTS5 owner token. Must equal  'o' || replace(ownerId, '-', '')  in server/db.ts. */
+export function ownerToken(scope: Scope): string {
+  return "o" + scope.ownerId.replace(/-/g, "");
+}
+
+/** FTS5 contact token. Must equal  'c' || replace(id, '-', '')  in server/db.ts. */
+export function contactToken(contactId: string): string {
+  return "c" + contactId.replace(/-/g, "");
+}

--- a/tests/integration/tenancy.context.upload.test.ts
+++ b/tests/integration/tenancy.context.upload.test.ts
@@ -1,0 +1,96 @@
+// =============================================================================
+// Integration Tests — request context across multer
+// =============================================================================
+// Open question T25: multer issue #1111 reports that the AsyncLocalStorage
+// context is lost in the route handler after upload.single() when the
+// multipart body ALSO carries a text field. The upload routes carry no text
+// fields today, so the plan could not reproduce it and left a fallback.
+//
+// This test settles it on the installed multer, with one text field and one
+// file, and records the answer for Phase 1. If the handler assertion ever
+// fails, the two upload handlers must read the scope from req.principal
+// instead of the context.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import multer from "multer";
+import request from "supertest";
+import http from "http";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  attachRequestContext,
+  getContext,
+} from "../../server/tenancy/requestContext.ts";
+
+const OWNER = "aaaaaaaa-0000-4000-8000-000000000001";
+
+/** Where each multer callback and the handler saw the owner, or null. */
+const seen: Record<string, string | null | undefined> = {};
+let server: http.Server;
+let tmp: string;
+
+beforeAll(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "contrack-ctx-"));
+
+  const storage = multer.diskStorage({
+    destination: (_req, _file, cb) => {
+      seen.destination = getContext()?.scope?.ownerId ?? null;
+      cb(null, tmp);
+    },
+    filename: (_req, _file, cb) => {
+      seen.filename = getContext()?.scope?.ownerId ?? null;
+      cb(null, `probe-${Date.now()}.txt`);
+    },
+  });
+  const upload = multer({ storage, limits: { fileSize: 1024 * 1024 } });
+
+  const app = express();
+  // Stand in for attachPrincipal, then run the real context middleware.
+  app.use((req, _res, next) => {
+    req.requestId = "ctx-test";
+    req.principal = {
+      kind: "user",
+      user: { id: OWNER } as never,
+      sessionId: "s",
+    };
+    next();
+  });
+  app.use(attachRequestContext);
+
+  app.post("/probe", upload.single("file"), (req, res) => {
+    seen.handler = getContext()?.scope?.ownerId ?? null;
+    res.json({
+      field: req.body?.note ?? null,
+      file: req.file?.filename ?? null,
+    });
+  });
+
+  server = app.listen(0);
+});
+
+afterAll(() => {
+  server?.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("request context survives multer", () => {
+  it("is intact in destination, in filename, and in the handler, with a text field present", async () => {
+    const res = await request(server)
+      .post("/probe")
+      .field("note", "one text field, which is the T25 trigger")
+      .attach("file", Buffer.from("hello"), "probe.txt");
+
+    expect(res.status).toBe(200);
+    // The multipart body really did carry both parts.
+    expect(res.body.field).toBe("one text field, which is the T25 trigger");
+    expect(res.body.file).toMatch(/^probe-/);
+
+    expect(seen.destination).toBe(OWNER);
+    expect(seen.filename).toBe(OWNER);
+    // T25: this is the assertion multer issue #1111 predicts might fail.
+    expect(seen.handler).toBe(OWNER);
+  });
+});

--- a/tests/integration/tenancy.routing.test.ts
+++ b/tests/integration/tenancy.routing.test.ts
@@ -1,0 +1,89 @@
+// =============================================================================
+// Integration Tests — router mount order and the request id on a limiter 429
+// =============================================================================
+// Task 0.11. contactsRouter used to mount before mcpRouter, so the literal
+// path GET /api/contacts/action-items was captured by GET /api/contacts/:id,
+// which looked up "action-items" as a contact id and answered 404. The route
+// was dead. mcpRouter now mounts first, and these tests hold that order in
+// place while proving the :id route still works.
+// =============================================================================
+
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import http from "http";
+import { createApp, finalizeApp, notFoundHandler } from "../../server/app.ts";
+import { makeTestApp } from "./helpers.ts";
+
+const app = makeTestApp();
+
+describe("GET /api/contacts/action-items", () => {
+  it("reaches the MCP handler instead of being captured by /contacts/:id", async () => {
+    const res = await request(app).get("/api/contacts/action-items");
+
+    expect(res.status).toBe(200);
+    // The MCP payload is a list of contacts with their open action items.
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it("returns the MCP payload, which is the contacts that are due", async () => {
+    // mcpService.getActionItems() answers "who is due for follow-up", so a
+    // contact with a past nextFollowUpAt must appear. That proves the MCP
+    // handler ran, not merely that some handler returned an array.
+    const created = await request(app)
+      .post("/api/contacts")
+      .send({ name: "Ada Lovelace", nextFollowUpAt: "2020-01-01" });
+    expect(created.status).toBe(201);
+
+    const res = await request(app).get("/api/contacts/action-items");
+    expect(res.status).toBe(200);
+    const mine = (res.body as { id?: string }[]).find(
+      (r) => r.id === created.body.id,
+    );
+    expect(mine).toBeTruthy();
+  });
+});
+
+describe("GET /api/contacts/:id still resolves after the reorder", () => {
+  it("returns the contact for a real id", async () => {
+    const created = await request(app)
+      .post("/api/contacts")
+      .send({ name: "Grace Hopper" });
+    expect(created.status).toBe(201);
+
+    const res = await request(app).get(`/api/contacts/${created.body.id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe("Grace Hopper");
+  });
+
+  it("still 404s for an id that does not exist", async () => {
+    const res = await request(app).get(
+      "/api/contacts/00000000-0000-4000-8000-000000000999",
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("the AI rate limiter", () => {
+  it("carries a requestId on its 429, because req.requestId is assigned first", async () => {
+    // A dedicated app: makeTestApp disables the limiter on purpose.
+    const limited = createApp();
+    limited.use(notFoundHandler);
+    const server = http.createServer(finalizeApp(limited));
+    server.listen(0, "127.0.0.1");
+    server.unref();
+
+    // /api/parse-contact matches AI_COST_PATTERNS and rejects an empty body
+    // quickly, so the window fills without doing any real work. max is 60.
+    let last = await request(server).post("/api/parse-contact").send({});
+    for (let i = 0; i < 61 && last.status !== 429; i++) {
+      last = await request(server).post("/api/parse-contact").send({});
+    }
+
+    expect(last.status).toBe(429);
+    // The envelope nests the trace id under `error`, and the header repeats it.
+    expect(last.body.error.requestId).toMatch(/^[0-9a-f]{8}$/);
+    expect(last.headers["x-request-id"]).toBe(last.body.error.requestId);
+    expect(last.body.error.code).toBe("RATE_LIMITED");
+    server.close();
+  });
+});

--- a/tests/unit/tenancy.requestContext.test.ts
+++ b/tests/unit/tenancy.requestContext.test.ts
@@ -1,0 +1,146 @@
+// =============================================================================
+// Unit Tests — request context (AsyncLocalStorage)
+// =============================================================================
+// These tests pin the two facts Phase 2 depends on.
+//
+// 1. The store survives every async boundary the request path uses, so an
+//    insert deep in a service can still read who is asking.
+// 2. An EventEmitter listener runs in the context of whoever calls emit(),
+//    NOT the context that subscribed. Every SSE and NDJSON handler therefore
+//    captures its Scope in the closure before subscribing. This test is the
+//    reason that rule exists, so it asserts the surprising behavior directly.
+// =============================================================================
+
+import { describe, it, expect } from "vitest";
+import { EventEmitter } from "node:events";
+import {
+  runWithContext,
+  getContext,
+  currentScope,
+  currentScopeOrNull,
+  type RequestContext,
+} from "../../server/tenancy/requestContext.ts";
+import { scopeForOwnerId } from "../../server/tenancy/scope.ts";
+import { AppError } from "../../server/utils/AppError.ts";
+
+const ctx = (id: string): RequestContext => ({
+  requestId: `req-${id}`,
+  principal: null,
+  scope: scopeForOwnerId(id),
+});
+
+const A = "aaaaaaaa-0000-4000-8000-000000000001";
+const B = "bbbbbbbb-0000-4000-8000-000000000002";
+
+describe("request context: async boundaries", () => {
+  it("survives await", async () => {
+    await runWithContext(ctx(A), async () => {
+      await Promise.resolve();
+      expect(currentScope().ownerId).toBe(A);
+    });
+  });
+
+  it("survives setTimeout", async () => {
+    await runWithContext(
+      ctx(A),
+      () =>
+        new Promise<void>((resolve) =>
+          setTimeout(() => {
+            expect(currentScope().ownerId).toBe(A);
+            resolve();
+          }, 1),
+        ),
+    );
+  });
+
+  it("survives setImmediate", async () => {
+    await runWithContext(
+      ctx(A),
+      () =>
+        new Promise<void>((resolve) =>
+          setImmediate(() => {
+            expect(currentScope().ownerId).toBe(A);
+            resolve();
+          }),
+        ),
+    );
+  });
+
+  it("survives Promise.all and keeps each context separate", async () => {
+    const read = async () => {
+      await Promise.resolve();
+      return currentScope().ownerId;
+    };
+    const [a, b] = await Promise.all([
+      runWithContext(ctx(A), () => Promise.all([read(), read()])),
+      runWithContext(ctx(B), () => Promise.all([read(), read()])),
+    ]);
+    expect(a).toEqual([A, A]);
+    expect(b).toEqual([B, B]);
+  });
+
+  it("survives a for await loop", async () => {
+    async function* gen() {
+      yield 1;
+      await Promise.resolve();
+      yield 2;
+    }
+    await runWithContext(ctx(A), async () => {
+      for await (const _ of gen()) {
+        expect(currentScope().ownerId).toBe(A);
+      }
+    });
+  });
+});
+
+describe("request context: the EventEmitter rule", () => {
+  it("gives a listener the emitter's context, not the subscriber's", () => {
+    const bus = new EventEmitter();
+    const seen: (string | null)[] = [];
+
+    // Subscribe inside A.
+    runWithContext(ctx(A), () => {
+      bus.on("tick", () => seen.push(currentScopeOrNull()?.ownerId ?? null));
+    });
+
+    // Emit from inside B. The listener sees B, not A.
+    runWithContext(ctx(B), () => bus.emit("tick"));
+    expect(seen).toEqual([B]);
+
+    // Emit from outside any context. The listener sees nothing at all.
+    bus.emit("tick");
+    expect(seen).toEqual([B, null]);
+  });
+});
+
+describe("request context: no scope", () => {
+  it("currentScope throws NO_SCOPE outside a context", () => {
+    expect(() => currentScope()).toThrow(AppError);
+    try {
+      currentScope();
+    } catch (e) {
+      expect((e as AppError).statusCode).toBe(500);
+      expect((e as AppError).code).toBe("NO_SCOPE");
+    }
+  });
+
+  it("currentScope throws when the context carries a null scope", () => {
+    runWithContext({ requestId: "r", principal: null, scope: null }, () => {
+      expect(() => currentScope()).toThrow(/No owner scope/);
+    });
+  });
+
+  it("currentScopeOrNull returns null instead of throwing", () => {
+    expect(currentScopeOrNull()).toBeNull();
+    runWithContext({ requestId: "r", principal: null, scope: null }, () => {
+      expect(currentScopeOrNull()).toBeNull();
+    });
+  });
+
+  it("getContext returns null outside a context and the context inside", () => {
+    expect(getContext()).toBeNull();
+    runWithContext(ctx(A), () => {
+      expect(getContext()?.requestId).toBe(`req-${A}`);
+    });
+  });
+});

--- a/tests/unit/tenancy.scope.test.ts
+++ b/tests/unit/tenancy.scope.test.ts
@@ -1,0 +1,106 @@
+// =============================================================================
+// Unit Tests — Scope and the FTS5 owner and contact tokens
+// =============================================================================
+// The tokens are generated in two places that must never drift: TypeScript,
+// here, and the SQL that server/db.ts writes into the FTS triggers in Phase 1.
+// Both forms are computed in this test and compared, so a change to either
+// one fails rather than silently splitting a user's search index in half.
+// =============================================================================
+
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import type { Request } from "express";
+import {
+  scopeForUser,
+  scopeForOwnerId,
+  scopeOf,
+  ownerToken,
+  contactToken,
+} from "../../server/tenancy/scope.ts";
+import { AppError } from "../../server/utils/AppError.ts";
+
+const UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("Scope", () => {
+  it("builds a frozen scope from a user and from a bare owner id", () => {
+    const fromUser = scopeForUser({ id: UUID });
+    const fromId = scopeForOwnerId(UUID);
+    expect(fromUser.ownerId).toBe(UUID);
+    expect(fromId.ownerId).toBe(UUID);
+    expect(Object.isFrozen(fromUser)).toBe(true);
+    expect(Object.isFrozen(fromId)).toBe(true);
+  });
+
+  it("derives a scope from a user principal", () => {
+    const req = {
+      principal: { kind: "user", user: { id: UUID }, sessionId: "s" },
+    } as unknown as Request;
+    expect(scopeOf(req).ownerId).toBe(UUID);
+  });
+
+  it.each([
+    ["anonymous", { kind: "anonymous" }],
+    ["service", { kind: "service" }],
+    ["absent", undefined],
+  ])("throws 401 for a %s principal", (_label, principal) => {
+    const req = { principal } as unknown as Request;
+    expect(() => scopeOf(req)).toThrow(AppError);
+    try {
+      scopeOf(req);
+    } catch (e) {
+      expect((e as AppError).statusCode).toBe(401);
+      expect((e as AppError).code).toBe("UNAUTHORIZED");
+    }
+  });
+});
+
+describe("FTS5 tokens", () => {
+  it("matches the SQL expression server/db.ts uses", () => {
+    const db = new Database(":memory:");
+    const sqlOwner = db
+      .prepare("SELECT 'o' || replace(?, '-', '') AS t")
+      .get(UUID) as { t: string };
+    const sqlContact = db
+      .prepare("SELECT 'c' || replace(?, '-', '') AS t")
+      .get(UUID) as { t: string };
+
+    expect(ownerToken(scopeForOwnerId(UUID))).toBe(sqlOwner.t);
+    expect(contactToken(UUID)).toBe(sqlContact.t);
+    db.close();
+  });
+
+  it("is a single FTS5 term, so an owner filter cannot be split", () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE VIRTUAL TABLE tok USING fts5(t)");
+    db.exec("CREATE VIRTUAL TABLE tok_v USING fts5vocab(tok, 'row')");
+    const token = ownerToken(scopeForOwnerId(UUID));
+    db.prepare("INSERT INTO tok(t) VALUES (?)").run(token);
+
+    const hit = db
+      .prepare("SELECT count(*) AS n FROM tok WHERE tok MATCH ?")
+      .get(`t:${token}`) as { n: number };
+    expect(hit.n).toBe(1);
+
+    // One row in, one distinct term out. A hyphen would make it several.
+    const terms = db.prepare("SELECT count(*) AS n FROM tok_v").get() as {
+      n: number;
+    };
+    expect(terms.n).toBe(1);
+
+    // A different owner's token must not match.
+    const other = ownerToken(
+      scopeForOwnerId("00000000-0000-4000-8000-000000000001"),
+    );
+    const miss = db
+      .prepare("SELECT count(*) AS n FROM tok WHERE tok MATCH ?")
+      .get(`t:${other}`) as { n: number };
+    expect(miss.n).toBe(0);
+    db.close();
+  });
+
+  it("strips every hyphen", () => {
+    expect(ownerToken(scopeForOwnerId(UUID))).not.toContain("-");
+    expect(contactToken(UUID)).not.toContain("-");
+    expect(ownerToken(scopeForOwnerId(UUID))).toHaveLength(33);
+  });
+});


### PR DESCRIPTION
This adds the two tenancy primitives that every later phase builds on, mounts the request context in the pipeline, and fixes the router mount order that made one route unreachable. It changes no behavior for a single-account instance.

Phase 0 task 0.1, task 0.2 and task 0.11. The remaining Phase 0 tasks follow in the next pull requests, because the whole phase in one diff is well past the size Block B.4 asks us to split at.

## What the API sees

- **`GET /api/contacts/action-items` works again.** `contactsRouter` mounted before `mcpRouter`, so `GET /contacts/:id` matched first and looked up `action-items` as a contact id, answering `404`. The route was dead, so no working client changes behavior.
  - Reverting the order makes the new test fail with `expected 404 to be 200`, so this is pinned rather than asserted.
  - `GET /api/contacts/:id` still resolves, and still `404`s for an id that does not exist. Both are covered.

Nothing else changes. No schema change, no `WHERE ownerId` on any read, no change to the `Principal` union.

## How it works

- `server/tenancy/scope.ts` defines `Scope`, the branded `OwnerId`, `scopeForUser`, `scopeForOwnerId`, `scopeOf`, `ownerToken` and `contactToken`.
  - The two token helpers are compared against the SQL that `server/db.ts` will use in Phase 1, `'o' || replace(id, '-', '')`, computed by SQLite inside the same test. A drift between the two forms would split an owner's search index in half, so both forms are computed rather than trusted.
  - `fts5vocab` confirms the 33 character token is stored as exactly one term.
- `server/tenancy/requestContext.ts` carries who is asking through the async call tree with `AsyncLocalStorage`, mounted directly after `attachPrincipal`.
  - **This is attribution only, and never the isolation mechanism.** Reads and writes of owned data take an explicit `Scope`, because a context lost across a library boundary must never widen what a query returns.

## Operational behavior

Two things the phase document expected to be work were already true in the tree, so this PR pins them instead of changing them.

- **`req.requestId` is already the first middleware**, well above the AI limiter. Task 0.2 asked for it to be moved. Risk T19 records it at `:145`, below the limiter at `:142`, which is no longer where it sits. A limiter `429` therefore already carries a trace id, and a test now holds that.

## Guarantees

- **Open question T25 is resolved.** Multer issue #1111 predicted the context would be lost in the handler after `upload.single()` when the body also carries a text field. On the installed multer 2.2.0 it is not. The context is intact in `destination`, in `filename`, and in the handler, with one text field and one file in the same request. **Phase 1 does not need the `req.principal` fallback the plan reserved.**
- The EventEmitter rule is asserted directly, because it is surprising and Phase 2 depends on it. A listener that subscribes inside context A and is emitted from context B sees **B**, and an emit from outside any context gives the listener **nothing**. This is why every SSE handler in Phase 2 must capture its scope in the closure.
- The context is proven to survive `await`, `setTimeout`, `setImmediate`, `Promise.all` with two interleaved owners, and a `for await` loop.
- `currentScope()` throws `NO_SCOPE` with status 500 outside a context, and `currentScopeOrNull()` returns null instead.

## Testing

```
npm run lint          exit 0
npm run format:check  exit 0
npm test              exit 0
npm run build         exit 0
```

Raw vitest summary, 681 before and 705 after:

```
 Test Files  57 passed (57)
      Tests  705 passed (705)
```

New files: `tests/unit/tenancy.scope.test.ts`, `tests/unit/tenancy.requestContext.test.ts`, `tests/integration/tenancy.context.upload.test.ts`, `tests/integration/tenancy.routing.test.ts`.
