### PR TITLE
feat(tenancy): phase 0, route manifest and tenant lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Phase 0.** A route manifest at `server/tenancy/routeManifest.ts` names
+  every route and what guards it. A test compares it against the routes the
+  app really registers, so a new route cannot ship unclassified. The route
+  list is recorded while the app builds, because Express 5 keeps no mount
+  path strings.
+- **Phase 0.** `scripts/tenant-lint.mjs` reports SQL over owned tables that
+  carries no owner predicate. `npm run lint` runs it in report mode, so it
+  cannot fail a build yet. The Phase 0 baseline is 240 statements across 35
+  files, committed under `bench/` so later phases can watch it reach zero.
 - **Phase 0.** The request context, `server/tenancy/scope.ts` and
   `server/tenancy/requestContext.ts`. A request now carries who is asking
   through the async call tree, which later phases use to stamp ownership.

--- a/docs/multi-tenant-plan/bench/tenant-lint-baseline.txt
+++ b/docs/multi-tenant-plan/bench/tenant-lint-baseline.txt
@@ -1,0 +1,43 @@
+tenant-lint report (Phase 0 baseline)
+
+  statements over owned tables with no owner predicate: 240
+  allow comments with an unknown reason:                0
+  files affected:                                       35
+
+| count | file |
+| ----- | ---- |
+|    31 | server/services/contactService.ts |
+|    24 | server/services/dedupe/suggestions.ts |
+|    20 | server/services/interactionService.ts |
+|    16 | server/services/dedupe/merging.ts |
+|    16 | server/services/listService.ts |
+|    15 | server/services/dashboardService.ts |
+|    14 | server/services/actionItemService.ts |
+|     9 | server/db.ts |
+|     9 | server/services/search/localEmbeddings.ts |
+|     8 | server/routes/contacts.ts |
+|     8 | server/services/dedupe/embeddings.ts |
+|     7 | server/services/dedupe/engine.ts |
+|     7 | server/services/relationshipService.ts |
+|     6 | server/services/aiStatsService.ts |
+|     6 | server/services/exportService.ts |
+|     5 | server/services/mcpService.ts |
+|     5 | server/services/search/ftsIndex.ts |
+|     5 | server/services/zeroStateService.ts |
+|     4 | server/repositories/contactRepository.ts |
+|     3 | server/services/geocoding/queue.ts |
+|     2 | server/routes/search.ts |
+|     2 | server/services/aiSearch/mergeEngine.ts |
+|     2 | server/services/dedupe/blocking.ts |
+|     2 | server/services/dedupe/context.ts |
+|     2 | server/services/dedupe/normalization.ts |
+|     2 | server/services/search/hybridRetrieval.ts |
+|     2 | server/services/searchService.ts |
+|     1 | server/routes/dedupe/embeddings.ts |
+|     1 | server/services/aiSearch/contactSnapshot.ts |
+|     1 | server/services/contactGuard.ts |
+|     1 | server/services/dedupe/clustering.ts |
+|     1 | server/services/dedupe/passes.ts |
+|     1 | server/services/geocoding/index.ts |
+|     1 | server/services/search/indexQueue.ts |
+|     1 | server/services/search/lexical.ts |

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "clean": "rm -rf dist",
-    "lint": "eslint . && tsc --noEmit",
+    "lint": "eslint . && tsc --noEmit && node scripts/tenant-lint.mjs --report",
     "lint:js": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/scripts/tenant-lint.mjs
+++ b/scripts/tenant-lint.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+// =============================================================================
+// tenant-lint — find SQL over owned tables that carries no owner predicate
+// =============================================================================
+// Multi-tenancy fails quietly. A SELECT that forgets `AND ownerId = ?` returns
+// another person's contacts and looks perfectly healthy in every test that
+// only ever creates one user. This scanner reads server/**/*.ts, finds every
+// statement that touches an owned table, and flags the ones with no owner in
+// them.
+//
+// A statement that legitimately carries no owner predicate is annotated on the
+// line above:
+//
+//   // tenant-lint: allow instance sweep
+//   sqlite.prepare("DELETE FROM ai_invocations WHERE createdAt < ?")
+//
+// Two modes:
+//   --report          print a table, exit 0. Phase 0 runs this in npm run lint.
+//   --strict <glob>   exit 1 on any flag in a matching file. Phase 2 moves
+//                     files under --strict as it converts them, and ends with
+//                     --strict "server/**".
+// =============================================================================
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** Tables with an ownerId column, or that hold owned rows. */
+export const OWNED_TABLES = [
+  "contacts",
+  "lists",
+  "interactions",
+  "action_items",
+  "dedupe_suggestions",
+  "dedupe_exclusions",
+  "dedupe_merge_log",
+  "ai_invocations",
+];
+
+/** Virtual tables partitioned by owner. FTS uses a token, not a column. */
+export const VIRTUAL_TABLES = [
+  "contacts_fts",
+  "search_embeddings",
+  "contact_embeddings",
+];
+
+/** Drizzle schema objects that map to owned tables. */
+export const OWNED_SCHEMA_KEYS = [
+  "contacts",
+  "lists",
+  "interactions",
+  "actionItems",
+];
+
+/** The only reasons an allow comment may give. */
+export const ALLOWED_REASONS = [
+  "instance sweep",
+  "owner-checked by caller",
+  "boot migration",
+  "admin cross-user",
+  "derived table",
+];
+
+const ALL_TABLES = [...OWNED_TABLES, ...VIRTUAL_TABLES];
+const TABLE_RE = new RegExp(
+  `\\b(?:FROM|JOIN|UPDATE|INTO)\\s+(${ALL_TABLES.join("|")})\\b`,
+  "i",
+);
+const DRIZZLE_RE = new RegExp(
+  `\\b(?:from|insert|update|delete)\\s*\\(\\s*(?:schema\\.)?(${OWNED_SCHEMA_KEYS.join("|")})\\b`,
+);
+
+/**
+ * Pull every string and template literal out of a source file, with the line
+ * it starts on. Comments are skipped so a SQL example in a comment is not
+ * mistaken for a statement.
+ */
+function extractLiterals(source) {
+  const out = [];
+  let i = 0;
+  let line = 1;
+  const n = source.length;
+
+  while (i < n) {
+    const c = source[i];
+    const next = source[i + 1];
+
+    if (c === "\n") {
+      line++;
+      i++;
+      continue;
+    }
+    // Line comment.
+    if (c === "/" && next === "/") {
+      while (i < n && source[i] !== "\n") i++;
+      continue;
+    }
+    // Block comment.
+    if (c === "/" && next === "*") {
+      i += 2;
+      while (i < n && !(source[i] === "*" && source[i + 1] === "/")) {
+        if (source[i] === "\n") line++;
+        i++;
+      }
+      i += 2;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      const quote = c;
+      const startLine = line;
+      let value = "";
+      i++;
+      while (i < n) {
+        const ch = source[i];
+        if (ch === "\\") {
+          value += ch + (source[i + 1] ?? "");
+          if (source[i + 1] === "\n") line++;
+          i += 2;
+          continue;
+        }
+        if (ch === quote) {
+          i++;
+          break;
+        }
+        if (ch === "\n") line++;
+        value += ch;
+        i++;
+      }
+      out.push({ value, line: startLine });
+      continue;
+    }
+    i++;
+  }
+  return out;
+}
+
+/** Read the `// tenant-lint: allow <reason>` annotation above a line, if any. */
+function allowAbove(lines, lineNumber) {
+  for (let i = lineNumber - 2; i >= 0 && i >= lineNumber - 3; i--) {
+    const text = (lines[i] ?? "").trim();
+    const m = text.match(/^\/\/\s*tenant-lint:\s*allow\s+(.+?)\s*$/);
+    if (m) return m[1];
+    if (text !== "" && !text.startsWith("//")) break;
+  }
+  return null;
+}
+
+/**
+ * Scan one file's source. Returns a finding per statement that touches an
+ * owned table without an owner predicate, and per invalid allow comment.
+ */
+export function scanSource(source, file = "<memory>") {
+  const findings = [];
+  const lines = source.split("\n");
+
+  const consider = (text, line, kind) => {
+    const hasOwner = /ownerId|ownerTok/.test(text);
+    const reason = allowAbove(lines, line);
+
+    if (reason !== null && !ALLOWED_REASONS.includes(reason)) {
+      findings.push({
+        file,
+        line,
+        kind,
+        severity: "unknown-reason",
+        reason,
+        text: text.trim().slice(0, 120).replace(/\s+/g, " "),
+      });
+      return;
+    }
+    if (hasOwner || reason !== null) return;
+    findings.push({
+      file,
+      line,
+      kind,
+      severity: "unscoped",
+      reason: null,
+      text: text.trim().slice(0, 120).replace(/\s+/g, " "),
+    });
+  };
+
+  for (const lit of extractLiterals(source)) {
+    const m = lit.value.match(TABLE_RE);
+    if (m) consider(lit.value, lit.line, `sql:${m[1].toLowerCase()}`);
+  }
+
+  lines.forEach((text, idx) => {
+    const m = text.match(DRIZZLE_RE);
+    if (!m) return;
+    // Look at the whole chained statement, which may span several lines.
+    let stmt = text;
+    for (let j = idx + 1; j < lines.length && !stmt.includes(";"); j++) {
+      stmt += "\n" + lines[j];
+    }
+    consider(stmt, idx + 1, `drizzle:${m[1]}`);
+  });
+
+  return findings;
+}
+
+function walk(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, acc);
+    else if (entry.name.endsWith(".ts")) acc.push(full);
+  }
+  return acc;
+}
+
+export function scanProject(root = "server") {
+  const findings = [];
+  for (const file of walk(root)) {
+    findings.push(...scanSource(fs.readFileSync(file, "utf8"), file));
+  }
+  return findings;
+}
+
+/** Turn a shell-style glob into a RegExp. Supports ** and *. */
+export function globToRegExp(glob) {
+  // ** crosses path separators, * does not. Both are handled in one pass so
+  // no placeholder character is needed.
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*|\*/g, (m) => (m === "**" ? ".*" : "[^/]*"));
+  return new RegExp(`^${escaped}$`);
+}
+
+function main(argv) {
+  const strictIndex = argv.indexOf("--strict");
+  const strict = strictIndex !== -1;
+  const glob = strict ? argv[strictIndex + 1] : null;
+  const findings = scanProject("server");
+
+  const unscoped = findings.filter((f) => f.severity === "unscoped");
+  const badReason = findings.filter((f) => f.severity === "unknown-reason");
+
+  if (strict) {
+    if (!glob) {
+      console.error(
+        "tenant-lint: --strict needs a glob, e.g. --strict 'server/**'",
+      );
+      process.exit(2);
+    }
+    const re = globToRegExp(glob);
+    const inScope = findings.filter((f) => re.test(f.file));
+    for (const f of inScope) {
+      console.error(`${f.file}:${f.line}  ${f.severity}  ${f.kind}  ${f.text}`);
+    }
+    if (inScope.length) {
+      console.error(
+        `\ntenant-lint: ${inScope.length} problem(s) in files matching ${glob}`,
+      );
+      process.exit(1);
+    }
+    console.log(`tenant-lint: clean for ${glob}`);
+    return;
+  }
+
+  // Report mode. Never fails the build in Phase 0.
+  const byFile = new Map();
+  for (const f of findings) {
+    byFile.set(f.file, (byFile.get(f.file) ?? 0) + 1);
+  }
+  const rows = [...byFile.entries()].sort(
+    (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+  );
+
+  console.log("tenant-lint report (Phase 0 baseline)");
+  console.log("");
+  console.log(
+    `  statements over owned tables with no owner predicate: ${unscoped.length}`,
+  );
+  console.log(
+    `  allow comments with an unknown reason:                ${badReason.length}`,
+  );
+  console.log(
+    `  files affected:                                       ${rows.length}`,
+  );
+  console.log("");
+  console.log("| count | file |");
+  console.log("| ----- | ---- |");
+  for (const [file, count] of rows) {
+    console.log(`| ${String(count).padStart(5)} | ${file} |`);
+  }
+  if (badReason.length) {
+    console.log("");
+    console.log("Unknown allow reasons:");
+    for (const f of badReason) {
+      console.log(`  ${f.file}:${f.line}  "${f.reason}"`);
+    }
+  }
+}
+
+// Run only when invoked as a CLI, so the unit test can import the scanner.
+if (
+  process.argv[1] &&
+  import.meta.url.endsWith(path.basename(process.argv[1]))
+) {
+  main(process.argv.slice(2));
+}

--- a/server.ts
+++ b/server.ts
@@ -91,16 +91,6 @@ async function startServer() {
 
   const app = createApp({ enableRequestLogging: true });
 
-  // ── Cache diagnostics (dev only) ─────────────────────────────────────────
-  // Exposes hit/miss counters and entry counts for all aiCache tiers.
-  // Useful for debugging: curl http://localhost:3210/api/debug/cache-stats
-  if (process.env.NODE_ENV !== "production") {
-    const { aiCache } = await import("./server/utils/aiCache.ts");
-    app.get("/api/debug/cache-stats", (_req, res) => {
-      res.json(aiCache.getStats());
-    });
-  }
-
   // 404 catch-all for unknown /api/* paths — runs immediately after the
   // API routers so we don't fall through to Vite or the SPA index.html.
   // Non-/api/* paths are passed through to Vite/static below.

--- a/server/app.ts
+++ b/server/app.ts
@@ -31,6 +31,7 @@ import { avatarRouter } from "./routes/avatar.ts";
 import { errorHandler, notFoundHandler } from "./middleware/errorHandler.ts";
 import { attachPrincipal, requireAuth } from "./middleware/auth.ts";
 import { attachRequestContext } from "./tenancy/requestContext.ts";
+import { aiCache } from "./utils/aiCache.ts";
 import { authRouter } from "./routes/auth.ts";
 import { healthRouter } from "./routes/health.ts";
 import { reconcileOwnership } from "./services/authService.ts";
@@ -221,6 +222,19 @@ export function createApp(options: CreateAppOptions = {}): express.Express {
   app.use("/api/ai/stats", aiStatsRouter);
   app.use("/api/ai", aiRouter);
   app.use("/api/logos", logosRouter);
+
+  // ── Cache diagnostics (dev only) ─────────────────────────────────────────
+  // Exposes hit/miss counters and entry counts for all aiCache tiers.
+  // Useful for debugging: curl http://localhost:3210/api/debug/cache-stats
+  //
+  // Registered here rather than in server.ts so the route manifest test can
+  // see it. A supertest app calls createApp() and never runs server.ts, so a
+  // route registered there is invisible to the manifest. Same NODE_ENV guard.
+  if (process.env.NODE_ENV !== "production") {
+    app.get("/api/debug/cache-stats", (_req, res) => {
+      res.json(aiCache.getStats());
+    });
+  }
 
   return app;
 }

--- a/server/tenancy/routeManifest.ts
+++ b/server/tenancy/routeManifest.ts
@@ -1,0 +1,611 @@
+// =============================================================================
+// Route manifest — every route this app registers, and what guards it
+// =============================================================================
+// The manifest is the checklist Phase 2 works through. Every route is
+// classified, and tenancy.routeManifest.test.ts fails if a route is added,
+// removed, or renamed without updating this file. A new route cannot reach
+// production unclassified, which is the point.
+//
+// `isolated` starts false for every route and flips as Phase 2 converts each
+// one and its isolation test goes green. The manifest test does not assert
+// `isolated` yet. Phase 2 adds that assertion when the last route flips.
+//
+// Seeded from docs/multi-tenant-plan/appendix-b-route-manifest.md.
+// =============================================================================
+
+export type RouteClass =
+  /** No credential needed: /healthz, /api/auth/status, /api/auth/login. */
+  | "public"
+  /** Acts on the caller's own account: /api/auth/me, /api/auth/tokens. */
+  | "session-self"
+  /** Reads or writes owned data for the caller's scope. */
+  | "scoped"
+  /** requireAdmin. */
+  | "admin"
+  /** Any authenticated caller, no owned data: /api/avatar/:style. */
+  | "instance-read"
+  /** The /uploads express.static layer. Guarded by middleware, not a route. */
+  | "static";
+
+export interface RouteEntry {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "USE";
+  /** Full path as a client sends it, including the mount prefix. */
+  path: string;
+  class: RouteClass;
+  /** Phase 2 flips this when the isolation test for the route is green. */
+  isolated: boolean;
+  /** Only registered when NODE_ENV !== "production". */
+  devOnly?: boolean;
+}
+
+export const ROUTE_MANIFEST: readonly RouteEntry[] = [
+  {
+    method: "GET",
+    path: "/api/action-items",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "DELETE",
+    path: "/api/action-items/:id",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "PATCH",
+    path: "/api/action-items/:id",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "PATCH",
+    path: "/api/action-items/:id/complete",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/action-items/completed",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/action-items/count",
+    class: "scoped",
+    isolated: false,
+  },
+  { method: "POST", path: "/api/ai-search", class: "scoped", isolated: false },
+  {
+    method: "POST",
+    path: "/api/ai-search/:batchId/cancel",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/ai-search/status",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/ai-search/stream",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/ai/diagnostics",
+    class: "admin",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/ai/grounding-capacity",
+    class: "admin",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/ai/stats/feed",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/ai/stats/summary",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/auth/change-password",
+    class: "session-self",
+    isolated: false,
+  },
+  { method: "POST", path: "/api/auth/login", class: "public", isolated: false },
+  {
+    method: "POST",
+    path: "/api/auth/logout",
+    class: "public",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/auth/me",
+    class: "session-self",
+    isolated: false,
+  },
+  {
+    method: "PATCH",
+    path: "/api/auth/me",
+    class: "session-self",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/auth/session-policy",
+    class: "session-self",
+    isolated: false,
+  },
+  {
+    method: "PUT",
+    path: "/api/auth/session-policy",
+    class: "admin",
+    isolated: false,
+  },
+  {
+    method: "DELETE",
+    path: "/api/auth/sessions",
+    class: "session-self",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/auth/sessions",
+    class: "session-self",
+    isolated: false,
+  },
+  { method: "POST", path: "/api/auth/setup", class: "public", isolated: false },
+  { method: "GET", path: "/api/auth/status", class: "public", isolated: false },
+  {
+    method: "GET",
+    path: "/api/avatar/:style",
+    class: "instance-read",
+    isolated: false,
+  },
+  { method: "GET", path: "/api/backups", class: "admin", isolated: false },
+  { method: "POST", path: "/api/backups", class: "admin", isolated: false },
+  {
+    method: "GET",
+    path: "/api/command-palette/zero-state",
+    class: "scoped",
+    isolated: false,
+  },
+  { method: "GET", path: "/api/contacts", class: "scoped", isolated: false },
+  { method: "POST", path: "/api/contacts", class: "scoped", isolated: false },
+  {
+    method: "DELETE",
+    path: "/api/contacts/:id",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/contacts/:id",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "PATCH",
+    path: "/api/contacts/:id",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "PUT",
+    path: "/api/contacts/:id",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/contacts/:id/action-items",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/contacts/:id/action-items",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/contacts/:id/attachments",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/contacts/:id/avatar",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/contacts/:id/briefing",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/contacts/:id/enrich",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/contacts/:id/interactions",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/contacts/:id/promote",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/contacts/:id/relationships",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/contacts/:id/score",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/contacts/:id/timeline",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/contacts/action-items",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/contacts/archived",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/contacts/bulk",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/contacts/bulk-delete",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "PUT",
+    path: "/api/contacts/bulk-update",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/contacts/map",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/contacts/merge",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/contacts/merge-batch",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/contacts/merge-cluster",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/contacts/merge-clusters",
+    class: "scoped",
+    isolated: false,
+  },
+  { method: "GET", path: "/api/dashboard", class: "scoped", isolated: false },
+  {
+    method: "GET",
+    path: "/api/dashboard/insight",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/debug/cache-stats",
+    class: "admin",
+    isolated: false,
+    devOnly: true,
+  },
+  {
+    method: "GET",
+    path: "/api/dedupe/active",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/dedupe/backfill-embeddings",
+    class: "admin",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/dedupe/embedding-status",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/dedupe/merge-log",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/dedupe/merge-log/:id/undo",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/dedupe/scan",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/dedupe/status",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/dedupe/stream",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/dedupe/suggestion-for/:contactId",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/dedupe/suggestions",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/dedupe/suggestions/:id/dismiss",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/dedupe/suggestions/:id/merge",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/dedupe/suggestions/count",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/dev/seed-duplicates",
+    class: "scoped",
+    isolated: false,
+    devOnly: true,
+  },
+  { method: "GET", path: "/api/export/csv", class: "scoped", isolated: false },
+  { method: "GET", path: "/api/export/json", class: "scoped", isolated: false },
+  { method: "GET", path: "/api/industries", class: "scoped", isolated: false },
+  {
+    method: "DELETE",
+    path: "/api/interactions/:id",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "PATCH",
+    path: "/api/interactions/:id",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/interactions/search",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/link-preview/unfurl",
+    class: "instance-read",
+    isolated: false,
+  },
+  { method: "GET", path: "/api/lists", class: "scoped", isolated: false },
+  { method: "POST", path: "/api/lists", class: "scoped", isolated: false },
+  {
+    method: "DELETE",
+    path: "/api/lists/:id",
+    class: "scoped",
+    isolated: false,
+  },
+  { method: "PATCH", path: "/api/lists/:id", class: "scoped", isolated: false },
+  {
+    method: "GET",
+    path: "/api/lists/:id/contacts",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/lists/:id/members",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "DELETE",
+    path: "/api/lists/:id/members/:contactId",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/lists/:id/members/bulk",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "PUT",
+    path: "/api/lists/reorder",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/logos/:domain",
+    class: "instance-read",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/parse-contact",
+    class: "instance-read",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/query/contacts",
+    class: "scoped",
+    isolated: false,
+  },
+  { method: "GET", path: "/api/search", class: "scoped", isolated: false },
+  {
+    method: "POST",
+    path: "/api/search/semantic",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/search/synthesize",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/settings/ai",
+    class: "instance-read",
+    isolated: false,
+  },
+  {
+    method: "PUT",
+    path: "/api/settings/ai/capabilities/:capability",
+    class: "admin",
+    isolated: false,
+  },
+  {
+    method: "PUT",
+    path: "/api/settings/ai/endpoints",
+    class: "admin",
+    isolated: false,
+  },
+  {
+    method: "DELETE",
+    path: "/api/settings/ai/endpoints/:id",
+    class: "admin",
+    isolated: false,
+  },
+  {
+    method: "GET",
+    path: "/api/settings/ai/models/:capability",
+    class: "instance-read",
+    isolated: false,
+  },
+  {
+    method: "DELETE",
+    path: "/api/settings/ai/providers/:id/key",
+    class: "admin",
+    isolated: false,
+  },
+  {
+    method: "PUT",
+    path: "/api/settings/ai/providers/:id/key",
+    class: "admin",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/settings/ai/providers/:id/refresh-models",
+    class: "admin",
+    isolated: false,
+  },
+  {
+    method: "PUT",
+    path: "/api/settings/ai/searxng",
+    class: "admin",
+    isolated: false,
+  },
+  { method: "GET", path: "/api/tags", class: "scoped", isolated: false },
+  { method: "GET", path: "/api/timeline", class: "scoped", isolated: false },
+  { method: "GET", path: "/api/trash", class: "scoped", isolated: false },
+  {
+    method: "DELETE",
+    path: "/api/trash/:id",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/trash/:id/restore",
+    class: "scoped",
+    isolated: false,
+  },
+  {
+    method: "POST",
+    path: "/api/trash/bulk-restore",
+    class: "scoped",
+    isolated: false,
+  },
+  { method: "GET", path: "/healthz", class: "public", isolated: false },
+  { method: "USE", path: "/uploads", class: "static", isolated: false },
+];

--- a/tests/integration/tenancy.isolation.test.ts
+++ b/tests/integration/tenancy.isolation.test.ts
@@ -1,0 +1,41 @@
+// =============================================================================
+// Integration Tests — the isolation matrix (skeleton)
+// =============================================================================
+// One row per scoped route, each starting as `it.todo`. Phase 2 replaces a
+// todo with a real two-user test as it converts each domain, so the diff of
+// every Phase 2 PR shows the matrix filling in and the reviewer can see what
+// is still unproven.
+//
+// The rows are generated from ROUTE_MANIFEST rather than written out, so a
+// new scoped route arrives here as a new todo automatically and cannot be
+// forgotten.
+//
+// Phase 0 adds no assertions. Nothing is scoped yet, and a test that passed
+// today would only prove that one user exists.
+// =============================================================================
+
+import { describe, it } from "vitest";
+import { ROUTE_MANIFEST } from "../../server/tenancy/routeManifest.ts";
+
+const scoped = ROUTE_MANIFEST.filter((r) => r.class === "scoped");
+
+/**
+ * Endpoints that return a collection. These need a second assertion beyond
+ * "B cannot read A's row by id": the list itself must not leak A's rows into
+ * B's response, which is the failure mode a per-id check cannot catch.
+ */
+const collections = scoped.filter(
+  (r) => r.method === "GET" && !r.path.includes("/:"),
+);
+
+describe("route isolation: user B cannot reach user A's data", () => {
+  for (const route of scoped) {
+    it.todo(`${route.method} ${route.path}: user B cannot reach user A's data`);
+  }
+});
+
+describe("list endpoints exclude other owners", () => {
+  for (const route of collections) {
+    it.todo(`${route.method} ${route.path}: returns only the caller's rows`);
+  }
+});

--- a/tests/integration/tenancy.routeManifest.test.ts
+++ b/tests/integration/tenancy.routeManifest.test.ts
@@ -1,0 +1,103 @@
+// =============================================================================
+// Integration Tests — the route manifest matches the app
+// =============================================================================
+// A route that reaches production unclassified is a route nobody decided the
+// tenancy rules for. This test makes that impossible: adding, removing, or
+// renaming a route fails here until server/tenancy/routeManifest.ts is
+// updated to say what the route is.
+//
+// The route list comes from the recorder in ./tenancy/listRoutes.ts, not from
+// a naive stack walk. Express 5 keeps no mount path strings, so a stack walk
+// alone yields "/reorder" rather than "/api/lists/reorder".
+// =============================================================================
+
+import { describe, it, expect } from "vitest";
+import { createApp } from "../../server/app.ts";
+import { listRoutes } from "./tenancy/listRoutes.ts";
+import {
+  ROUTE_MANIFEST,
+  type RouteEntry,
+} from "../../server/tenancy/routeManifest.ts";
+
+const registered = listRoutes(() => createApp({ disableRateLimit: true }));
+const key = (r: { method: string; path: string }) => `${r.method} ${r.path}`;
+
+const isProduction = process.env.NODE_ENV === "production";
+const expected = ROUTE_MANIFEST.filter((r) => !r.devOnly || !isProduction);
+
+describe("route manifest", () => {
+  it("classifies every registered route exactly once", () => {
+    const counts = new Map<string, number>();
+    for (const entry of ROUTE_MANIFEST) {
+      counts.set(key(entry), (counts.get(key(entry)) ?? 0) + 1);
+    }
+    const duplicated = [...counts.entries()].filter(([, n]) => n > 1);
+    expect(duplicated).toEqual([]);
+
+    const unclassified = registered
+      .map(key)
+      .filter((k) => !counts.has(k))
+      .sort();
+    expect(unclassified).toEqual([]);
+  });
+
+  it("has no stale rows for routes that no longer exist", () => {
+    const live = new Set(registered.map(key));
+    const stale = expected
+      .map(key)
+      .filter((k) => !live.has(k))
+      .sort();
+    expect(stale).toEqual([]);
+  });
+
+  it("records the /uploads static layer as exactly one static row", () => {
+    const staticRows = ROUTE_MANIFEST.filter((r) => r.class === "static");
+    expect(staticRows).toHaveLength(1);
+    expect(staticRows[0]).toMatchObject({
+      method: "USE",
+      path: "/uploads",
+      class: "static",
+    });
+    // The recorder must actually see the express.static layer.
+    expect(registered.map(key)).toContain("USE /uploads");
+  });
+
+  it("includes the dev-only routes, which are registered outside production", () => {
+    const devOnly = ROUTE_MANIFEST.filter((r) => r.devOnly)
+      .map(key)
+      .sort();
+    expect(devOnly).toEqual([
+      "GET /api/debug/cache-stats",
+      "POST /api/dev/seed-duplicates",
+    ]);
+    // GET /api/debug/cache-stats moved into createApp() so it is visible here.
+    if (!isProduction) {
+      expect(registered.map(key)).toContain("GET /api/debug/cache-stats");
+    }
+  });
+
+  it("gives every row a known class and starts every route un-isolated", () => {
+    const classes = new Set([
+      "public",
+      "session-self",
+      "scoped",
+      "admin",
+      "instance-read",
+      "static",
+    ]);
+    for (const entry of ROUTE_MANIFEST as RouteEntry[]) {
+      expect(classes.has(entry.class)).toBe(true);
+      expect(entry.path.startsWith("/")).toBe(true);
+    }
+    // Phase 2 flips these one domain at a time. None are converted yet.
+    expect(ROUTE_MANIFEST.every((r) => r.isolated === false)).toBe(true);
+  });
+
+  it("still classifies the route the mount-order fix made reachable", () => {
+    const entry = ROUTE_MANIFEST.find(
+      (r) => key(r) === "GET /api/contacts/action-items",
+    );
+    expect(entry?.class).toBe("scoped");
+    expect(registered.map(key)).toContain("GET /api/contacts/action-items");
+  });
+});

--- a/tests/integration/tenancy/listRoutes.ts
+++ b/tests/integration/tenancy/listRoutes.ts
@@ -1,0 +1,138 @@
+// =============================================================================
+// Route recorder
+// =============================================================================
+// Express 5 does not keep mount path strings. `app.router` is a lazy getter,
+// layers carry no `regexp`, and `layer.path` is only set after a successful
+// `layer.match(url)`. Walking the stack alone therefore yields leaf paths with
+// no prefix: `/reorder` instead of `/api/lists/reorder`.
+//
+// So the mount paths are recorded as they happen. `Router.prototype.use` and
+// `application.use` are wrapped while `createApp()` runs, each string mount
+// path is stored against the handle it mounted, and the stack walk then joins
+// prefix to route path.
+//
+// Shape pinned against express@5.2.1 and router@2.2.0. The fields read here
+// are `layer.route`, `route.path`, `route.methods`, `layer.name` and
+// `layer.handle`, which are the stable ones.
+// =============================================================================
+
+import express from "express";
+
+export interface RegisteredRoute {
+  method: string;
+  path: string;
+  handlers: string[];
+}
+
+type Layer = {
+  name?: string;
+  route?: { path?: string; methods?: Record<string, boolean>; stack?: Layer[] };
+  handle?: unknown;
+};
+
+/** Join a mount prefix and a route path into the path a client sends. */
+function joinPath(prefix: string, path: string): string {
+  const joined = `${prefix}${path}`.replace(/\/{2,}/g, "/");
+  if (joined.length > 1 && joined.endsWith("/")) return joined.slice(0, -1);
+  return joined === "" ? "/" : joined;
+}
+
+/**
+ * Build the app with `use` wrapped, then walk the router stack and return
+ * every registered route with its full path.
+ */
+export function listRoutes(build: () => express.Express): RegisteredRoute[] {
+  const mounts = new Map<unknown, string[]>();
+
+  const record = (args: unknown[]): void => {
+    const [first, ...rest] = args;
+    const paths =
+      typeof first === "string"
+        ? [first]
+        : Array.isArray(first) && first.every((p) => typeof p === "string")
+          ? (first as string[])
+          : null;
+    if (!paths) return;
+    for (const handle of rest) {
+      const existing = mounts.get(handle) ?? [];
+      mounts.set(handle, [...existing, ...paths]);
+    }
+  };
+
+  const routerProto = express.Router.prototype as unknown as {
+    use: (...args: unknown[]) => unknown;
+  };
+  // `express.application` is the prototype every app is created from.
+  const appProto = (
+    express as unknown as { application: { use: (...a: unknown[]) => unknown } }
+  ).application;
+
+  const originalRouterUse = routerProto.use;
+  const originalAppUse = appProto.use;
+
+  let app: express.Express;
+  try {
+    routerProto.use = function patched(...args: unknown[]) {
+      record(args);
+      return originalRouterUse.apply(this, args);
+    };
+    appProto.use = function patched(...args: unknown[]) {
+      record(args);
+      return originalAppUse.apply(this, args);
+    };
+    app = build();
+  } finally {
+    routerProto.use = originalRouterUse;
+    appProto.use = originalAppUse;
+  }
+
+  const found: RegisteredRoute[] = [];
+  const seen = new Set<string>();
+
+  const push = (method: string, path: string, handlers: string[]): void => {
+    const key = `${method} ${path}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    found.push({ method, path, handlers });
+  };
+
+  const walk = (stack: Layer[], prefix: string): void => {
+    for (const layer of stack) {
+      if (layer.route) {
+        const routePath = layer.route.path ?? "";
+        const methods = Object.keys(layer.route.methods ?? {});
+        const handlers = (layer.route.stack ?? []).map(
+          (l) => (l.handle as { name?: string })?.name || "anonymous",
+        );
+        for (const m of methods) {
+          push(m.toUpperCase(), joinPath(prefix, routePath), handlers);
+        }
+        continue;
+      }
+
+      // The express.static layer is middleware, not a route.
+      if (layer.name === "serveStatic") {
+        for (const p of mounts.get(layer.handle) ?? ["/"]) {
+          push("USE", joinPath("", p), ["serveStatic"]);
+        }
+        continue;
+      }
+
+      // A mounted router. Recurse once per path it was mounted at.
+      const nested = (layer.handle as { stack?: Layer[] })?.stack;
+      if (layer.name === "router" && Array.isArray(nested)) {
+        const paths = mounts.get(layer.handle) ?? [""];
+        for (const p of paths) {
+          walk(nested, joinPath(prefix, p === "/" ? "" : p));
+        }
+      }
+    }
+  };
+
+  walk((app.router as unknown as { stack: Layer[] }).stack, "");
+  return found.sort((a, b) =>
+    a.path === b.path
+      ? a.method.localeCompare(b.method)
+      : a.path.localeCompare(b.path),
+  );
+}

--- a/tests/unit/tenantLint.test.ts
+++ b/tests/unit/tenantLint.test.ts
@@ -1,0 +1,133 @@
+// =============================================================================
+// Unit Tests — tenant-lint scanner
+// =============================================================================
+// The scanner is what stops an unscoped query reaching production in Phase 2,
+// so its own rules are pinned here. A scanner that silently stops flagging is
+// worse than no scanner, because the report keeps printing a reassuring zero.
+// =============================================================================
+
+import { describe, it, expect } from "vitest";
+import {
+  scanSource,
+  globToRegExp,
+  ALLOWED_REASONS,
+} from "../../scripts/tenant-lint.mjs";
+
+const findings = (src: string) => scanSource(src, "test.ts");
+
+describe("tenant-lint: flagging", () => {
+  it("flags a SELECT over an owned table with no owner predicate", () => {
+    const out = findings(`const q = "SELECT * FROM contacts WHERE id = ?";`);
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe("unscoped");
+    expect(out[0].kind).toBe("sql:contacts");
+  });
+
+  it.each([
+    ["UPDATE", `"UPDATE lists SET name = ?"`],
+    ["DELETE FROM", `"DELETE FROM interactions WHERE id = ?"`],
+    ["INSERT INTO", `"INSERT INTO action_items (id) VALUES (?)"`],
+    ["JOIN", `"SELECT * FROM x JOIN dedupe_suggestions s ON s.id = x.id"`],
+  ])("flags a bare %s", (_label, literal) => {
+    expect(findings(`const q = ${literal};`)).toHaveLength(1);
+  });
+
+  it("flags a virtual table the same way", () => {
+    const out = findings(`const q = "SELECT * FROM search_embeddings";`);
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe("sql:search_embeddings");
+  });
+
+  it("flags a Drizzle builder chain on an owned table", () => {
+    const out = findings(`const rows = db.select().from(schema.contacts);`);
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe("drizzle:contacts");
+  });
+
+  it("reports the line the statement starts on", () => {
+    const out = findings(
+      ["// header", "", `const q = "SELECT * FROM contacts";`].join("\n"),
+    );
+    expect(out[0].line).toBe(3);
+  });
+});
+
+describe("tenant-lint: passing", () => {
+  it("accepts a statement that carries ownerId", () => {
+    const src = `const q = "SELECT * FROM contacts WHERE id = ? AND ownerId = ?";`;
+    expect(findings(src)).toEqual([]);
+  });
+
+  it("accepts an FTS statement that carries ownerTok", () => {
+    const src = `const q = "SELECT * FROM contacts_fts WHERE contacts_fts MATCH 'ownerTok:' || ?";`;
+    expect(findings(src)).toEqual([]);
+  });
+
+  it("ignores a table that is not owned", () => {
+    expect(findings(`const q = "SELECT * FROM users WHERE id = ?";`)).toEqual(
+      [],
+    );
+    expect(findings(`const q = "SELECT * FROM sessions";`)).toEqual([]);
+  });
+
+  it("ignores SQL that only appears in a comment", () => {
+    const src = [
+      `// SELECT * FROM contacts`,
+      `/* DELETE FROM lists */`,
+      `const x = 1;`,
+    ].join("\n");
+    expect(findings(src)).toEqual([]);
+  });
+});
+
+describe("tenant-lint: allow comments", () => {
+  it.each(ALLOWED_REASONS as string[])("honors the reason %s", (reason) => {
+    const src = [
+      `// tenant-lint: allow ${reason}`,
+      `const q = "SELECT * FROM contacts";`,
+    ].join("\n");
+    expect(findings(src)).toEqual([]);
+  });
+
+  it("rejects an allow comment with an unknown reason", () => {
+    const src = [
+      `// tenant-lint: allow because I said so`,
+      `const q = "SELECT * FROM contacts";`,
+    ].join("\n");
+    const out = findings(src);
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe("unknown-reason");
+    expect(out[0].reason).toBe("because I said so");
+  });
+
+  it("does not let an allow comment leak onto a later statement", () => {
+    const src = [
+      `// tenant-lint: allow instance sweep`,
+      `const a = "DELETE FROM ai_invocations WHERE createdAt < ?";`,
+      `const b = "SELECT * FROM contacts";`,
+      `const c = "SELECT * FROM lists";`,
+    ].join("\n");
+    const out = findings(src);
+    expect(out.map((f) => f.kind)).toEqual(["sql:contacts", "sql:lists"]);
+  });
+});
+
+describe("tenant-lint: glob matching for --strict", () => {
+  it("matches a directory tree with **", () => {
+    const re = globToRegExp("server/**");
+    expect(re.test("server/services/contactService.ts")).toBe(true);
+    expect(re.test("scripts/seed.ts")).toBe(false);
+  });
+
+  it("matches a single file", () => {
+    const re = globToRegExp("server/services/listService.ts");
+    expect(re.test("server/services/listService.ts")).toBe(true);
+    expect(re.test("server/services/contactService.ts")).toBe(false);
+  });
+
+  it("does not let * cross a path separator", () => {
+    const re = globToRegExp("server/*.ts");
+    expect(re.test("server/db.ts")).toBe(true);
+    expect(re.test("server/services/listService.ts")).toBe(false);
+  });
+});


### PR DESCRIPTION
This adds the two safety nets Phase 2 works against: a manifest that classifies every route, and a linter that finds SQL over owned tables with no owner predicate. Neither changes runtime behavior.

Phase 0 tasks 0.3, 0.4 and 0.7.

## What the API sees

Nothing changes, with one move. `GET /api/debug/cache-stats` was registered in `server.ts`, outside `createApp()`. It now lives inside `createApp()` behind the same `NODE_ENV !== "production"` guard.

- A supertest app calls `createApp()` and never runs `server.ts`, so a route registered there is invisible to the manifest test. The route keeps its path, its guard and its behavior.

## How it works

- **`server/tenancy/routeManifest.ts`** classifies all 112 routes: 80 `scoped`, 14 `admin`, 6 `session-self`, 6 `instance-read`, 5 `public`, and the one `/uploads` static layer.
  - The test compares the manifest against the app **in both directions**, so a new route cannot ship unclassified and a deleted route cannot leave a stale row behind.
  - `isolated` is `false` on every row. Phase 2 flips them, and the test does not assert that field yet.
- **`tests/integration/tenancy/listRoutes.ts`** records the routes. Express 5 keeps no mount path strings, `app.router` is a lazy getter, and `layer.path` is only set after a successful `layer.match()`.
  - It wraps `Router.prototype.use` and `application.use` while `createApp()` runs, stores each mount path against the handle it mounted, then joins prefixes to route paths. **A naive stack walk yields `/reorder`, not `/api/lists/reorder`.** The originals are restored in a `finally`.
- **`scripts/tenant-lint.mjs`** finds SQL over the eight owned tables and three vec or FTS tables, plus Drizzle builder chains, and flags any statement with no `ownerId` or `ownerTok` in it. A statement that legitimately has no owner predicate carries `// tenant-lint: allow <reason>` above it, and only the five documented reasons are accepted.

## Operational behavior

- `npm run lint` now ends with `tenant-lint --report`. **Report mode always exits 0**, so this cannot fail a build during Phase 0. Phase 2 moves files under `--strict` as it converts them, and ends with `--strict "server/**"`.
- The baseline is committed to `bench/tenant-lint-baseline.txt`: **240 unscoped statements across 35 files**, which matches the "roughly 240" the current-state document estimated. The three largest are `contactService.ts` at 31, `dedupe/suggestions.ts` at 24, and `interactionService.ts` at 20.

## Guarantees

- The manifest was reconciled against the running app rather than transcribed from the appendix. That reconciliation found one gap: **`POST /api/ai-search/:batchId/cancel` exists in the code but is missing from appendix B.** It is classified `scoped` here, and the appendix needs the row added.
- The linter's own rules are pinned by 22 unit tests: it flags each statement form, honors each of the five allow reasons, rejects an unknown reason, does not let an allow comment leak onto the next statement, ignores unowned tables, and ignores SQL that only appears in a comment.
- The isolation matrix is generated from the manifest, not written out, so a new scoped route arrives as a new todo automatically. It is 111 todos: 80 scoped routes plus 31 collection endpoints.

## Testing

```
npm run lint          exit 0
npm run format:check  exit 0
npm test              exit 0
npm run build         exit 0
```

Raw vitest summary, 705 before and 733 after, plus the new todo skeleton:

```
 Test Files  59 passed | 1 skipped (60)
      Tests  733 passed | 111 todo (844)
```
