### PR TITLE
feat(tenancy): phase 0, ownership stamping, harness, and baseline

### DIFF
--- a/.agent/ARCHITECTURE.md
+++ b/.agent/ARCHITECTURE.md
@@ -354,6 +354,7 @@ _No free tier. Prepaid billing required (~$5 starter credits for new accounts). 
 - **Exception**: `server/services/dedupe/embeddings.ts` imports `@google/genai` directly for embedding generation — this is Gemini-only and does not go through the provider adapter.
 - **Local-First Mandate**: External relational database usage is forbidden. All data lives in `curator.db`.
 - **Thin Routes / Heavy Services**: Express routes parse payloads and delegate. Business logic lives in `server/services/`.
+- **MUST** take a `Scope` as the first argument in every function that reads or writes an owned table, and put the user-supplied id and the owner in the SAME SQL statement (`WHERE id = ? AND ownerId = ?`). Never select by id and compare in JavaScript. See `server/tenancy/scope.ts`. The request context in `server/tenancy/requestContext.ts` is for attribution only and is never the isolation mechanism.
 
 ## 8. Error Handling
 

--- a/.agent/TESTING.md
+++ b/.agent/TESTING.md
@@ -25,12 +25,16 @@ _This file tracks test methods, scenarios, and results with concrete execution e
 - **Globals**: `true` (describe/it/expect available without imports)
 - **Coverage**: V8 provider with `text`, `json`, `html` reporters (see `vitest.config.ts`)
 
-### Two vitest projects (vitest.config.ts)
+### Three vitest projects (vitest.config.ts)
 
 | Project       | Include                | Database                                                                                  | Setup file                   |
 | ------------- | ---------------------- | ----------------------------------------------------------------------------------------- | ---------------------------- |
 | `unit`        | `tests/unit/**`        | **Mocked** — `tests/setup.ts` stubs `server/db.ts`                                        | `tests/setup.ts`             |
 | `integration` | `tests/integration/**` | **Real SQLite** in a per-file temp `DATA_DIR` (migrations, FTS triggers, indexes all run) | `tests/integration-setup.ts` |
+| `contract`    | `tests/contract/**`    | Real provider APIs. NOT part of `npm test`; run with `npm run test:contract`              | none                         |
+
+`npm test` runs `unit` and `integration` only, so a clone with no credentials
+passes. Each provider block in `contract` skips itself when its key is absent.
 
 Integration tests mount the production request pipeline via `createApp()`
 (`server/app.ts`) with supertest — no port, no Vite. `tests/integration-setup.ts`
@@ -45,6 +49,24 @@ create/rename/child-table triggers, bulk create/delete, interactions +
 @mention linking (`interaction_mentions`), action items + the
 `nextFollowUpAt` triggers, lists + membership, hard-merge (409 undo
 contract) and soft-merge → audit log → undo, dashboard/zero-state/MCP.
+
+### Tenancy tests (2.0, Phase 0)
+
+| File                                               | Asserts                                                                                                                                                                                                                         |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tests/unit/tenancy.scope.test.ts`                 | The FTS owner and contact tokens equal SQLite's `'o' \|\| replace(id, '-', '')`, and a token is one FTS5 term. `scopeOf` throws 401 for a non-user principal.                                                                   |
+| `tests/unit/tenancy.requestContext.test.ts`        | The context survives `await`, `setTimeout`, `setImmediate`, `Promise.all` and `for await`. An EventEmitter listener sees the **emitter's** context, not the subscriber's. `currentScope()` throws `NO_SCOPE` outside a context. |
+| `tests/unit/tenantLint.test.ts`                    | The scanner flags an unscoped statement, honors each allow reason, rejects an unknown reason, and ignores unowned tables.                                                                                                       |
+| `tests/unit/search.test.ts`                        | BM25 weights are positional and count `UNINDEXED` columns.                                                                                                                                                                      |
+| `tests/integration/tenancy.routeManifest.test.ts`  | Every registered route is classified, with no stale rows and the `/uploads` static layer present.                                                                                                                               |
+| `tests/integration/tenancy.stamping.test.ts`       | Contacts, bulk imports, lists, mention ghosts, AI invocations and merge-log rows all carry the signed-in user's id.                                                                                                             |
+| `tests/integration/tenancy.context.upload.test.ts` | The context survives multer, including a body with one text field plus one file.                                                                                                                                                |
+| `tests/integration/tenancy.routing.test.ts`        | `GET /api/contacts/action-items` is reachable, `/contacts/:id` still resolves, and a limiter 429 carries a `requestId`.                                                                                                         |
+| `tests/integration/tenancy.isolation.test.ts`      | Skeleton only. One `it.todo` per scoped route, filled in during Phase 2.                                                                                                                                                        |
+
+`tests/integration/tenancy/helpers.ts` builds two real users with real
+sessions. `tests/integration/tenancy/listRoutes.ts` records mount paths while
+`createApp()` runs, because Express 5 keeps no mount path strings.
 
 ### Test Setup Mock Pattern (`tests/setup.ts`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Phase 0.** New rows carry their owner. On an instance with
+  `AUTH_REQUIRED=true`, a contact, a bulk import, a list, a ghost contact from
+  an `@mention`, an AI invocation and a merge log row are all stamped with the
+  signed-in user's id as they are written. This starts working without a
+  restart. Anonymous instances still write no owner and are unaffected.
+- **Phase 0.** A benchmark script, `scripts/bench-tenancy.ts`, and the Phase 0
+  baseline under `bench/baseline-phase-0.md`. Phase 5 re-runs it to show that
+  scoping every query did not cost performance.
 - **Phase 0.** A route manifest at `server/tenancy/routeManifest.ts` names
   every route and what guards it. A test compares it against the routes the
   app really registers, so a new route cannot ship unclassified. The route

--- a/docs/multi-tenant-plan/05-phase-0-foundations.md
+++ b/docs/multi-tenant-plan/05-phase-0-foundations.md
@@ -451,18 +451,18 @@ line, marked as a ranking change).
 
 ## 4. Acceptance criteria
 
-- [ ] CI runs on pull requests into `v2.0` (task 0.0 merged first).
-- [ ] `npm run lint` passes. `tenant-lint --report` prints the baseline count and exits 0.
-- [ ] `npm test` passes. All 575 existing tests unchanged, plus the new files.
-- [ ] `tenancy.routeManifest.test.ts` passes: every route classified, including `/api/debug/cache-stats` and the `devOnly` rows.
-- [ ] `tenancy.isolation.test.ts` exists with one `it.todo` per scoped route.
-- [ ] Stamping test green for contacts, lists, interactions (ghost), merge log, AI invocations.
-- [ ] Context tests green, including the emitter rule and the multipart-with-text-field case (or the fallback recorded in the PR).
-- [ ] `bench-tenancy` runs and `bench/baseline-phase-0.md` is committed.
-- [ ] `GET /api/contacts/action-items` returns the MCP payload.
-- [ ] A limiter `429` carries a `requestId`.
-- [ ] A single-account instance upgraded from 1.5.5 shows no behavior change. Verified by running the full existing integration suite and by a manual smoke on a copy of a real database.
-- [ ] PR description carries the raw vitest summary line and the lint output.
+- [x] CI runs on pull requests into `v2.0` (task 0.0 merged first). PR #24, then verified on #25, #26 and #27.
+- [x] `npm run lint` passes. `tenant-lint --report` prints the baseline count and exits 0. Baseline is 240 statements across 35 files.
+- [x] `npm test` passes. All existing tests unchanged, plus the new files. **The 575 in this line was stale: the real baseline on `v2.0` was 679 tests in 53 files.** After Phase 0 it is 740 passing plus 111 todo.
+- [x] `tenancy.routeManifest.test.ts` passes: every route classified, including `/api/debug/cache-stats` and the `devOnly` rows. 112 routes.
+- [x] `tenancy.isolation.test.ts` exists with one `it.todo` per scoped route. 111 todos: 80 scoped routes plus 31 collection endpoints.
+- [x] Stamping test green for contacts, lists, interactions (ghost), merge log, AI invocations. Bulk import covered too.
+- [x] Context tests green, including the emitter rule and the multipart-with-text-field case. **T25 did not reproduce on multer 2.2.0: the context is intact in the handler, so the `req.principal` fallback is not needed.**
+- [x] `bench-tenancy` runs and `bench/baseline-phase-0.md` is committed. Both the 1 x 5000 and the 10 x 2000 runs.
+- [x] `GET /api/contacts/action-items` returns the MCP payload. Reverting the mount order makes the test fail with `expected 404 to be 200`.
+- [x] A limiter `429` carries a `requestId`. It already did: `req.requestId` was already assigned above the limiter, contrary to T19.
+- [~] A single-account instance upgraded from 1.5.5 shows no behavior change. The full existing suite passes unchanged. **The manual smoke on a copy of a real database is not done and is left for the operator.**
+- [x] PR description carries the raw vitest summary line and the lint output.
 
 ---
 

--- a/docs/multi-tenant-plan/bench/baseline-phase-0.md
+++ b/docs/multi-tenant-plan/bench/baseline-phase-0.md
@@ -1,0 +1,92 @@
+# Phase 0 benchmark baseline
+
+Measured on `v2.0` before any query is scoped. Phase 5 re-runs the same
+script and compares. The 10 owner run is the interesting one: nothing is
+scoped yet, so all 20,000 contacts are returned to each of the ten owners.
+
+Reproduce with:
+
+```
+npx tsx scripts/bench-tenancy.ts
+OWNERS=10 CONTACTS_PER_OWNER=2000 npx tsx scripts/bench-tenancy.ts
+```
+
+---
+
+# Tenancy benchmark: 1 owner(s) x 5000 contacts
+
+- Machine: Apple M5 Pro, 18 cores, 52 GB
+- Platform: darwin 25.6.0 (arm64)
+- Node: v22.23.2
+- SQLite: 3.53.2
+- sqlite-vec: v0.1.9
+- Contacts in the database: 5000
+- Interactions per contact: 3
+- Seed time: 7.4s
+- Measured as one signed-in owner, 50 iterations unless noted.
+
+| Endpoint | p50 ms | p95 ms | n | Note |
+| -------- | -----: | -----: | -: | ---- |
+| `GET /api/contacts?view=slim` | 51.8 | 59.5 | 50 |  |
+| `GET /api/contacts/:id` | 0.4 | 2.9 | 50 |  |
+| `GET /api/search?q=` | 1.5 | 2.5 | 50 |  |
+| `POST /api/search/semantic` | 4.2 | 9.7 | 50 | mock AI, so this is FTS plus vector |
+| `GET /api/dashboard` | 13.9 | 16.7 | 50 |  |
+| `GET /api/command-palette/zero-state` | 1.0 | 3.9 | 50 |  |
+| `GET /api/contacts/:id/timeline` | 0.4 | 0.5 | 50 |  |
+| `GET /api/action-items` | 0.3 | 0.4 | 50 |  |
+| `PATCH /api/contacts/:id` | 0.6 | 1.7 | 20 | one FTS trigger delete plus reinsert per update |
+| `POST /api/dedupe/scan` | 3507.0 | 3538.0 | 3 | wall time, mock AI |
+
+---
+
+# Tenancy benchmark: 10 owner(s) x 2000 contacts
+
+- Machine: Apple M5 Pro, 18 cores, 52 GB
+- Platform: darwin 25.6.0 (arm64)
+- Node: v22.23.2
+- SQLite: 3.53.2
+- sqlite-vec: v0.1.9
+- Contacts in the database: 20000
+- Interactions per contact: 3
+- Seed time: 31.0s
+- Measured as one signed-in owner, 50 iterations unless noted.
+
+| Endpoint | p50 ms | p95 ms | n | Note |
+| -------- | -----: | -----: | -: | ---- |
+| `GET /api/contacts?view=slim` | 242.7 | 272.8 | 50 |  |
+| `GET /api/contacts/:id` | 0.5 | 2.1 | 50 |  |
+| `GET /api/search?q=` | 3.2 | 5.9 | 50 |  |
+| `POST /api/search/semantic` | 9.2 | 16.0 | 50 | mock AI, so this is FTS plus vector |
+| `GET /api/dashboard` | 67.0 | 75.1 | 50 |  |
+| `GET /api/command-palette/zero-state` | 3.2 | 5.3 | 50 |  |
+| `GET /api/contacts/:id/timeline` | 0.4 | 0.5 | 50 |  |
+| `GET /api/action-items` | 0.4 | 3.4 | 50 |  |
+| `PATCH /api/contacts/:id` | 0.8 | 4.0 | 20 | one FTS trigger delete plus reinsert per update |
+| `POST /api/dedupe/scan` | 70995.7 | 76342.1 | 3 | wall time, mock AI |
+
+---
+
+## What this shows
+
+The two runs hold total work roughly constant, so the difference is what
+tenancy costs today.
+
+- **The list endpoints carry every owner's rows.** `GET /api/contacts?view=slim`
+  goes from 51.8 ms to 242.7 ms, because the ten-owner instance returns all
+  20,000 contacts to each of the ten people. `GET /api/dashboard` does the same,
+  13.9 ms to 67.0 ms. Phase 2 should make both **faster** than the single-owner
+  numbers, because each owner then reads a tenth of the rows.
+- **Keyed lookups are already flat.** `GET /api/contacts/:id` and
+  `GET /api/contacts/:id/timeline` sit at 0.4 ms in both runs. Adding
+  `AND ownerId = ?` to an indexed lookup should not move them, and Phase 5
+  can check that here.
+- **The dedupe scan is the outlier: 3.5 s to 71.0 s.** Four times the contacts
+  costs twenty times the wall clock, so the blocking stage is superlinear. This
+  is a single-owner scan reading every owner's contacts. Phase 2e scoping the
+  scan is a correctness fix that should also remove most of this.
+- **The `PATCH` cost is smaller than the plan expected.** The phase document
+  predicted several milliseconds from the FTS trigger scan. It measures 0.6 ms
+  at 5,000 contacts and 0.8 ms at 20,000. The `contacts_fts` delete scan that
+  T10 measured at 4 ms was taken at 40,000 rows, so the cost is real but does
+  not bite at this size.

--- a/scripts/bench-tenancy.ts
+++ b/scripts/bench-tenancy.ts
@@ -1,0 +1,340 @@
+// =============================================================================
+// bench-tenancy — the before picture
+// =============================================================================
+// Phase 5 has to show that scoping every query did not make the app slower.
+// That claim needs a number from before the work started, measured the same
+// way, so this script is written in Phase 0 and run again at the end.
+//
+// The 10-owner run is the one that matters. Nothing is scoped yet, so every
+// list endpoint hands all 20,000 contacts to each of the ten owners. Phase 2
+// should make those endpoints faster, not slower, because each owner then
+// reads a tenth of the rows.
+//
+//   npx tsx scripts/bench-tenancy.ts                 # 1 owner, 5000 contacts
+//   OWNERS=10 CONTACTS_PER_OWNER=2000 npx tsx scripts/bench-tenancy.ts
+//   OWNERS=25 CONTACTS_PER_OWNER=2000 npx tsx scripts/bench-tenancy.ts
+// =============================================================================
+
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import os from "node:os";
+
+const OWNERS = Number(process.env.OWNERS ?? 1);
+const CONTACTS_PER_OWNER = Number(process.env.CONTACTS_PER_OWNER ?? 5000);
+const INTERACTIONS_PER_CONTACT = Number(
+  process.env.INTERACTIONS_PER_CONTACT ?? 3,
+);
+const ITERATIONS = Number(process.env.ITERATIONS ?? 50);
+
+// Must be set before any server module is imported.
+process.env.DATA_DIR = mkdtempSync(path.join(tmpdir(), "contrack-bench-"));
+process.env.DISABLE_BACKGROUND_JOBS = "true";
+process.env.AI_PROVIDER = "gemini";
+process.env.GEMINI_API_KEY = "";
+process.env.OPENAI_API_KEY = "";
+process.env.ANTHROPIC_API_KEY = "";
+process.env.MAPBOX_API_KEY = "";
+process.env.AUTH_REQUIRED = "true";
+process.env.NODE_ENV = "test";
+
+const http = await import("node:http");
+const request = (await import("supertest")).default;
+const { createApp, finalizeApp } = await import("../server/app.ts");
+const { sqlite } = await import("../server/db.ts");
+const authService = await import("../server/services/authService.ts");
+const { contactService } = await import("../server/services/contactService.ts");
+const { interactionService } =
+  await import("../server/services/interactionService.ts");
+const { runWithContext } = await import("../server/tenancy/requestContext.ts");
+const { scopeForOwnerId } = await import("../server/tenancy/scope.ts");
+
+const FIRST = [
+  "Ada",
+  "Grace",
+  "Alan",
+  "Katherine",
+  "Linus",
+  "Barbara",
+  "Dennis",
+  "Radia",
+  "Ken",
+  "Margaret",
+  "Guido",
+  "Anita",
+  "Bjarne",
+  "Shafi",
+  "Tim",
+  "Frances",
+];
+const LAST = [
+  "Lovelace",
+  "Hopper",
+  "Turing",
+  "Johnson",
+  "Torvalds",
+  "Liskov",
+  "Ritchie",
+  "Perlman",
+  "Thompson",
+  "Hamilton",
+  "Rossum",
+  "Borg",
+  "Stroustrup",
+  "Goldwasser",
+];
+const COMPANIES = [
+  "Acme Corp",
+  "Globex",
+  "Initech",
+  "Umbrella",
+  "Stark Industries",
+  "Tyrell",
+  "Wonka Industries",
+  "Cyberdyne",
+  "Soylent",
+  "Aperture Science",
+];
+const ROLES = [
+  "Engineer",
+  "VP Sales",
+  "Designer",
+  "Founder",
+  "Analyst",
+  "Recruiter",
+];
+const TAGS = ["investor", "customer", "friend", "alumni", "mentor", "vendor"];
+const CITIES = ["Austin", "Berlin", "Lagos", "Osaka", "Lima", "Toronto"];
+
+function pick<T>(list: T[], i: number): T {
+  return list[i % list.length];
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((p / 100) * sorted.length) - 1),
+  );
+  return sorted[idx];
+}
+
+interface Row {
+  label: string;
+  p50: number;
+  p95: number;
+  n: number;
+  note: string;
+}
+
+async function measure(
+  label: string,
+  fn: () => Promise<unknown>,
+  iterations = ITERATIONS,
+  note = "",
+): Promise<Row> {
+  // One warm-up so prepared statements and caches are not charged to run 1.
+  await fn();
+  const samples: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    const t0 = performance.now();
+    await fn();
+    samples.push(performance.now() - t0);
+  }
+  samples.sort((a, b) => a - b);
+  return {
+    label,
+    p50: percentile(samples, 50),
+    p95: percentile(samples, 95),
+    n: iterations,
+    note,
+  };
+}
+
+async function main(): Promise<void> {
+  const app = createApp({ disableRateLimit: true });
+  const server = http.createServer(finalizeApp(app));
+  server.listen(0, "127.0.0.1");
+
+  const seedStart = performance.now();
+  const owners: { id: string; username: string; password: string }[] = [];
+
+  for (let o = 0; o < OWNERS; o++) {
+    const creds = {
+      email: `bench${o}@example.com`,
+      username: `bench${o}`,
+      password: "correct horse battery staple",
+      displayName: `Bench Owner ${o}`,
+    };
+    const user = await authService.createUser(creds);
+    owners.push({
+      id: user.id,
+      username: creds.username,
+      password: creds.password,
+    });
+
+    // Every insert runs inside that owner's scope, which is what task 0.5
+    // reads. This is how production will write once Phase 1 lands.
+    runWithContext(
+      {
+        requestId: `bench-seed-${o}`,
+        principal: null,
+        scope: scopeForOwnerId(user.id),
+      },
+      () => {
+        for (let c = 0; c < CONTACTS_PER_OWNER; c++) {
+          const contact: { id: string } | null = contactService.createContact({
+            name: `${pick(FIRST, c)} ${pick(LAST, c + o)}`,
+            company: pick(COMPANIES, c + o),
+            role: pick(ROLES, c),
+            location: pick(CITIES, c),
+            tags: [pick(TAGS, c), pick(TAGS, c + 1)],
+          } as never);
+          if (!contact) continue;
+          for (let n = 0; n < INTERACTIONS_PER_CONTACT; n++) {
+            interactionService.createInteraction(contact.id, {
+              type: "note",
+              title: `Touchpoint ${n}`,
+              content: `Discussed roadmap and budget, round ${n}.`,
+            } as never);
+          }
+        }
+      },
+    );
+    process.stderr.write(
+      `  seeded owner ${o + 1}/${OWNERS} (${CONTACTS_PER_OWNER} contacts)\n`,
+    );
+  }
+  const seedMs = performance.now() - seedStart;
+
+  // Measure as the first owner, signed in the way a browser is.
+  const login = await request(server)
+    .post("/api/auth/login")
+    .send({ identifier: owners[0].username, password: owners[0].password });
+  const cookie = (login.headers["set-cookie"] as unknown as string[]) ?? [];
+  if (!cookie.length) {
+    throw new Error(`bench: login failed with ${login.status}`);
+  }
+  const auth = (r: import("supertest").Test): import("supertest").Test =>
+    r.set("Cookie", cookie);
+  const sampleId = (
+    sqlite.prepare("SELECT id FROM contacts LIMIT 1").get() as { id: string }
+  ).id;
+
+  const rows: Row[] = [];
+  rows.push(
+    await measure("GET /api/contacts?view=slim", () =>
+      auth(request(server).get("/api/contacts?view=slim")).expect(200),
+    ),
+  );
+  rows.push(
+    await measure("GET /api/contacts/:id", () =>
+      auth(request(server).get(`/api/contacts/${sampleId}`)).expect(200),
+    ),
+  );
+  rows.push(
+    await measure("GET /api/search?q=", () =>
+      auth(request(server).get("/api/search?q=Acme")).expect(200),
+    ),
+  );
+  rows.push(
+    await measure(
+      "POST /api/search/semantic",
+      () =>
+        auth(
+          request(server).post("/api/search/semantic").send({ query: "Acme" }),
+        ),
+      ITERATIONS,
+      "mock AI, so this is FTS plus vector",
+    ),
+  );
+  rows.push(
+    await measure("GET /api/dashboard", () =>
+      auth(request(server).get("/api/dashboard")).expect(200),
+    ),
+  );
+  rows.push(
+    await measure("GET /api/command-palette/zero-state", () =>
+      auth(request(server).get("/api/command-palette/zero-state")).expect(200),
+    ),
+  );
+  rows.push(
+    await measure("GET /api/contacts/:id/timeline", () =>
+      auth(request(server).get(`/api/contacts/${sampleId}/timeline`)).expect(
+        200,
+      ),
+    ),
+  );
+  rows.push(
+    await measure("GET /api/action-items", () =>
+      auth(request(server).get("/api/action-items")).expect(200),
+    ),
+  );
+  rows.push(
+    await measure(
+      "PATCH /api/contacts/:id",
+      () =>
+        auth(
+          request(server)
+            .patch(`/api/contacts/${sampleId}`)
+            .send({ role: `Role ${Math.random().toString(36).slice(2, 8)}` }),
+        ),
+      Math.min(ITERATIONS, 20),
+      "one FTS trigger delete plus reinsert per update",
+    ),
+  );
+  rows.push(
+    await measure(
+      "POST /api/dedupe/scan",
+      () => auth(request(server).post("/api/dedupe/scan").send({})),
+      3,
+      "wall time, mock AI",
+    ),
+  );
+
+  const vec = sqlite.prepare("SELECT vec_version() AS v").get() as {
+    v: string;
+  };
+  const sqliteVersion = sqlite
+    .prepare("SELECT sqlite_version() AS v")
+    .get() as {
+    v: string;
+  };
+  const totalContacts = (
+    sqlite.prepare("SELECT COUNT(*) AS n FROM contacts").get() as { n: number }
+  ).n;
+
+  const out: string[] = [];
+  out.push(
+    `# Tenancy benchmark: ${OWNERS} owner(s) x ${CONTACTS_PER_OWNER} contacts`,
+  );
+  out.push("");
+  out.push(
+    `- Machine: ${os.cpus()[0]?.model ?? "unknown"}, ${os.cpus().length} cores, ${(os.totalmem() / 1e9).toFixed(0)} GB`,
+  );
+  out.push(`- Platform: ${process.platform} ${os.release()} (${process.arch})`);
+  out.push(`- Node: ${process.version}`);
+  out.push(`- SQLite: ${sqliteVersion.v}`);
+  out.push(`- sqlite-vec: ${vec.v}`);
+  out.push(`- Contacts in the database: ${totalContacts}`);
+  out.push(`- Interactions per contact: ${INTERACTIONS_PER_CONTACT}`);
+  out.push(`- Seed time: ${(seedMs / 1000).toFixed(1)}s`);
+  out.push(
+    `- Measured as one signed-in owner, ${ITERATIONS} iterations unless noted.`,
+  );
+  out.push("");
+  out.push("| Endpoint | p50 ms | p95 ms | n | Note |");
+  out.push("| -------- | -----: | -----: | -: | ---- |");
+  for (const r of rows) {
+    out.push(
+      `| \`${r.label}\` | ${r.p50.toFixed(1)} | ${r.p95.toFixed(1)} | ${r.n} | ${r.note} |`,
+    );
+  }
+  out.push("");
+
+  console.log(out.join("\n"));
+  server.close();
+  sqlite.close();
+}
+
+await main();

--- a/server/db.ts
+++ b/server/db.ts
@@ -269,7 +269,7 @@ try {
 }
 
 // =============================================================================
-// 2a. Data Cleanup — Sanitize legacy AI Search artifacts
+// 2b. Data Cleanup — Sanitize legacy AI Search artifacts
 // =============================================================================
 // These idempotent queries fix two issues in previously-hydrated contacts:
 // 1. AI-search interests stored without isAiGenerated=1 (LLM didn't set the flag)

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -17,9 +17,11 @@
 // binding below). API_TOKEN also implies enforcement, because a token is only
 // meaningful on an instance that is gated.
 //
-// Every request carries a Principal describing who is asking. Today nothing
-// downstream filters by it beyond "are you allowed in at all", but it is the
-// seam multi-tenancy needs, and stamping ownership on new rows already uses it.
+// Every request carries a Principal describing who is asking. As of Phase 0 of
+// the 2.0 work, attachRequestContext turns that Principal into a Scope and
+// every insert into an owned table stamps ownership from it. Reads are still
+// unscoped: Phase 2 adds the owner predicate to each query. See
+// docs/multi-tenant-plan/ and server/tenancy/scope.ts.
 //
 // Note on defaults: auth is off out of the box, including in Docker, because
 // the common case is a container reached only from its host. The server logs a
@@ -221,10 +223,10 @@ export function attachPrincipal(
   }
 
   // Session cookie → person. Resolved even when auth is off, so that someone
-  // who signed in before enforcement was disabled is still *identified* —
-  // which is what stamps ownership on the rows they create and what makes
-  // /api/auth/me answer. Costs one indexed lookup, and only when a cookie is
-  // actually present.
+  // who signed in before enforcement was disabled is still *identified*. That
+  // identity reaches the request context, which is what stamps ownership on
+  // the rows they create, and it is what makes /api/auth/me answer. Costs one
+  // indexed lookup, and only when a cookie is actually present.
   const secret = presentedSessionSecret(req);
   if (secret) {
     const resolved = resolveSession(secret);

--- a/server/services/aiStatsService.ts
+++ b/server/services/aiStatsService.ts
@@ -19,6 +19,7 @@
 // =============================================================================
 
 import { sqlite } from "../db.ts";
+import { currentScopeOrNull } from "../tenancy/requestContext.ts";
 import { log } from "../utils/logger.ts";
 import { aiCache } from "../utils/aiCache.ts";
 import { isProviderConfigured } from "../ai/singleton.ts";
@@ -86,8 +87,8 @@ export interface FeedParams {
 // =============================================================================
 
 const insertStmt = sqlite.prepare(`
-  INSERT INTO ai_invocations (id, operation, model, tokenCount, latencyMs, cached, description, createdAt)
-  VALUES (?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  INSERT INTO ai_invocations (id, operation, model, tokenCount, latencyMs, cached, description, ownerId, createdAt)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
 `);
 
 const summaryStmt = sqlite.prepare(`
@@ -152,6 +153,9 @@ export function recordInvocation(entry: InvocationEntry): void {
       entry.latencyMs,
       entry.cached ? 1 : 0,
       entry.description ?? null,
+      // A boot-time or background job has no context, so this is null. The
+      // AI stats view groups null as "system" until Phase 2 wraps those jobs.
+      currentScopeOrNull()?.ownerId ?? null,
     );
     log.debug(
       "AIStats",

--- a/server/services/contactService.ts
+++ b/server/services/contactService.ts
@@ -21,6 +21,7 @@ import {
   isBase64DataUri,
 } from "../utils/avatarProcessor.ts";
 import { aiCache } from "../utils/aiCache.ts";
+import { currentScopeOrNull } from "../tenancy/requestContext.ts";
 import { buildContactUpdate } from "../utils/helpers.ts";
 import { buildAvatarUrl } from "./avatarService.ts";
 import { generateAndStoreEmbedding } from "./dedupe/embeddings.ts";
@@ -94,6 +95,10 @@ function scheduleIncrementalDedupe(contactId: string) {
 function buildInsertValues(body: NewContactPayload, id: string) {
   return {
     id,
+    // Stamped from the request context, so a signed-in caller's rows are
+    // owned the moment they are written. Anonymous mode writes null, which
+    // reconcileOwnership still claims at boot for a single account.
+    ownerId: currentScopeOrNull()?.ownerId ?? null,
     name: body.name,
     firstName: body.firstName || null,
     lastName: body.lastName || null,

--- a/server/services/dedupe/engine.ts
+++ b/server/services/dedupe/engine.ts
@@ -1,5 +1,6 @@
 import crypto from "crypto";
 import { sqlite } from "../../db.ts";
+import { currentScopeOrNull } from "../../tenancy/requestContext.ts";
 import { log } from "../../utils/logger.ts";
 import { contactRepo } from "../../repositories/contactRepository.ts";
 import { normalizePhone, isNicknameMatch } from "../../utils/nlp/index.ts";
@@ -581,8 +582,11 @@ export const dedupeService = {
       crypto.randomUUID(),
     ];
 
+    // Dev-only seed. Stamped like every other insert so the seeded rows
+    // belong to whoever asked for them.
+    const owner = currentScopeOrNull()?.ownerId ?? null;
     const insertContact = sqlite.prepare(
-      "INSERT INTO contacts (id, name, company, role, themeColor) VALUES (?, ?, ?, ?, ?)",
+      "INSERT INTO contacts (id, name, company, role, themeColor, ownerId) VALUES (?, ?, ?, ?, ?, ?)",
     );
     const insertEmail = sqlite.prepare(
       "INSERT INTO contact_emails (id, contactId, email, isPrimary) VALUES (?, ?, ?, 1)",
@@ -597,6 +601,7 @@ export const dedupeService = {
       "Acme Corp",
       "VP Sales",
       "brand",
+      owner,
     );
     insertPhone.run(crypto.randomUUID(), ids[0], "(555) 867-5309");
 
@@ -606,6 +611,7 @@ export const dedupeService = {
       "Acme Corp",
       "Vice President of Sales",
       "indigo",
+      owner,
     );
     insertEmail.run(crypto.randomUUID(), ids[1], "bob.johnson@gmail.com");
 
@@ -615,10 +621,11 @@ export const dedupeService = {
       "Acme Corporation",
       "VP Sales",
       "violet",
+      owner,
     );
     insertEmail.run(crypto.randomUUID(), ids[2], "bob.johnson@gmail.com");
 
-    insertContact.run(ids[3], "R. Johnson", null, null, "teal");
+    insertContact.run(ids[3], "R. Johnson", null, null, "teal", owner);
     insertPhone.run(crypto.randomUUID(), ids[3], "555-867-5309");
   },
 };

--- a/server/services/dedupe/suggestions.ts
+++ b/server/services/dedupe/suggestions.ts
@@ -126,8 +126,19 @@ const _stmts = {
   // --- Merge Log ---
   insertMergeLog: sqlite.prepare(`
     INSERT INTO dedupe_merge_log
-      (id, primaryId, duplicateId, mergedBy, mergeType, confidence, reasoning, duplicateSnapshot)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      (id, primaryId, duplicateId, mergedBy, mergeType, confidence, reasoning, duplicateSnapshot, ownerId)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `),
+
+  /**
+   * The owner of a merge log row is the owner of the surviving contact, not
+   * whoever is signed in. A merge can run from a background scan that carries
+   * no request context, and the audit row still belongs to the person whose
+   * data was merged.
+   */
+  // tenant-lint: allow owner-checked by caller
+  getContactOwner: sqlite.prepare(`
+    SELECT ownerId FROM contacts WHERE id = ?
   `),
 
   getMergeLog: sqlite.prepare(`
@@ -445,6 +456,10 @@ export function recordMergeUnsafe(
   snapshot?: string | null,
 ): string {
   const id = crypto.randomUUID();
+  const owner = (
+    _stmts.getContactOwner.get(primaryId) as
+      { ownerId: string | null } | undefined
+  )?.ownerId;
   _stmts.insertMergeLog.run(
     id,
     primaryId,
@@ -454,6 +469,7 @@ export function recordMergeUnsafe(
     confidence,
     reasoning,
     snapshot ?? null,
+    owner ?? null,
   );
   log.info(
     "DedupeSuggestions",

--- a/server/services/interactionService.ts
+++ b/server/services/interactionService.ts
@@ -15,6 +15,7 @@ import {
 } from "../ai/aiService.ts";
 import { relationshipService } from "./relationshipService.ts";
 import { aiCache, contentHash } from "../utils/aiCache.ts";
+import { currentScopeOrNull } from "../tenancy/requestContext.ts";
 import { AppError } from "../utils/AppError.ts";
 import { resolveCapability } from "../ai/capabilities.ts";
 import { SharedWork } from "../ai/workQueue.ts";
@@ -86,6 +87,9 @@ async function runMentionExtraction(
               company: m.company || null,
               isGhost: 1,
               themeColor: newTheme,
+              // Mention extraction is started inside the request that created
+              // the interaction, so the context still carries that caller.
+              ownerId: currentScopeOrNull()?.ownerId ?? null,
             })
             .returning()
             .get();

--- a/server/services/listService.ts
+++ b/server/services/listService.ts
@@ -3,6 +3,7 @@ import { assertContactExists } from "./contactGuard.ts";
 import { ACTIVE_CONTACT_SQL } from "./search/ftsIndex.ts";
 import crypto from "crypto";
 import { sqlite } from "../db.ts";
+import { currentScopeOrNull } from "../tenancy/requestContext.ts";
 import { contactRepo } from "../repositories/contactRepository.ts";
 
 interface ListRow {
@@ -38,9 +39,15 @@ export const listService = {
 
     sqlite
       .prepare(
-        "INSERT INTO lists (id, name, icon, sortOrder) VALUES (?, ?, ?, ?)",
+        "INSERT INTO lists (id, name, icon, sortOrder, ownerId) VALUES (?, ?, ?, ?, ?)",
       )
-      .run(id, name.trim(), icon || "star", sortOrder);
+      .run(
+        id,
+        name.trim(),
+        icon || "star",
+        sortOrder,
+        currentScopeOrNull()?.ownerId ?? null,
+      );
 
     return sqlite
       .prepare("SELECT *, 0 as memberCount FROM lists WHERE id = ?")

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -141,10 +141,14 @@ export const contacts = sqliteTable("contacts", {
 // `ownerId` appears on exactly four tables: contacts, lists, ai_invocations,
 // and dedupe_merge_log. That is not an oversight — it is every table that is
 // NOT reachable from `contacts` through a foreign key. Interactions, action
-// items, list members, the eleven contact_* child tables and the dedupe
+// items, list members, the ten contact_* child tables and the dedupe
 // suggestion/exclusion tables all carry a `contactId` (or `listId`) with ON
 // DELETE CASCADE, so their owner is derivable by a join and duplicating it
 // would only create a column that can drift out of sync.
+//
+// The 2.0 multi-tenant work revisits this: see docs/multi-tenant-plan/,
+// specifically 04-data-model-and-migration.md, which denormalizes `ownerId`
+// onto four of those child tables for covering indexes.
 //
 // dedupe_merge_log is the interesting exception: it deliberately has no
 // foreign key, because it stores snapshots of contacts that were hard-deleted

--- a/tests/integration/tenancy.stamping.test.ts
+++ b/tests/integration/tenancy.stamping.test.ts
@@ -1,0 +1,255 @@
+// =============================================================================
+// Integration Tests — ownership stamping
+// =============================================================================
+// Phase 0 does not scope any read. What it does do is stop the hole getting
+// deeper: from this phase on, a row written by a signed-in caller carries that
+// caller's id from the moment it is created, so Phase 1 has less to backfill
+// and Phase 2 has something true to filter on.
+//
+// Auth is switched on inside this file rather than at boot, because the
+// acceptance criterion is that stamping starts working WITHOUT a restart.
+// isAuthRequired() reads process.env on every call, so flipping it here is
+// the real thing and not a fixture.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import request from "supertest";
+
+// Mentions are AI driven, and integration runs with no provider configured, so
+// the real extractor always returns nothing and no ghost is ever created. The
+// stub returns one unknown name and records an AI invocation on the way, which
+// puts both writes inside the request's async context. That is the point of
+// the test: the context has to survive setTimeout, an await, and a
+// transaction before either insert happens.
+vi.mock("../../server/ai/aiService.ts", async (importActual) => {
+  const actual =
+    await importActual<typeof import("../../server/ai/aiService.ts")>();
+  const { recordInvocation } =
+    await import("../../server/services/aiStatsService.ts");
+  return {
+    ...actual,
+    extractMentions: async (text: string) => {
+      recordInvocation({
+        operation: "mentions",
+        model: "mock",
+        tokenCount: 1,
+        latencyMs: 1,
+        cached: false,
+        description: "stamping test",
+      });
+      return text.includes("Ghostly McGhostface")
+        ? [{ name: "Ghostly McGhostface", company: "Nowhere", context: "test" }]
+        : [];
+    },
+  };
+});
+
+const { makeTestApp } = await import("./helpers.ts");
+const { sqlite } = await import("../../server/db.ts");
+const { createActor, asUser, resetAccounts } =
+  await import("./tenancy/helpers.ts");
+
+const app = makeTestApp();
+let actor: Awaited<ReturnType<typeof createActor>>;
+
+const ownerOf = (table: string, id: string): string | null | undefined =>
+  (
+    sqlite.prepare(`SELECT ownerId FROM ${table} WHERE id = ?`).get(id) as
+      { ownerId: string | null } | undefined
+  )?.ownerId;
+
+beforeAll(async () => {
+  resetAccounts();
+  // Auth on, at runtime, with no restart.
+  process.env.AUTH_REQUIRED = "true";
+  actor = await createActor(app);
+});
+
+afterAll(() => {
+  process.env.AUTH_REQUIRED = "";
+  resetAccounts();
+});
+
+describe("ownership stamping with auth on", () => {
+  it("stamps a contact with the signed-in user's id", async () => {
+    const res = await asUser(actor)(
+      request(app).post("/api/contacts").send({ name: "Stamped Contact" }),
+    );
+    expect(res.status).toBe(201);
+    expect(ownerOf("contacts", res.body.id)).toBe(actor.user.id);
+  });
+
+  it("stamps every contact from a bulk import", async () => {
+    const res = await asUser(actor)(
+      request(app)
+        .post("/api/contacts/bulk")
+        .send([{ name: "Bulk One" }, { name: "Bulk Two" }]),
+    );
+    expect([200, 201]).toContain(res.status);
+
+    const unowned = sqlite
+      .prepare(
+        "SELECT COUNT(*) AS n FROM contacts WHERE name LIKE 'Bulk %' AND (ownerId IS NULL OR ownerId != ?)",
+      )
+      .get(actor.user.id) as { n: number };
+    expect(unowned.n).toBe(0);
+  });
+
+  it("stamps a list", async () => {
+    const res = await asUser(actor)(
+      request(app).post("/api/lists").send({ name: "Stamped List" }),
+    );
+    expect([200, 201]).toContain(res.status);
+    expect(ownerOf("lists", res.body.id)).toBe(actor.user.id);
+  });
+
+  it("stamps a ghost contact created by mention extraction", async () => {
+    const contact = await asUser(actor)(
+      request(app).post("/api/contacts").send({ name: "Note Author" }),
+    );
+    expect(contact.status).toBe(201);
+
+    // Mention extraction is guarded by DISABLE_BACKGROUND_JOBS, which the
+    // integration setup turns on for the whole project. Flip it for this one
+    // request and put it straight back, so no other fire-and-forget work in
+    // this file outlives the test.
+    const previous = process.env.DISABLE_BACKGROUND_JOBS;
+    process.env.DISABLE_BACKGROUND_JOBS = "";
+    let res;
+    try {
+      res = await asUser(actor)(
+        request(app)
+          .post(`/api/contacts/${contact.body.id}/interactions`)
+          .send({
+            type: "note",
+            title: "Deal chat",
+            content: "Spoke with Ghostly McGhostface about the deal",
+          }),
+      );
+    } finally {
+      process.env.DISABLE_BACKGROUND_JOBS = previous;
+    }
+    expect([200, 201]).toContain(res.status);
+
+    // Extraction is fire and forget behind a setTimeout, so wait for the row.
+    let ghost: { id: string; ownerId: string | null } | undefined;
+    for (let i = 0; i < 50 && !ghost; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      ghost = sqlite
+        .prepare("SELECT id, ownerId FROM contacts WHERE name = ?")
+        .get("Ghostly McGhostface") as
+        { id: string; ownerId: string | null } | undefined;
+    }
+
+    expect(ghost, "the ghost contact was never created").toBeTruthy();
+    // The context survived setTimeout, an await, and a transaction.
+    expect(ghost?.ownerId).toBe(actor.user.id);
+  });
+
+  it("stamps an AI invocation recorded during a request", async () => {
+    const row = sqlite
+      .prepare(
+        "SELECT ownerId FROM ai_invocations WHERE operation = 'mentions' ORDER BY createdAt DESC LIMIT 1",
+      )
+      .get() as { ownerId: string | null } | undefined;
+
+    expect(row, "no AI invocation was recorded").toBeTruthy();
+    expect(row?.ownerId).toBe(actor.user.id);
+  });
+
+  it("stamps a merge log row from the surviving contact, not the caller", async () => {
+    const a = await asUser(actor)(
+      request(app).post("/api/contacts").send({ name: "Merge Primary" }),
+    );
+    const b = await asUser(actor)(
+      request(app).post("/api/contacts").send({ name: "Merge Duplicate" }),
+    );
+    expect(a.status).toBe(201);
+    expect(b.status).toBe(201);
+
+    const res = await asUser(actor)(
+      request(app)
+        .post("/api/contacts/merge")
+        .send({ primaryId: a.body.id, duplicateId: b.body.id }),
+    );
+    expect([200, 201]).toContain(res.status);
+
+    const row = sqlite
+      .prepare(
+        "SELECT ownerId FROM dedupe_merge_log WHERE primaryId = ? ORDER BY mergedAt DESC LIMIT 1",
+      )
+      .get(a.body.id) as { ownerId: string | null } | undefined;
+
+    expect(row, "no merge log row was written").toBeTruthy();
+    expect(row?.ownerId).toBe(actor.user.id);
+  });
+});
+
+describe("ownership stamping with no context", () => {
+  it("writes a null owner rather than throwing, which is what background jobs need", async () => {
+    const { recordInvocation } =
+      await import("../../server/services/aiStatsService.ts");
+    recordInvocation({
+      operation: "rerank",
+      model: "mock",
+      tokenCount: 1,
+      latencyMs: 1,
+      cached: false,
+      description: "no context",
+    });
+
+    const row = sqlite
+      .prepare(
+        "SELECT ownerId FROM ai_invocations WHERE description = 'no context' LIMIT 1",
+      )
+      .get() as { ownerId: string | null } | undefined;
+
+    expect(row).toBeTruthy();
+    // Null groups as "system" in the AI stats view until Phase 2 wraps jobs.
+    expect(row?.ownerId).toBeNull();
+  });
+});
+
+// =============================================================================
+// The two-user harness itself
+// =============================================================================
+// Phase 1's contract says the harness can create a second account through
+// authService.createUser and sign it in. Phase 2 builds every isolation test
+// on that, so it is worth proving here rather than discovering it is broken
+// in the first PR that needs it.
+// =============================================================================
+
+describe("two-user harness", () => {
+  it("creates a second signed-in account whose rows are stamped to it", async () => {
+    const { seedOwner, rowsOwnedBy } = await import("./tenancy/helpers.ts");
+
+    const second = await createActor(app);
+    expect(second.user.id).not.toBe(actor.user.id);
+    expect(second.cookie.length).toBeGreaterThan(0);
+    expect(second.scope.ownerId).toBe(second.user.id);
+
+    // The session really works: an authenticated route answers for B.
+    const me = await asUser(second)(request(app).get("/api/auth/me"));
+    expect(me.status).toBe(200);
+
+    const before = rowsOwnedBy("contacts", second.user.id);
+    const seeded = await seedOwner(app, second, {
+      contacts: 2,
+      lists: 1,
+      interactions: 1,
+      actionItems: 1,
+    });
+
+    expect(seeded.contactIds).toHaveLength(2);
+    expect(seeded.listIds).toHaveLength(1);
+    expect(seeded.interactionIds).toHaveLength(1);
+    expect(seeded.actionItemIds).toHaveLength(1);
+
+    // Everything seedOwner wrote belongs to B, and none of it to A.
+    expect(rowsOwnedBy("contacts", second.user.id)).toBe(before + 2);
+    expect(rowsOwnedBy("lists", second.user.id)).toBe(1);
+    for (const id of seeded.contactIds) {
+      expect(ownerOf("contacts", id)).toBe(second.user.id);
+    }
+  });
+});

--- a/tests/integration/tenancy/helpers.ts
+++ b/tests/integration/tenancy/helpers.ts
@@ -1,0 +1,221 @@
+// =============================================================================
+// Two-user test harness
+// =============================================================================
+// Phase 2 proves isolation, and isolation cannot be proven with one account.
+// Every test in the matrix needs two real users with real sessions and real
+// rows, created the way production creates them, so this builds them once.
+//
+// `seedOwner` deliberately goes through the public API rather than inserting
+// rows directly. A row written by hand would carry whatever ownerId the test
+// chose, which proves nothing. A row written through POST /api/contacts is
+// stamped by the same code path a browser hits, so the assertion is about the
+// product and not about the fixture.
+// =============================================================================
+
+import request from "supertest";
+import type http from "http";
+import { sqlite } from "../../../server/db.ts";
+import * as authService from "../../../server/services/authService.ts";
+import { __resetAuthRateLimits } from "../../../server/routes/auth.ts";
+import { scopeForOwnerId, type Scope } from "../../../server/tenancy/scope.ts";
+
+export interface Actor {
+  user: { id: string; email: string; username: string };
+  cookie: string[];
+  scope: Scope;
+}
+
+export interface Seeded {
+  contactIds: string[];
+  listIds: string[];
+  interactionIds: string[];
+  actionItemIds: string[];
+}
+
+interface ActorOverrides {
+  email?: string;
+  username?: string;
+  password?: string;
+  displayName?: string;
+}
+
+const DEFAULT_PASSWORD = "correct horse battery staple";
+let actorCount = 0;
+
+function cookieFrom(res: request.Response): string[] {
+  return (res.headers["set-cookie"] as unknown as string[]) ?? [];
+}
+
+function hasAnyUser(): boolean {
+  const row = sqlite.prepare("SELECT COUNT(*) AS n FROM users").get() as {
+    n: number;
+  };
+  return row.n > 0;
+}
+
+/**
+ * Create an account and sign it in.
+ *
+ * The first actor goes through POST /api/auth/setup, which is the only way to
+ * create the first admin. Later actors are created with authService.createUser
+ * and then signed in, because setup refuses to run twice.
+ */
+export async function createActor(
+  app: http.Server,
+  overrides: ActorOverrides = {},
+): Promise<Actor> {
+  actorCount += 1;
+  const creds = {
+    email: overrides.email ?? `actor${actorCount}@example.com`,
+    username: overrides.username ?? `actor${actorCount}`,
+    password: overrides.password ?? DEFAULT_PASSWORD,
+    displayName: overrides.displayName ?? `Actor ${actorCount}`,
+  };
+
+  // The credential endpoints share one fixed window across the whole file.
+  // Creating several actors trips it, and a tripped limiter returns 429 with
+  // no Set-Cookie, which surfaces later as a baffling 401.
+  __resetAuthRateLimits();
+
+  if (!hasAnyUser()) {
+    const res = await request(app).post("/api/auth/setup").send(creds);
+    if (res.status !== 200 && res.status !== 201) {
+      throw new Error(
+        `createActor: setup failed with ${res.status}: ${JSON.stringify(res.body)}`,
+      );
+    }
+    const user = res.body?.user ?? res.body;
+    return {
+      user: { id: user.id, email: creds.email, username: creds.username },
+      cookie: cookieFrom(res),
+      scope: scopeForOwnerId(user.id),
+    };
+  }
+
+  const created = await authService.createUser(creds);
+  __resetAuthRateLimits();
+  const res = await request(app)
+    .post("/api/auth/login")
+    .send({ identifier: creds.username, password: creds.password });
+  if (res.status !== 200) {
+    throw new Error(
+      `createActor: login failed with ${res.status}: ${JSON.stringify(res.body)}`,
+    );
+  }
+  return {
+    user: { id: created.id, email: creds.email, username: creds.username },
+    cookie: cookieFrom(res),
+    scope: scopeForOwnerId(created.id),
+  };
+}
+
+/** Attach an actor's session to a supertest request. */
+export function asUser(actor: Actor) {
+  return (req: request.Test): request.Test => req.set("Cookie", actor.cookie);
+}
+
+/**
+ * Create rows for an actor through the public API, so every row is stamped
+ * exactly the way production stamps it.
+ */
+export async function seedOwner(
+  app: http.Server,
+  actor: Actor,
+  shape: {
+    contacts: number;
+    interactions?: number;
+    lists?: number;
+    actionItems?: number;
+  },
+): Promise<Seeded> {
+  const auth = asUser(actor);
+  const out: Seeded = {
+    contactIds: [],
+    listIds: [],
+    interactionIds: [],
+    actionItemIds: [],
+  };
+
+  for (let i = 0; i < shape.contacts; i++) {
+    const res = await auth(
+      request(app)
+        .post("/api/contacts")
+        .send({
+          name: `${actor.user.username} Contact ${i}`,
+          company: `Company ${i}`,
+        }),
+    );
+    if (res.status !== 201) {
+      throw new Error(`seedOwner: contact ${i} failed with ${res.status}`);
+    }
+    out.contactIds.push(res.body.id);
+  }
+
+  for (let i = 0; i < (shape.lists ?? 0); i++) {
+    const res = await auth(
+      request(app)
+        .post("/api/lists")
+        .send({ name: `${actor.user.username} List ${i}` }),
+    );
+    if (res.status !== 200 && res.status !== 201) {
+      throw new Error(`seedOwner: list ${i} failed with ${res.status}`);
+    }
+    out.listIds.push(res.body.id);
+  }
+
+  const target = out.contactIds[0];
+  for (let i = 0; target && i < (shape.interactions ?? 0); i++) {
+    const res = await auth(
+      request(app)
+        .post(`/api/contacts/${target}/interactions`)
+        .send({ type: "note", title: `Note ${i}` }),
+    );
+    if (res.status !== 200 && res.status !== 201) {
+      throw new Error(`seedOwner: interaction ${i} failed with ${res.status}`);
+    }
+    out.interactionIds.push(res.body.id);
+  }
+
+  for (let i = 0; target && i < (shape.actionItems ?? 0); i++) {
+    const res = await auth(
+      request(app)
+        .post(`/api/contacts/${target}/action-items`)
+        .send({ title: `Task ${i}`, dueAt: "2027-01-01" }),
+    );
+    if (res.status !== 200 && res.status !== 201) {
+      throw new Error(`seedOwner: action item ${i} failed with ${res.status}`);
+    }
+    out.actionItemIds.push(res.body.id);
+  }
+
+  return out;
+}
+
+/** How many rows in `table` belong to `ownerId`. */
+export function rowsOwnedBy(table: string, ownerId: string): number {
+  // tenant-lint: allow derived table
+  const row = sqlite
+    .prepare(`SELECT COUNT(*) AS n FROM ${table} WHERE ownerId = ?`)
+    .get(ownerId) as { n: number };
+  return row.n;
+}
+
+/**
+ * Remove every account and every owned row.
+ *
+ * Order matters. `users` is referenced with ON DELETE RESTRICT, so the owned
+ * rows have to go first or the delete fails. Phase 1 changes this to keep or
+ * recreate the permanent local owner (see 06-phase-1-storage.md, task 1.13).
+ */
+export function resetAccounts(): void {
+  sqlite.exec(`
+    DELETE FROM dedupe_merge_log;
+    DELETE FROM ai_invocations;
+    DELETE FROM lists;
+    DELETE FROM contacts;
+    DELETE FROM sessions;
+    DELETE FROM users;
+  `);
+  actorCount = 0;
+  __resetAuthRateLimits();
+}


### PR DESCRIPTION
This makes every new row carry its owner from the moment it is written, adds the two-user harness Phase 2 needs, and records the performance baseline Phase 5 compares against. It completes Phase 0.

Phase 0 tasks 0.5, 0.6, 0.8, 0.9 and 0.12.

## What users see

On an instance with `AUTH_REQUIRED=true`, rows created by a signed-in person are stamped with that person's id as they are written. Nothing is filtered yet, so no read changes and no screen changes. An anonymous instance still writes no owner and behaves exactly as before.

- **Stamping starts working without a restart.** `isAuthRequired()` reads the environment on every call, so the test flips auth on mid-file and asserts the very next insert is owned. That is the real behavior, not a fixture.

## How it works

Each insert takes its owner from the request context, so no signature changed for one more phase.

- `contactService.buildInsertValues`, which covers both `createContact` and `bulkCreateContacts`.
- `listService.createList`, `aiStatsService.recordInvocation`, the mention ghost in `interactionService`, and the dev-only dedupe seed.
- **The merge log is the exception.** It reads `ownerId` from the surviving contact's row rather than the context, because a merge can run from a background scan that carries no context, and the audit row belongs to the person whose data was merged.

## Guarantees

- **The ghost test is the one that matters.** Mention extraction runs behind a `setTimeout`, then an `await`, then a transaction, and the row still lands with the caller's id. That is the async propagation Phase 2 depends on, proven end to end rather than argued from the unit test.
- With no context at all, `recordInvocation` writes `null` instead of throwing, which is what background jobs need until Phase 2 wraps them.
- The two-user harness creates real accounts with real sessions, and `seedOwner` writes through the public API so a seeded row is stamped by the same code a browser hits. **It has its own test**, because Phase 2 builds every isolation test on it.

## Operational behavior

`bench/baseline-phase-0.md` records both runs. The ten-owner run is the point: nothing is scoped, so every owner is served all 20,000 contacts.

| Endpoint | 1 x 5000 | 10 x 2000 |
| -------- | -------: | --------: |
| `GET /api/contacts?view=slim` | 51.8 ms | 242.7 ms |
| `GET /api/dashboard` | 13.9 ms | 67.0 ms |
| `GET /api/contacts/:id` | 0.4 ms | 0.5 ms |
| `POST /api/dedupe/scan` | 3.5 s | 71.0 s |

- Keyed lookups are already flat, so adding an owner predicate to an indexed lookup should not move them.
- **The dedupe scan is the outlier.** Four times the contacts costs twenty times the wall clock, so the blocking stage is superlinear. Scoping it in Phase 2e is a correctness fix that should remove most of this.
- **One plan expectation did not hold.** The phase document predicted a `PATCH` cost of several milliseconds from the FTS trigger scan. It measures 0.6 ms at 5,000 contacts and 0.8 ms at 20,000. T10 measured that 4 ms at 40,000 rows, so the cost is real but does not bite at this size.

## Corrections, task 0.9

- `server/middleware/auth.ts` comments now say ownership is stamped from the request context.
- `src/db/schema.ts` said "eleven contact_* child tables". **Verified against the schema: there are ten.** Corrected, with a pointer to the plan.
- `server/db.ts` had two sections labelled `2a`. The second is now `2b`.
- `.agent/ARCHITECTURE.md` gains the Scope invariant. `.agent/TESTING.md` says three vitest projects, not two, and lists the nine new tenancy test files.

The acceptance boxes in section 4 of the phase document are ticked in this PR, with two annotated rather than ticked clean: the stale 575 test count, and the manual smoke on a real database copy, which is left for the operator.

## Testing

```
npm run lint          exit 0
npm run format:check  exit 0
npm test              exit 0
npm run build         exit 0
```

Raw vitest summary, 733 before and 741 after:

```
 Test Files  60 passed | 1 skipped (61)
      Tests  741 passed | 111 todo (852)
```
