### PR TITLE
perf(import): one dedupe scan for a bulk import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Extra S3.** A bulk import checks its contacts for duplicates in one pass
+  instead of one pass each. Every check normalized the whole account and built
+  a whole scan context of its own, so importing `n` contacts into a corpus of
+  `m` did about `n × m` work and nearly all of it was the same work repeated.
+  Measured: a thousand contacts into a corpus of ten thousand went from 113
+  seconds to 1.8 seconds, and the gap widens as the corpus grows. The
+  streaming import used its own separate matching, written out in the route
+  and weaker than the other path's, so what counted as a duplicate depended on
+  whether the client asked for a stream. Both paths now run the same scan, and
+  a streaming import finds nicknames and close profiles it could not see
+  before. One behaviour changed with it: an imported contact whose name
+  already exists is now a suggestion to review rather than an automatic merge.
+  The streaming import scored that at 0.95 and merged it, the other import
+  scored it at 0.92 and asked, and two people can share a name.
 - **Phase 3.** An expired personal token is refused from the moment it
   expires. The expiry check compared a database timestamp against a
   JavaScript one, and a space sorts before a `T`, so a token whose expiry fell

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -209,6 +209,18 @@ The SSE stream sends progress events through 4 phases:
 3. `scanning` — Looking for duplicates
 4. `done` — Summary with counts (imported, auto-merged, needs-review, new-unique)
 
+Both modes run the same duplicate scan over the imported contacts, against the
+caller's own contacts only. It compares each new contact with the existing
+ones and with the rest of the import, so the same person on two rows of one
+spreadsheet is found. A shared email address or phone number is merged
+automatically; a matching name, a nickname, or a close profile becomes a
+suggestion to review.
+
+The difference between the two modes is when the scan runs. In streaming mode
+it runs before the `done` event, and the counts in the summary are its result.
+In standard mode the response returns first and the scan starts a few seconds
+later, so `GET /api/dedupe/suggestions` is where its result appears.
+
 ---
 
 ### `POST /api/contacts/bulk-delete`

--- a/server/routes/contacts.ts
+++ b/server/routes/contacts.ts
@@ -23,7 +23,6 @@ import {
 import { z } from "zod";
 import { AppError, NotFoundError } from "../utils/AppError.ts";
 import { asyncHandler } from "../utils/asyncHandler.ts";
-import { sqlite } from "../db.ts";
 import { scopeOf } from "../tenancy/scope.ts";
 import { runWithContext } from "../tenancy/requestContext.ts";
 import { providerIdFor } from "../ai/gateway.ts";
@@ -38,18 +37,6 @@ import {
   isEmbeddingAvailable,
 } from "../services/dedupe/embeddings.ts";
 import { dedupeService } from "../services/dedupe/index.ts";
-import { ParallelQueue } from "../ai/routing/ParallelQueue.ts";
-import {
-  normalizeContactById,
-  normalizeContacts,
-} from "../services/dedupe/normalization.ts";
-import { normalizePhone, isNicknameMatch } from "../utils/nlp/index.ts";
-import {
-  loadNegativeConstraints,
-  pairKey,
-} from "../services/dedupe/blocking.ts";
-import { storeSuggestion } from "../services/dedupe/suggestions.ts";
-import { computePrimaryScore } from "../services/dedupe/clustering.ts";
 import {
   contactRepo,
   RELATION_REGISTRY,
@@ -260,267 +247,42 @@ router.post(
         }
       }
 
-      // Phase 3: Dedupe scan against imported contacts
+      // Phase 3: Dedupe scan against the imported contacts
+      //
+      // This used to be about two hundred and fifty lines of matching written
+      // out here, which found exact names, emails and phone numbers and
+      // nothing else. The JSON branch below ran a different and stronger
+      // check on the same contacts, so what counted as a duplicate depended
+      // on whether the client had asked for a stream. Both branches now call
+      // the same scan.
       let autoMerged = 0;
       let needsReview = 0;
-      // Track which imported contacts were involved in any match
-      const matchedImportIds = new Set<string>();
+      let matchedImportIds = new Set<string>();
 
       if (createdIds.length >= 1) {
         send({ phase: "scanning", message: "Looking for duplicates…" });
 
         try {
-          const importedSet = new Set(createdIds);
-          const distinctPairs = loadNegativeConstraints(scope);
-          const allNormalized = normalizeContacts(scope);
-          const seenPairs = new Set<string>();
-
-          // For each imported contact, check for duplicates against ALL contacts
-          for (let i = 0; i < createdIds.length; i++) {
-            // Yield between contacts: the per-contact scan is O(all contacts)
-            // of synchronous work, so a large import would otherwise starve
-            // every concurrent request (and the SSE flush) for the whole scan.
-            if (i > 0) {
-              await new Promise<void>((resolve) => setImmediate(resolve));
-            }
-            const contactId = createdIds[i];
-            const target = normalizeContactById(scope, contactId);
-            if (!target) continue;
-
-            // Check exact name matches
-            if (target.nameNorm) {
-              for (const other of allNormalized) {
-                if (other.id === contactId) continue;
-                // Skip other imported contacts in this same batch
-                if (importedSet.has(other.id)) continue;
-                const pk = pairKey(contactId, other.id);
-                if (seenPairs.has(pk) || distinctPairs.has(pk)) continue;
-
-                if (target.nameNorm === other.nameNorm) {
-                  seenPairs.add(pk);
-                  matchedImportIds.add(contactId);
-
-                  // During import, an exact name match against an existing contact
-                  // is almost certainly a duplicate — use higher confidence (0.95)
-                  // than the general scan's 0.92 for same-source matches.
-                  const pair = {
-                    idA: contactId,
-                    idB: other.id,
-                    matchType: "name",
-                    confidence: 0.95,
-                    reasoning: "Exact name match (import-time detection)",
-                  };
-
-                  try {
-                    const rawA = contactRepo.hydrate(
-                      contactRepo.findOwned(scope, pair.idA),
-                    );
-                    const rawB = contactRepo.hydrate(
-                      contactRepo.findOwned(scope, pair.idB),
-                    );
-                    const scoreA = computePrimaryScore(scope, rawA);
-                    const scoreB = computePrimaryScore(scope, rawB);
-                    const [primaryId, duplicateId] =
-                      scoreA >= scoreB
-                        ? [pair.idA, pair.idB]
-                        : [pair.idB, pair.idA];
-
-                    dedupeService.softMergeContacts(
-                      scope,
-                      primaryId,
-                      duplicateId,
-                      pair.confidence,
-                      pair.reasoning,
-                      rid,
-                    );
-                    storeSuggestion(scope, pair, "auto_merged");
-                    autoMerged++;
-                  } catch (err: unknown) {
-                    log.warn(
-                      "API",
-                      `[${rid}] Auto-merge failed, queued for review: ${getErrorMessage(err)}`,
-                    );
-                    storeSuggestion(scope, pair, "pending");
-                    needsReview++;
-                  }
-                  continue;
+          const result = await dedupeService.runImportScan(
+            scope,
+            createdIds,
+            rid,
+            {
+              onProgress: (checked, total) => {
+                if (checked % 50 === 0 && checked < total) {
+                  send({
+                    phase: "scanning",
+                    message: `Checked ${checked}/${total} contacts…`,
+                    autoMerged,
+                    needsReview,
+                  });
                 }
-
-                // Nickname match
-                if (
-                  target.lastNameNorm &&
-                  target.lastNameNorm === other.lastNameNorm &&
-                  target.firstNameNorm &&
-                  other.firstNameNorm
-                ) {
-                  if (
-                    isNicknameMatch(target.firstNameNorm, other.firstNameNorm)
-                  ) {
-                    seenPairs.add(pk);
-                    matchedImportIds.add(contactId);
-                    const pair = {
-                      idA: contactId,
-                      idB: other.id,
-                      matchType: "nickname",
-                      confidence: 0.88,
-                      reasoning: `Nickname match ("${target.firstNameNorm}" ↔ "${other.firstNameNorm}")`,
-                    };
-                    storeSuggestion(scope, pair, "pending");
-                    needsReview++;
-                  }
-                }
-              }
-            }
-
-            // Check email overlap
-            if (target.emailsNorm.length > 0) {
-              const placeholders = target.emailsNorm.map(() => "?").join(",");
-              const emailMatches = sqlite
-                .prepare(
-                  `
-              SELECT DISTINCT ce.contactId
-              FROM contact_emails ce
-              JOIN contacts c ON c.id = ce.contactId
-              WHERE LOWER(TRIM(ce.email)) IN (${placeholders})
-                AND ce.contactId != ?
-                AND c.ownerId = ?
-                AND c.isGhost = 0 AND (c.isArchived = 0 OR c.isArchived IS NULL) AND c.canonicalId IS NULL
-            `,
-                )
-                .all(...target.emailsNorm, contactId, scope.ownerId) as {
-                contactId: string;
-              }[];
-
-              for (const match of emailMatches) {
-                if (importedSet.has(match.contactId)) continue;
-                const pk = pairKey(contactId, match.contactId);
-                if (seenPairs.has(pk) || distinctPairs.has(pk)) continue;
-                seenPairs.add(pk);
-                matchedImportIds.add(contactId);
-
-                const pair = {
-                  idA: contactId,
-                  idB: match.contactId,
-                  matchType: "email",
-                  confidence: 0.99,
-                  reasoning: "Shared email address",
-                };
-
-                try {
-                  const rawA = contactRepo.hydrate(
-                    contactRepo.findOwned(scope, pair.idA),
-                  );
-                  const rawB = contactRepo.hydrate(
-                    contactRepo.findOwned(scope, pair.idB),
-                  );
-                  const scoreA = computePrimaryScore(scope, rawA);
-                  const scoreB = computePrimaryScore(scope, rawB);
-                  const [primaryId, duplicateId] =
-                    scoreA >= scoreB
-                      ? [pair.idA, pair.idB]
-                      : [pair.idB, pair.idA];
-
-                  dedupeService.softMergeContacts(
-                    scope,
-                    primaryId,
-                    duplicateId,
-                    pair.confidence,
-                    pair.reasoning,
-                    rid,
-                  );
-                  storeSuggestion(scope, pair, "auto_merged");
-                  autoMerged++;
-                } catch (err: unknown) {
-                  log.warn(
-                    "API",
-                    `[${rid}] Auto-merge failed, queued for review: ${getErrorMessage(err)}`,
-                  );
-                  storeSuggestion(scope, pair, "pending");
-                  needsReview++;
-                }
-              }
-            }
-
-            // Check phone overlap
-            if (target.phonesNorm.length > 0) {
-              const allPhones = sqlite
-                .prepare(
-                  `
-              SELECT cp.contactId, cp.phone FROM contact_phones cp
-              JOIN contacts c ON c.id = cp.contactId
-              WHERE cp.contactId != ? AND c.ownerId = ?
-                AND c.isGhost = 0 AND (c.isArchived = 0 OR c.isArchived IS NULL) AND c.canonicalId IS NULL
-            `,
-                )
-                .all(contactId, scope.ownerId) as {
-                contactId: string;
-                phone: string;
-              }[];
-
-              const targetPhoneSet = new Set(target.phonesNorm);
-              for (const row of allPhones) {
-                if (importedSet.has(row.contactId)) continue;
-                const norm = normalizePhone(row.phone);
-                if (norm && targetPhoneSet.has(norm)) {
-                  const pk = pairKey(contactId, row.contactId);
-                  if (seenPairs.has(pk) || distinctPairs.has(pk)) continue;
-                  seenPairs.add(pk);
-                  matchedImportIds.add(contactId);
-
-                  const pair = {
-                    idA: contactId,
-                    idB: row.contactId,
-                    matchType: "phone",
-                    confidence: 0.95,
-                    reasoning: "Shared phone number",
-                  };
-
-                  try {
-                    const rawA = contactRepo.hydrate(
-                      contactRepo.findOwned(scope, pair.idA),
-                    );
-                    const rawB = contactRepo.hydrate(
-                      contactRepo.findOwned(scope, pair.idB),
-                    );
-                    const scoreA = computePrimaryScore(scope, rawA);
-                    const scoreB = computePrimaryScore(scope, rawB);
-                    const [primaryId, duplicateId] =
-                      scoreA >= scoreB
-                        ? [pair.idA, pair.idB]
-                        : [pair.idB, pair.idA];
-
-                    dedupeService.softMergeContacts(
-                      scope,
-                      primaryId,
-                      duplicateId,
-                      pair.confidence,
-                      pair.reasoning,
-                      rid,
-                    );
-                    storeSuggestion(scope, pair, "auto_merged");
-                    autoMerged++;
-                  } catch (err: unknown) {
-                    log.warn(
-                      "API",
-                      `[${rid}] Auto-merge failed, queued for review: ${getErrorMessage(err)}`,
-                    );
-                    storeSuggestion(scope, pair, "pending");
-                    needsReview++;
-                  }
-                }
-              }
-            }
-
-            // Stream progress periodically
-            if (i > 0 && i % 50 === 0) {
-              send({
-                phase: "scanning",
-                message: `Checked ${i}/${createdIds.length} contacts…`,
-                autoMerged,
-                needsReview,
-              });
-            }
-          }
+              },
+            },
+          );
+          autoMerged = result.autoMerged;
+          needsReview = result.pending;
+          matchedImportIds = result.matchedIds;
 
           log.info(
             "API",
@@ -574,27 +336,28 @@ router.post(
                 `Background bulk embedding failed: ${getErrorMessage(err)}`,
               ),
             );
-            // Process incremental dedupe sequentially in the background to prevent lock saturation and CPU spikes
+            // One scan for the whole import, not one check per contact.
+            //
+            // The loop that was here called `incrementalDedupeCheck` once per
+            // created contact, and every one of those normalized the account's
+            // whole corpus and built a pass context of its own. Importing `n`
+            // contacts into a corpus of `m` cost about `n × m`, nearly all of
+            // it the same work done again. `runImportScan` builds the corpus
+            // once and matches every new contact against that.
             void (async () => {
               // Let bulk inserts and embedding tasks settle first.
               await new Promise((resolve) =>
                 setTimeout(resolve, IMPORT_SETTLE_MS),
               );
-              await ParallelQueue.process(createdIds, 1, async (cid) => {
-                const irid = `imp-${cid.slice(0, 8)}`;
-                try {
-                  await dedupeService.incrementalDedupeCheck(cid, irid);
-                } catch (err) {
-                  log.warn(
-                    "API",
-                    `Incremental dedupe for ${cid} failed: ${getErrorMessage(err)}`,
-                  );
-                }
-              });
+              await dedupeService.runImportScan(
+                scope,
+                createdIds,
+                `imp-${rid}`,
+              );
             })().catch((err) =>
               log.error(
                 "API",
-                `Bulk background dedupe queue crashed: ${getErrorMessage(err)}`,
+                `Bulk background dedupe scan crashed: ${getErrorMessage(err)}`,
               ),
             );
           },

--- a/server/services/dedupe/engine.ts
+++ b/server/services/dedupe/engine.ts
@@ -4,35 +4,23 @@ import { runWithContext } from "../../tenancy/requestContext.ts";
 import type { Scope } from "../../tenancy/scope.ts";
 import { log } from "../../utils/logger.ts";
 import { contactRepo } from "../../repositories/contactRepository.ts";
-import { normalizePhone, isNicknameMatch } from "../../utils/nlp/index.ts";
 import { dedupeQueue } from "./jobQueue.ts";
 import { buildPassContext } from "./context.ts";
 import {
   backfillOwnerEmbeddings,
   isEmbeddingAvailable,
   getEmbeddingCount,
-  getEmbedding,
-  findNearestNeighbors,
   clearOwnerEmbeddings,
   reEmbedStaleContacts,
 } from "./embeddings.ts";
 import {
-  normalizeContacts,
-  normalizeContactById,
-  scopeOfContact,
-} from "./normalization.ts";
-import { loadNegativeConstraints, pairKey } from "./blocking.ts";
-import {
-  computeMatchSignals,
-  computeCompositeScore,
-  classifyPair,
-  distanceToSimilarity,
-} from "./scoring.ts";
-import {
-  runDeterministicPass,
-  runFunnelPass,
-  buildScoringReasoning,
-} from "./passes.ts";
+  buildIncrementalCorpus,
+  findIncrementalPairs,
+  normalizeTarget,
+  type IncrementalCorpus,
+} from "./incremental.ts";
+import { scopeOfContact } from "./normalization.ts";
+import { runDeterministicPass, runFunnelPass } from "./passes.ts";
 import { buildClusters, computePrimaryScore } from "./clustering.ts";
 import {
   storeSuggestion,
@@ -41,13 +29,7 @@ import {
   clearAllPendingSuggestions,
 } from "./suggestions.ts";
 import { softMergeContacts, mergeContacts } from "./merging.ts";
-import type {
-  DedupeScanMode,
-  RawPair,
-  MatchType,
-  NormalizedContact,
-  ContactRow,
-} from "./types.ts";
+import type { DedupeScanMode, RawPair, MatchType } from "./types.ts";
 import { getErrorMessage } from "../../utils/helpers.ts";
 
 function resolveMode(mode: DedupeScanMode): "quick" | "deep" | "full" {
@@ -66,6 +48,79 @@ function resolveMode(mode: DedupeScanMode): "quick" | "deep" | "full" {
 }
 
 /**
+ * Persist the pairs one contact produced.
+ *
+ * Anything at or above the auto-merge threshold is merged now and recorded as
+ * `auto_merged`; everything else becomes a pending suggestion for somebody to
+ * look at. A merge that throws becomes a pending suggestion too, because the
+ * pair is still a pair even when the merge could not be completed.
+ *
+ * Returns what went where, so a batch can add up its own summary, and adds
+ * every merged-away contact to `corpus.retired` so later contacts in the same
+ * batch stop being offered a contact that is no longer there.
+ */
+function persistIncrementalPairs(
+  corpus: IncrementalCorpus,
+  pairs: RawPair[],
+  rid: string,
+  autoMergeThreshold: number,
+): { autoMerged: number; pending: number } {
+  const { scope } = corpus;
+  let autoMerged = 0;
+  let pending = 0;
+
+  const qualifying = pairs.filter((p) => p.confidence >= autoMergeThreshold);
+  for (const pair of pairs) {
+    if (pair.confidence >= autoMergeThreshold) continue;
+    storeSuggestion(scope, pair, "pending");
+    pending++;
+  }
+
+  if (qualifying.length === 0) return { autoMerged, pending };
+
+  const ids = [...new Set(qualifying.flatMap((p) => [p.idA, p.idB]))];
+  const hydrated = new Map(
+    contactRepo
+      .hydrateMany(contactRepo.findManyOwned(scope, ids))
+      .map((c) => [c.id, c]),
+  );
+
+  for (const pair of qualifying) {
+    try {
+      const rawA = hydrated.get(pair.idA);
+      const rawB = hydrated.get(pair.idB);
+      if (!rawA || !rawB) continue;
+
+      const scoreA = computePrimaryScore(scope, rawA);
+      const scoreB = computePrimaryScore(scope, rawB);
+      const [primaryId, duplicateId] =
+        scoreA >= scoreB ? [pair.idA, pair.idB] : [pair.idB, pair.idA];
+
+      dedupeService.softMergeContacts(
+        scope,
+        primaryId,
+        duplicateId,
+        pair.confidence,
+        pair.reasoning,
+        rid,
+      );
+      storeSuggestion(scope, pair, "auto_merged");
+      corpus.retired.add(duplicateId);
+      autoMerged++;
+    } catch (err: unknown) {
+      log.warn(
+        "DedupeService",
+        `[${rid}] Incremental auto-merge failed: ${getErrorMessage(err)}`,
+      );
+      storeSuggestion(scope, pair, "pending");
+      pending++;
+    }
+  }
+
+  return { autoMerged, pending };
+}
+
+/**
  * The body of one incremental check, inside the contact owner's context.
  *
  * Every read below names that owner: a duplicate of a contact can only be
@@ -79,9 +134,9 @@ async function runIncrementalCheck(
   autoMergeThreshold: number,
 ): Promise<void> {
   const t0 = Date.now();
-
   try {
-    const target = normalizeContactById(scope, contactId);
+    const corpus = buildIncrementalCorpus(scope, rid);
+    const target = normalizeTarget(corpus, contactId);
     if (!target) {
       log.debug(
         "DedupeService",
@@ -90,189 +145,7 @@ async function runIncrementalCheck(
       return;
     }
 
-    const distinctPairs = loadNegativeConstraints(scope);
-    const pairs: RawPair[] = [];
-    const seenPairs = new Set<string>();
-
-    if (target.emailsNorm.length > 0) {
-      const placeholders = target.emailsNorm.map(() => "?").join(",");
-      const emailMatches = sqlite
-        .prepare(
-          `
-          SELECT DISTINCT ce.contactId
-          FROM contact_emails ce
-          JOIN contacts c ON c.id = ce.contactId
-          WHERE c.ownerId = ?
-            AND LOWER(TRIM(ce.email)) IN (${placeholders})
-            AND ce.contactId != ?
-            AND c.isGhost = 0 AND (c.isArchived = 0 OR c.isArchived IS NULL) AND c.canonicalId IS NULL
-        `,
-        )
-        .all(scope.ownerId, ...target.emailsNorm, contactId) as {
-        contactId: string;
-      }[];
-
-      for (const match of emailMatches) {
-        const pk = pairKey(contactId, match.contactId);
-        if (!seenPairs.has(pk) && !distinctPairs.has(pk)) {
-          seenPairs.add(pk);
-          pairs.push({
-            idA: contactId,
-            idB: match.contactId,
-            matchType: "email",
-            confidence: 0.99,
-            reasoning: "Shared email address",
-          });
-        }
-      }
-    }
-
-    if (target.phonesNorm.length > 0) {
-      const allPhones = sqlite
-        .prepare(
-          `
-          SELECT cp.contactId, cp.phone FROM contact_phones cp
-          JOIN contacts c ON c.id = cp.contactId
-          WHERE c.ownerId = ? AND cp.contactId != ?
-            AND c.isGhost = 0 AND (c.isArchived = 0 OR c.isArchived IS NULL) AND c.canonicalId IS NULL
-        `,
-        )
-        .all(scope.ownerId, contactId) as {
-        contactId: string;
-        phone: string;
-      }[];
-
-      const targetPhoneSet = new Set(target.phonesNorm);
-      for (const row of allPhones) {
-        const norm = normalizePhone(row.phone);
-        if (norm && targetPhoneSet.has(norm)) {
-          const pk = pairKey(contactId, row.contactId);
-          if (!seenPairs.has(pk) && !distinctPairs.has(pk)) {
-            seenPairs.add(pk);
-            pairs.push({
-              idA: contactId,
-              idB: row.contactId,
-              matchType: "phone",
-              confidence: 0.99,
-              reasoning: "Shared phone number",
-            });
-          }
-        }
-      }
-    }
-
-    if (target.nameNorm) {
-      const allNormalized = normalizeContacts(scope);
-      const targetBlockKeys = new Set(target.blockKeys);
-
-      for (const other of allNormalized) {
-        if (other.id === contactId) continue;
-        const pk = pairKey(contactId, other.id);
-        if (seenPairs.has(pk) || distinctPairs.has(pk)) continue;
-
-        const sharesBlock = other.blockKeys.some((k) => targetBlockKeys.has(k));
-        if (!sharesBlock) continue;
-
-        if (target.nameNorm === other.nameNorm) {
-          seenPairs.add(pk);
-          const isCrossSource =
-            target.sources.length > 0 &&
-            other.sources.length > 0 &&
-            !target.sources.some((s) => other.sources.includes(s));
-          pairs.push({
-            idA: contactId,
-            idB: other.id,
-            matchType: isCrossSource ? "cross_source" : "name",
-            confidence: isCrossSource ? 0.95 : 0.92,
-            reasoning: isCrossSource
-              ? `Exact name match across different sources (${target.sources[0]} ↔ ${other.sources[0]})`
-              : "Exact name match",
-          });
-          continue;
-        }
-
-        if (
-          target.lastNameNorm &&
-          target.lastNameNorm === other.lastNameNorm &&
-          target.firstNameNorm &&
-          other.firstNameNorm
-        ) {
-          if (isNicknameMatch(target.firstNameNorm, other.firstNameNorm)) {
-            seenPairs.add(pk);
-            pairs.push({
-              idA: contactId,
-              idB: other.id,
-              matchType: "nickname",
-              confidence: 0.88,
-              reasoning: `Nickname match ("${target.firstNameNorm}" ↔ "${other.firstNameNorm}")`,
-            });
-          }
-        }
-      }
-    }
-
-    if (isEmbeddingAvailable()) {
-      try {
-        const queryVec = getEmbedding(contactId);
-        if (queryVec) {
-          const neighbors = findNearestNeighbors(scope, queryVec, 5, contactId);
-          const normalizedCache = new Map<string, NormalizedContact>();
-
-          const targetSimCtx = buildPassContext(scope, rid);
-
-          for (const neighbor of neighbors) {
-            const pk = pairKey(contactId, neighbor.contactId);
-            if (seenPairs.has(pk) || distinctPairs.has(pk)) continue;
-
-            if (!normalizedCache.has(neighbor.contactId)) {
-              const n = normalizeContactById(scope, neighbor.contactId);
-              if (n) normalizedCache.set(neighbor.contactId, n);
-            }
-            const otherNorm = normalizedCache.get(neighbor.contactId);
-            if (!otherNorm) continue;
-
-            const pairDistinct = distinctPairs.has(pk);
-            const signals = computeMatchSignals(
-              target,
-              otherNorm,
-              distanceToSimilarity(neighbor.distance),
-              pairDistinct,
-              targetSimCtx.socialUrlsByContact.get(target.id) ?? [],
-              targetSimCtx.socialUrlsByContact.get(otherNorm.id) ?? [],
-            );
-            const score = computeCompositeScore(signals);
-            const classification = classifyPair(score);
-
-            if (classification !== "discard") {
-              seenPairs.add(pk);
-              const rawA =
-                (contactRepo.findOwned(
-                  scope,
-                  contactId,
-                ) as ContactRow | null) ?? undefined;
-              const rawB =
-                (contactRepo.findOwned(
-                  scope,
-                  neighbor.contactId,
-                ) as ContactRow | null) ?? undefined;
-              pairs.push({
-                idA: contactId,
-                idB: neighbor.contactId,
-                matchType: "fuzzy",
-                confidence: score,
-                reasoning: buildScoringReasoning(signals, score, rawA, rawB),
-              });
-            }
-          }
-        }
-      } catch (err: unknown) {
-        log.debug(
-          "DedupeService",
-          `[${rid}] Incremental KNN failed: ${getErrorMessage(err)}`,
-        );
-      }
-    }
-
+    const pairs = findIncrementalPairs(corpus, contactId, target, new Set());
     if (pairs.length === 0) {
       log.debug(
         "DedupeService",
@@ -281,54 +154,7 @@ async function runIncrementalCheck(
       return;
     }
 
-    const qualifyingPairs = pairs.filter(
-      (p) => p.confidence >= autoMergeThreshold,
-    );
-    const pendingPairs = pairs.filter((p) => p.confidence < autoMergeThreshold);
-    for (const pair of pendingPairs) {
-      storeSuggestion(scope, pair, "pending");
-    }
-
-    if (qualifyingPairs.length > 0) {
-      const pairIds = [
-        ...new Set(qualifyingPairs.flatMap((p) => [p.idA, p.idB])),
-      ];
-      const pairHydratedMap = new Map(
-        contactRepo
-          .hydrateMany(contactRepo.findManyOwned(scope, pairIds))
-          .map((c) => [c.id, c]),
-      );
-
-      for (const pair of qualifyingPairs) {
-        try {
-          const rawA = pairHydratedMap.get(pair.idA);
-          const rawB = pairHydratedMap.get(pair.idB);
-          if (!rawA || !rawB) continue;
-
-          const scoreA = computePrimaryScore(scope, rawA);
-          const scoreB = computePrimaryScore(scope, rawB);
-          const [primaryId, duplicateId] =
-            scoreA >= scoreB ? [pair.idA, pair.idB] : [pair.idB, pair.idA];
-
-          dedupeService.softMergeContacts(
-            scope,
-            primaryId,
-            duplicateId,
-            pair.confidence,
-            pair.reasoning,
-            rid,
-          );
-          storeSuggestion(scope, pair, "auto_merged");
-        } catch (err: unknown) {
-          log.warn(
-            "DedupeService",
-            `[${rid}] Incremental auto-merge failed: ${getErrorMessage(err)}`,
-          );
-          storeSuggestion(scope, pair, "pending");
-        }
-      }
-    }
-
+    persistIncrementalPairs(corpus, pairs, rid, autoMergeThreshold);
     log.info(
       "DedupeService",
       `[${rid}] Incremental: ${pairs.length} match(es) for ${contactId} in ${Date.now() - t0}ms`,
@@ -643,6 +469,100 @@ export const dedupeService = {
       },
       () => runIncrementalCheck(scope, contactId, rid, autoMergeThreshold),
     );
+  },
+
+  /**
+   * Check a whole import against the account it landed in, in one pass.
+   *
+   * This replaces a loop that called `incrementalDedupeCheck` once per
+   * imported contact. Each of those calls normalized the entire corpus and
+   * built a whole pass context of its own, so importing `n` contacts into a
+   * corpus of `m` did about `n × m` work, almost all of it the same work
+   * repeated. The corpus is now built once and every new contact is matched
+   * against that one snapshot.
+   *
+   * The new contacts are the left side of every pair. Nothing compares two
+   * contacts that were both already there, which is what a full scan is for
+   * and what `POST /api/dedupe/scan` still does.
+   *
+   * It is NOT `runScan` with another mode, though the plan describes it that
+   * way. `runScan` takes the instance-wide run lock and clears every pending
+   * suggestion the account has before it writes its own. An import may do
+   * neither: it must not empty somebody's review queue, and it must not block
+   * or be blocked by a scan somebody asked for. What `runScan` and this share
+   * is the matching, not the lifecycle.
+   *
+   * Yields to the event loop between contacts. The per-contact work is
+   * synchronous and a large import would otherwise hold the thread for the
+   * whole batch, which on a shared instance is everybody else's requests.
+   */
+  async runImportScan(
+    scope: Scope,
+    contactIds: string[],
+    rid: string,
+    options: {
+      autoMergeThreshold?: number;
+      onProgress?: (checked: number, total: number) => void;
+    } = {},
+  ): Promise<{
+    autoMerged: number;
+    pending: number;
+    /** Imported contacts that matched something. The rest are new people. */
+    matchedIds: Set<string>;
+  }> {
+    const autoMergeThreshold = options.autoMergeThreshold ?? 0.93;
+    const matchedIds = new Set<string>();
+    let autoMerged = 0;
+    let pending = 0;
+
+    if (contactIds.length === 0) return { autoMerged, pending, matchedIds };
+
+    const t0 = Date.now();
+    const corpus = buildIncrementalCorpus(scope, rid);
+    const imported = new Set(contactIds);
+    // Shared across the batch, so a pair between two of the imported contacts
+    // is produced once rather than once from each end.
+    const seen = new Set<string>();
+
+    for (let i = 0; i < contactIds.length; i++) {
+      if (i > 0) await new Promise<void>((resolve) => setImmediate(resolve));
+
+      const contactId = contactIds[i];
+      try {
+        if (corpus.retired.has(contactId)) continue;
+        const target = normalizeTarget(corpus, contactId);
+        if (!target) continue;
+
+        const pairs = findIncrementalPairs(corpus, contactId, target, seen);
+        if (pairs.length === 0) continue;
+
+        for (const pair of pairs) {
+          matchedIds.add(pair.idA);
+          if (imported.has(pair.idB)) matchedIds.add(pair.idB);
+        }
+
+        const counts = persistIncrementalPairs(
+          corpus,
+          pairs,
+          rid,
+          autoMergeThreshold,
+        );
+        autoMerged += counts.autoMerged;
+        pending += counts.pending;
+      } catch (err: unknown) {
+        log.warn(
+          "DedupeService",
+          `[${rid}] Import scan failed for ${contactId}: ${getErrorMessage(err)}`,
+        );
+      }
+      options.onProgress?.(i + 1, contactIds.length);
+    }
+
+    log.info(
+      "DedupeService",
+      `[${rid}] Import scan: ${contactIds.length} new contacts against ${corpus.normalized.length} existing in ${Date.now() - t0}ms — ${autoMerged} auto-merged, ${pending} pending`,
+    );
+    return { autoMerged, pending, matchedIds };
   },
 
   seedDuplicates(scope: Scope) {

--- a/server/services/dedupe/incremental.ts
+++ b/server/services/dedupe/incremental.ts
@@ -1,0 +1,327 @@
+// =============================================================================
+// Incremental matching — one corpus, any number of new contacts
+// =============================================================================
+// Checking a newly written contact for duplicates means comparing it with
+// every other contact the same account owns. Most of that work does not
+// depend on which contact is being checked: normalizing the corpus, loading
+// the phone numbers, loading the pairs already marked as different people,
+// loading the social links. Doing it per contact is what made an import of
+// `n` contacts into a corpus of `m` cost about `n × m`.
+//
+// So it is split in two. `buildIncrementalCorpus` does the part that depends
+// on the account, once. `findIncrementalPairs` does the part that depends on
+// the contact, per contact. One contact created by hand builds the corpus and
+// uses it once; an import of four hundred builds it once and uses it four
+// hundred times.
+//
+// The matchers below are the ones that were inside the per-contact check, at
+// the confidences they had. This is a rearrangement of the work, not a change
+// to what counts as a duplicate, and `tests/integration/dedupe.import.test.ts`
+// is what holds that true.
+// =============================================================================
+
+import { sqlite } from "../../db.ts";
+import { log } from "../../utils/logger.ts";
+import { contactRepo } from "../../repositories/contactRepository.ts";
+import { isNicknameMatch } from "../../utils/nlp/index.ts";
+import { getErrorMessage } from "../../utils/helpers.ts";
+import {
+  findNearestNeighbors,
+  getEmbedding,
+  isEmbeddingAvailable,
+} from "./embeddings.ts";
+import { loadNegativeConstraints, pairKey } from "./blocking.ts";
+import { normalizeContactById, normalizeContacts } from "./normalization.ts";
+import {
+  classifyPair,
+  computeCompositeScore,
+  computeMatchSignals,
+  distanceToSimilarity,
+} from "./scoring.ts";
+import { buildScoringReasoning } from "./passes.ts";
+import type { Scope } from "../../tenancy/scope.ts";
+import type { ContactRow, NormalizedContact, RawPair } from "./types.ts";
+
+/** How many vector neighbours one new contact is compared with. */
+const KNN_LIMIT = 5;
+
+/**
+ * Everything an incremental check needs that belongs to the account rather
+ * than to the contact being checked.
+ */
+export interface IncrementalCorpus {
+  scope: Scope;
+  rid: string;
+  /** Pairs the account has already said are two different people. */
+  distinctPairs: Set<string>;
+  /** Every active contact, normalized. */
+  normalized: NormalizedContact[];
+  normalizedById: Map<string, NormalizedContact>;
+  /** Normalized phone number to the contacts that carry it. */
+  contactsByPhone: Map<string, string[]>;
+  /** Lowercased email to the contacts that carry it. */
+  contactsByEmail: Map<string, string[]>;
+  socialUrlsByContact: Map<string, string[]>;
+  /** True while the vector store can answer, checked once. */
+  embeddingsAvailable: boolean;
+  /**
+   * Contacts that stopped being candidates part way through the run.
+   *
+   * A batch merges as it goes, so a contact merged away by an earlier pair
+   * must not be offered to a later one. The snapshot above cannot know that,
+   * because it was taken before any of it happened.
+   */
+  retired: Set<string>;
+}
+
+/**
+ * Load and normalize one account, once.
+ *
+ * Five queries and one normalization pass. `normalizeContacts` is the
+ * expensive half and is the reason this function exists: it was called once
+ * per contact checked, and on a corpus of ten thousand that is a second of
+ * work repeated for every row of the import.
+ */
+export function buildIncrementalCorpus(
+  scope: Scope,
+  rid: string,
+): IncrementalCorpus {
+  const t0 = Date.now();
+
+  const normalized = normalizeContacts(scope);
+  const normalizedById = new Map(normalized.map((n) => [n.id, n]));
+
+  // Both maps are built from the normalized rows rather than from their own
+  // queries, so a contact that is a candidate by phone is a contact the name
+  // matcher can also see. Two sets that disagreed would produce pairs whose
+  // other half has no normalized record, which the scorer cannot use.
+  const contactsByPhone = new Map<string, string[]>();
+  const contactsByEmail = new Map<string, string[]>();
+  for (const contact of normalized) {
+    for (const phone of contact.phonesNorm) {
+      if (!contactsByPhone.has(phone)) contactsByPhone.set(phone, []);
+      contactsByPhone.get(phone)!.push(contact.id);
+    }
+    for (const email of contact.emailsNorm) {
+      if (!contactsByEmail.has(email)) contactsByEmail.set(email, []);
+      contactsByEmail.get(email)!.push(contact.id);
+    }
+  }
+
+  const socialUrlsByContact = new Map<string, string[]>();
+  const socialRows = sqlite
+    .prepare(
+      `SELECT sl.contactId, LOWER(TRIM(sl.url)) AS url FROM contact_social_links sl
+       JOIN contacts c ON c.id = sl.contactId WHERE c.ownerId = ?`,
+    )
+    .all(scope.ownerId) as { contactId: string; url: string }[];
+  for (const row of socialRows) {
+    if (!socialUrlsByContact.has(row.contactId)) {
+      socialUrlsByContact.set(row.contactId, []);
+    }
+    socialUrlsByContact.get(row.contactId)!.push(row.url);
+  }
+
+  const corpus: IncrementalCorpus = {
+    scope,
+    rid,
+    distinctPairs: loadNegativeConstraints(scope),
+    normalized,
+    normalizedById,
+    contactsByPhone,
+    contactsByEmail,
+    socialUrlsByContact,
+    embeddingsAvailable: isEmbeddingAvailable(),
+    retired: new Set(),
+  };
+
+  log.debug(
+    "DedupeService",
+    `[${rid}] Incremental corpus built in ${Date.now() - t0}ms: ${normalized.length} contacts, ${corpus.distinctPairs.size} negative constraints`,
+  );
+  return corpus;
+}
+
+/**
+ * The contact to compare against the corpus.
+ *
+ * Read through `normalizeContactById` even when the corpus already holds a
+ * record for it. The two builders agree on every field the matchers read, but
+ * they can order `sources` differently, and that string appears in the
+ * reasoning a cross-source match writes. Five small indexed queries per new
+ * contact is not the cost this story is about.
+ *
+ * `normalizeContactById` does not filter out ghosts or archived contacts: the
+ * caller asked about this specific contact. The corpus on the other side is
+ * active contacts only.
+ */
+export function normalizeTarget(
+  corpus: IncrementalCorpus,
+  contactId: string,
+): NormalizedContact | null {
+  return normalizeContactById(corpus.scope, contactId);
+}
+
+/** Whether this contact can still be one half of a pair. */
+function isCandidate(
+  corpus: IncrementalCorpus,
+  contactId: string,
+  targetId: string,
+  seen: Set<string>,
+): boolean {
+  if (contactId === targetId) return false;
+  if (corpus.retired.has(contactId)) return false;
+  const pk = pairKey(targetId, contactId);
+  return !seen.has(pk) && !corpus.distinctPairs.has(pk);
+}
+
+/**
+ * Every duplicate of one contact, inside its own account.
+ *
+ * Four matchers in order of certainty: a shared email address, a shared phone
+ * number, a name that matches exactly or through a nickname, and a vector
+ * neighbour that scores high enough on the full signal set. Each one takes
+ * the first claim on a pair, so a contact that shares an email is reported as
+ * an email match and never scored a second time as a fuzzy one.
+ *
+ * `seen` is passed in rather than created here. Across a batch it is shared,
+ * so a pair between two newly imported contacts is produced once by whichever
+ * of them is reached first, instead of twice in opposite orders.
+ */
+export function findIncrementalPairs(
+  corpus: IncrementalCorpus,
+  contactId: string,
+  target: NormalizedContact,
+  seen: Set<string>,
+): RawPair[] {
+  const pairs: RawPair[] = [];
+
+  const claim = (otherId: string, pair: Omit<RawPair, "idA" | "idB">): void => {
+    seen.add(pairKey(contactId, otherId));
+    pairs.push({ idA: contactId, idB: otherId, ...pair });
+  };
+
+  // 1. A shared email address.
+  for (const email of target.emailsNorm) {
+    for (const otherId of corpus.contactsByEmail.get(email) ?? []) {
+      if (!isCandidate(corpus, otherId, contactId, seen)) continue;
+      claim(otherId, {
+        matchType: "email",
+        confidence: 0.99,
+        reasoning: "Shared email address",
+      });
+    }
+  }
+
+  // 2. A shared phone number.
+  for (const phone of target.phonesNorm) {
+    for (const otherId of corpus.contactsByPhone.get(phone) ?? []) {
+      if (!isCandidate(corpus, otherId, contactId, seen)) continue;
+      claim(otherId, {
+        matchType: "phone",
+        confidence: 0.99,
+        reasoning: "Shared phone number",
+      });
+    }
+  }
+
+  // 3. The same name, or a nickname of it. Blocked on the shared keys, so
+  //    this is a scan of the corpus and not a comparison with all of it.
+  if (target.nameNorm) {
+    const targetBlockKeys = new Set(target.blockKeys);
+    for (const other of corpus.normalized) {
+      if (!isCandidate(corpus, other.id, contactId, seen)) continue;
+      if (!other.blockKeys.some((key) => targetBlockKeys.has(key))) continue;
+
+      if (target.nameNorm === other.nameNorm) {
+        const isCrossSource =
+          target.sources.length > 0 &&
+          other.sources.length > 0 &&
+          !target.sources.some((s) => other.sources.includes(s));
+        claim(other.id, {
+          matchType: isCrossSource ? "cross_source" : "name",
+          confidence: isCrossSource ? 0.95 : 0.92,
+          reasoning: isCrossSource
+            ? `Exact name match across different sources (${target.sources[0]} ↔ ${other.sources[0]})`
+            : "Exact name match",
+        });
+        continue;
+      }
+
+      if (
+        target.lastNameNorm &&
+        target.lastNameNorm === other.lastNameNorm &&
+        target.firstNameNorm &&
+        other.firstNameNorm &&
+        isNicknameMatch(target.firstNameNorm, other.firstNameNorm)
+      ) {
+        claim(other.id, {
+          matchType: "nickname",
+          confidence: 0.88,
+          reasoning: `Nickname match ("${target.firstNameNorm}" ↔ "${other.firstNameNorm}")`,
+        });
+      }
+    }
+  }
+
+  // 4. Vector neighbours, scored on the full signal set.
+  if (corpus.embeddingsAvailable) {
+    try {
+      const queryVector = getEmbedding(contactId);
+      const neighbors = queryVector
+        ? findNearestNeighbors(corpus.scope, queryVector, KNN_LIMIT, contactId)
+        : [];
+
+      for (const neighbor of neighbors) {
+        if (!isCandidate(corpus, neighbor.contactId, contactId, seen)) continue;
+        // A vector can outlive its contact's place in the corpus: nothing
+        // removes the row when a contact is archived, so the KNN still
+        // answers with it while every other matcher here has stopped. The
+        // fallback keeps that pair reachable, which is what the per-contact
+        // check did. It is arguably wrong to suggest merging with a contact
+        // somebody archived, and it is not this change's to fix.
+        const other =
+          corpus.normalizedById.get(neighbor.contactId) ??
+          normalizeContactById(corpus.scope, neighbor.contactId);
+        if (!other) continue;
+
+        const signals = computeMatchSignals(
+          target,
+          other,
+          distanceToSimilarity(neighbor.distance),
+          // Never distinct. A pair the account marked as two different people
+          // was dropped by `isCandidate` above, so the flag could only ever
+          // be false by the time the scorer saw it.
+          false,
+          corpus.socialUrlsByContact.get(target.id) ?? [],
+          corpus.socialUrlsByContact.get(other.id) ?? [],
+        );
+        const score = computeCompositeScore(signals);
+        if (classifyPair(score) === "discard") continue;
+
+        const rawA =
+          (contactRepo.findOwned(
+            corpus.scope,
+            contactId,
+          ) as ContactRow | null) ?? undefined;
+        const rawB =
+          (contactRepo.findOwned(
+            corpus.scope,
+            neighbor.contactId,
+          ) as ContactRow | null) ?? undefined;
+        claim(neighbor.contactId, {
+          matchType: "fuzzy",
+          confidence: score,
+          reasoning: buildScoringReasoning(signals, score, rawA, rawB),
+        });
+      }
+    } catch (err: unknown) {
+      log.debug(
+        "DedupeService",
+        `[${corpus.rid}] Incremental KNN failed for ${contactId}: ${getErrorMessage(err)}`,
+      );
+    }
+  }
+
+  return pairs;
+}

--- a/tests/integration/dedupe.import.test.ts
+++ b/tests/integration/dedupe.import.test.ts
@@ -1,0 +1,461 @@
+// =============================================================================
+// Integration Tests — one scan after a bulk import
+// =============================================================================
+// The import used to check each new contact on its own, and each of those
+// checks normalized the whole account and built a whole pass context. An
+// import of `n` contacts into a corpus of `m` did about `n × m` work, and
+// almost all of it was the same work done again.
+//
+// Two things have to hold for the replacement to be worth having.
+//
+// 1. IT COSTS ONE PASS. The corpus is normalized once per import, whatever
+//    the size of the import. This is asserted by counting, not by timing, so
+//    it cannot pass on a fast machine and fail on a slow one. The wall clock
+//    test at the end is a second opinion with a deliberately loose bound.
+//
+// 2. IT FINDS THE SAME DUPLICATES. A rearrangement of the work that quietly
+//    changed what counts as a duplicate would be a much worse bug than the
+//    slowness it fixed. Each matcher has a case below, at the confidence it
+//    is supposed to carry.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import request from "supertest";
+
+// Counting wrappers around the two corpus-wide loads. Both stay real: what is
+// being measured is how often they are called, and a stub would measure the
+// stub.
+const calls = vi.hoisted(() => ({ normalizeContacts: 0, buildPassContext: 0 }));
+
+vi.mock(
+  "../../server/services/dedupe/normalization.ts",
+  async (importActual) => {
+    const actual =
+      await importActual<
+        typeof import("../../server/services/dedupe/normalization.ts")
+      >();
+    return {
+      ...actual,
+      normalizeContacts: (
+        ...args: Parameters<typeof actual.normalizeContacts>
+      ) => {
+        calls.normalizeContacts++;
+        return actual.normalizeContacts(...args);
+      },
+    };
+  },
+);
+
+vi.mock("../../server/services/dedupe/context.ts", async (importActual) => {
+  const actual =
+    await importActual<
+      typeof import("../../server/services/dedupe/context.ts")
+    >();
+  return {
+    ...actual,
+    buildPassContext: (...args: Parameters<typeof actual.buildPassContext>) => {
+      calls.buildPassContext++;
+      return actual.buildPassContext(...args);
+    },
+  };
+});
+
+const { makeTestApp } = await import("./helpers.ts");
+const { sqlite, ensureLocalOwner } = await import("../../server/db.ts");
+const { scopeForOwnerId } = await import("../../server/tenancy/scope.ts");
+const { contactService } =
+  await import("../../server/services/contactService.ts");
+const { dedupeService } = await import("../../server/services/dedupe/index.ts");
+
+const app = makeTestApp();
+const scope = scopeForOwnerId(ensureLocalOwner());
+
+interface SuggestionRow {
+  contactIdA: string;
+  contactIdB: string;
+  matchType: string;
+  confidence: number;
+  status: string;
+}
+
+function suggestions(): SuggestionRow[] {
+  return sqlite
+    .prepare(
+      `SELECT contactIdA, contactIdB, matchType, confidence, status
+         FROM dedupe_suggestions WHERE ownerId = ?
+        ORDER BY confidence DESC, matchType`,
+    )
+    .all(scope.ownerId) as SuggestionRow[];
+}
+
+function canonicalIdOf(contactId: string): string | null {
+  const row = sqlite
+    .prepare("SELECT canonicalId FROM contacts WHERE id = ?")
+    .get(contactId) as { canonicalId: string | null } | undefined;
+  return row?.canonicalId ?? null;
+}
+
+/** Write contacts the way an import does, and return their ids. */
+async function seed(
+  contacts: Parameters<typeof contactService.bulkCreateContacts>[1],
+): Promise<string[]> {
+  const { createdIds } = await contactService.bulkCreateContacts(
+    scope,
+    contacts,
+  );
+  return createdIds;
+}
+
+/** Empty every table this file writes to, between tests. */
+function reset(): void {
+  sqlite.exec("DELETE FROM dedupe_suggestions");
+  sqlite.exec("DELETE FROM dedupe_exclusions");
+  sqlite.exec("DELETE FROM dedupe_merge_log");
+  sqlite.exec("DELETE FROM contacts");
+  calls.normalizeContacts = 0;
+  calls.buildPassContext = 0;
+}
+
+beforeEach(() => reset());
+
+describe("dedupeService.runImportScan, the cost", () => {
+  it("normalizes the corpus once for an import of one", async () => {
+    await seed([{ name: "Existing Person" }]);
+    const imported = await seed([{ name: "New Person" }]);
+    calls.normalizeContacts = 0;
+
+    await dedupeService.runImportScan(scope, imported, "test");
+
+    expect(calls.normalizeContacts).toBe(1);
+  });
+
+  it("normalizes the corpus once for an import of forty", async () => {
+    await seed(
+      Array.from({ length: 60 }, (_, i) => ({ name: `Existing ${i}` })),
+    );
+    const imported = await seed(
+      Array.from({ length: 40 }, (_, i) => ({ name: `Imported ${i}` })),
+    );
+    calls.normalizeContacts = 0;
+
+    await dedupeService.runImportScan(scope, imported, "test");
+
+    // The number that matters. Forty before this change.
+    expect(calls.normalizeContacts).toBe(1);
+  });
+
+  it("never builds a scan pass context", async () => {
+    await seed([{ name: "Existing Person" }]);
+    const imported = await seed(
+      Array.from({ length: 10 }, (_, i) => ({ name: `Imported ${i}` })),
+    );
+    calls.buildPassContext = 0;
+
+    await dedupeService.runImportScan(scope, imported, "test");
+
+    // `buildPassContext` loads and normalizes the account twice over, and the
+    // per-contact check called it once per contact for one map out of it.
+    expect(calls.buildPassContext).toBe(0);
+  });
+
+  it("does nothing at all for an empty import", async () => {
+    await seed([{ name: "Existing Person" }]);
+    calls.normalizeContacts = 0;
+
+    const result = await dedupeService.runImportScan(scope, [], "test");
+
+    expect(calls.normalizeContacts).toBe(0);
+    expect(result).toEqual({
+      autoMerged: 0,
+      pending: 0,
+      matchedIds: new Set(),
+    });
+  });
+});
+
+describe("dedupeService.runImportScan, what it finds", () => {
+  it("auto-merges an imported contact that shares an email address", async () => {
+    const [existing] = await seed([
+      { name: "Margaret Ellington", emails: ["peggy@example.com"] },
+    ]);
+    const [imported] = await seed([
+      { name: "Peggy Ellington", emails: ["peggy@example.com"] },
+    ]);
+
+    const result = await dedupeService.runImportScan(scope, [imported], "test");
+
+    expect(result.autoMerged).toBe(1);
+    expect(result.pending).toBe(0);
+    expect(result.matchedIds).toEqual(new Set([imported]));
+
+    const rows = suggestions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].matchType).toBe("email");
+    expect(rows[0].confidence).toBeCloseTo(0.99, 5);
+    expect(rows[0].status).toBe("auto_merged");
+
+    // One of the two now points at the other. Which one is whichever carries
+    // more, and that is the merge service's decision, not this one's.
+    const merged = [existing, imported].filter((id) => canonicalIdOf(id));
+    expect(merged).toHaveLength(1);
+  });
+
+  it("auto-merges an imported contact that shares a phone number", async () => {
+    await seed([{ name: "Robert Castellanos", phones: ["+34 555 867 5309"] }]);
+    const [imported] = await seed([
+      { name: "Bob Castellanos", phones: ["555-867-5309"] },
+    ]);
+
+    const result = await dedupeService.runImportScan(scope, [imported], "test");
+
+    expect(result.autoMerged).toBe(1);
+    const rows = suggestions();
+    expect(rows[0].matchType).toBe("phone");
+    expect(rows[0].confidence).toBeCloseTo(0.99, 5);
+  });
+
+  it("suggests an exact name match rather than merging it", async () => {
+    await seed([{ name: "Jonathan Smith", company: "Northwind" }]);
+    const [imported] = await seed([
+      { name: "Jonathan Smith", company: "Ferrous Works" },
+    ]);
+
+    const result = await dedupeService.runImportScan(scope, [imported], "test");
+
+    // 0.92 is under the 0.93 auto-merge threshold on purpose: two people can
+    // share a name, and merging them would lose one of them.
+    expect(result.autoMerged).toBe(0);
+    expect(result.pending).toBe(1);
+    const rows = suggestions();
+    expect(rows[0].matchType).toBe("name");
+    expect(rows[0].confidence).toBeCloseTo(0.92, 5);
+    expect(rows[0].status).toBe("pending");
+    expect(canonicalIdOf(imported)).toBeNull();
+  });
+
+  it("suggests a nickname match", async () => {
+    await seed([{ name: "Robert Nakamura" }]);
+    const [imported] = await seed([{ name: "Bob Nakamura" }]);
+
+    const result = await dedupeService.runImportScan(scope, [imported], "test");
+
+    expect(result.pending).toBe(1);
+    const rows = suggestions();
+    expect(rows[0].matchType).toBe("nickname");
+    expect(rows[0].confidence).toBeCloseTo(0.88, 5);
+  });
+
+  it("finds two duplicates inside the same import", async () => {
+    const imported = await seed([
+      { name: "Elena Vasquez", emails: ["elena@example.com"] },
+      { name: "Elena Vazquez", emails: ["elena@example.com"] },
+    ]);
+
+    const result = await dedupeService.runImportScan(scope, imported, "test");
+
+    // A spreadsheet with the same person on two rows is the ordinary case,
+    // and the pair is reported once rather than once from each end.
+    expect(result.autoMerged).toBe(1);
+    expect(suggestions()).toHaveLength(1);
+    expect(result.matchedIds).toEqual(new Set(imported));
+  });
+
+  it("leaves a pair the account has already separated alone", async () => {
+    const [existing] = await seed([{ name: "Jonathan Smith" }]);
+    const [imported] = await seed([{ name: "Jonathan Smith" }]);
+    const [a, b] =
+      existing < imported ? [existing, imported] : [imported, existing];
+    sqlite
+      .prepare(
+        `INSERT INTO dedupe_exclusions (contactIdA, contactIdB, ownerId)
+         VALUES (?, ?, ?)`,
+      )
+      .run(a, b, scope.ownerId);
+
+    const result = await dedupeService.runImportScan(scope, [imported], "test");
+
+    expect(result.pending).toBe(0);
+    expect(suggestions()).toHaveLength(0);
+  });
+
+  it("reports nothing for an import with no duplicates in it", async () => {
+    await seed([{ name: "Hanna Virtanen" }, { name: "Diego Ferreira" }]);
+    const imported = await seed([
+      { name: "Grace Okonkwo" },
+      { name: "Felix Bergstrom" },
+    ]);
+
+    const result = await dedupeService.runImportScan(scope, imported, "test");
+
+    expect(result).toEqual({
+      autoMerged: 0,
+      pending: 0,
+      matchedIds: new Set(),
+    });
+    expect(suggestions()).toHaveLength(0);
+  });
+
+  it("points every merge at the survivor rather than building a chain", async () => {
+    const [existing] = await seed([
+      { name: "Ravi Krishnan", emails: ["ravi@example.com"] },
+    ]);
+    const imported = await seed([
+      { name: "Ravi Krishnan", emails: ["ravi@example.com"] },
+      { name: "R Krishnan", emails: ["ravi@example.com"] },
+    ]);
+    const all = [existing, ...imported];
+
+    const result = await dedupeService.runImportScan(scope, imported, "test");
+
+    // Three rows for one person collapse to one, and the other two point
+    // straight at it. A chain, where one merged contact points at another
+    // merged contact, has no reader: every screen follows a single hop.
+    expect(result.autoMerged).toBe(2);
+    const survivors = all.filter((id) => canonicalIdOf(id) === null);
+    expect(survivors).toHaveLength(1);
+    for (const id of all.filter((c) => c !== survivors[0])) {
+      expect(canonicalIdOf(id)).toBe(survivors[0]);
+    }
+  });
+
+  it("never suggests a contact that was merged away earlier in the same import", async () => {
+    await seed([{ name: "Elena Vasquez", emails: ["elena@example.com"] }]);
+    // The first imported row merges with the existing one on the shared
+    // email. The second matches both of them by name, at a confidence that
+    // makes a suggestion rather than a merge — and a suggestion naming the
+    // contact that just disappeared is a row in somebody's review queue that
+    // offers to merge a contact with nothing.
+    const imported = await seed([
+      { name: "Elena Vasquez", emails: ["elena@example.com"] },
+      { name: "Elena Vasquez" },
+    ]);
+
+    await dedupeService.runImportScan(scope, imported, "test");
+
+    const pending = suggestions().filter((row) => row.status === "pending");
+    expect(pending.length).toBeGreaterThan(0);
+    for (const row of pending) {
+      expect(canonicalIdOf(row.contactIdA)).toBeNull();
+      expect(canonicalIdOf(row.contactIdB)).toBeNull();
+    }
+  });
+
+  it("writes one suggestion for a pair, not one from each end", async () => {
+    // Two rows, same name, nothing else. The name match is under the
+    // auto-merge threshold, so neither contact disappears and both are still
+    // candidates when the second one is checked. Whichever is reached first
+    // claims the pair.
+    const imported = await seed([
+      { name: "Tomas Lindqvist" },
+      { name: "Tomas Lindqvist" },
+    ]);
+
+    const result = await dedupeService.runImportScan(scope, imported, "test");
+
+    expect(result.pending).toBe(1);
+    expect(suggestions()).toHaveLength(1);
+  });
+});
+
+describe("POST /api/contacts/bulk with a stream", () => {
+  /** The terminal `done` event of an SSE import. */
+  async function streamImport(body: object[]): Promise<{
+    imported: number;
+    autoMerged: number;
+    needsReview: number;
+    newUnique: number;
+  }> {
+    const res = await request(app)
+      .post("/api/contacts/bulk")
+      .set("Accept", "text/event-stream")
+      .send(body);
+    expect(res.status).toBe(200);
+    const summary = res.text
+      .split("\n\n")
+      .filter(Boolean)
+      .map((chunk) => JSON.parse(chunk.replace(/^data: /, "")))
+      .find((event) => event.done);
+    return summary.summary;
+  }
+
+  it("reports the duplicates the shared scan found", async () => {
+    await seed([{ name: "Margaret Ellington", emails: ["peggy@example.com"] }]);
+
+    const summary = await streamImport([
+      { name: "Peggy Ellington", emails: ["peggy@example.com"] },
+      { name: "Somebody Else" },
+    ]);
+
+    expect(summary).toEqual({
+      imported: 2,
+      autoMerged: 1,
+      needsReview: 0,
+      newUnique: 1,
+    });
+  });
+
+  it("finds a nickname, which the matching it used to carry could not", async () => {
+    await seed([{ name: "Robert Nakamura" }]);
+
+    // The streaming branch had its own two hundred and fifty lines of
+    // matching: exact name, email, phone, and nothing else. The same import
+    // through the JSON branch found this and the stream did not, so what
+    // counted as a duplicate depended on the Accept header.
+    const summary = await streamImport([{ name: "Bob Nakamura" }]);
+
+    expect(summary.needsReview).toBe(1);
+    expect(suggestions()[0].matchType).toBe("nickname");
+  });
+
+  it("asks about two people with the same name instead of merging them", async () => {
+    const [existing] = await seed([
+      { name: "David Lee", company: "Northwind Logistics" },
+    ]);
+
+    const summary = await streamImport([
+      { name: "David Lee", company: "Meridian Health Trust" },
+    ]);
+
+    // A DELIBERATE CHANGE. The matching this branch used to carry scored an
+    // exact name match at 0.95 and merged it, on the reasoning that a name
+    // that already exists is "almost certainly a duplicate". Two people can
+    // share a name, and a merge is how one of them stops existing. The other
+    // import path has always scored it 0.92 and asked, and now both do.
+    expect(summary.autoMerged).toBe(0);
+    expect(summary.needsReview).toBe(1);
+    expect(canonicalIdOf(existing)).toBeNull();
+    expect(suggestions()[0].confidence).toBeCloseTo(0.92, 5);
+  });
+});
+
+describe("dedupeService.runImportScan, the wall clock", () => {
+  it("imports one hundred contacts into a corpus of four hundred in under five seconds", async () => {
+    await seed(
+      Array.from({ length: 400 }, (_, i) => ({
+        name: `Existing Person ${i}`,
+        company: `Company ${i % 40}`,
+        emails: [`existing${i}@example.com`],
+      })),
+    );
+    const imported = await seed(
+      Array.from({ length: 100 }, (_, i) => ({
+        name: `Imported Person ${i}`,
+        company: `Company ${i % 40}`,
+        emails: [`imported${i}@example.com`],
+      })),
+    );
+    calls.normalizeContacts = 0;
+
+    const started = Date.now();
+    await dedupeService.runImportScan(scope, imported, "test");
+    const elapsed = Date.now() - started;
+
+    // The bound is loose on purpose. What it is really guarding is the shape:
+    // one hundred normalizations of a five hundred contact corpus is seconds
+    // of work, and one is milliseconds, so a return to the per-contact loop
+    // would fail this by a wide margin rather than by a hair. A slow machine
+    // does not get near it.
+    expect(calls.normalizeContacts).toBe(1);
+    expect(elapsed).toBeLessThan(5_000);
+  }, 60_000);
+});

--- a/tests/integration/tenancy.importTail.test.ts
+++ b/tests/integration/tenancy.importTail.test.ts
@@ -2,9 +2,10 @@
 // Integration Tests — the bulk-import tail keeps the importer's scope
 // =============================================================================
 // The non-stream import answers the client and then keeps working: it embeds
-// the new contacts, waits for the writes to settle, and runs a dedupe check
-// over each one. That second half starts from a timer, long after the response
-// has been sent, so nothing about the request is still in scope by then.
+// the new contacts, waits for the writes to settle, and runs one dedupe scan
+// over all of them. That second half starts from a timer, long after the
+// response has been sent, so nothing about the request is still in scope by
+// then.
 //
 // Both halves are wrapped in runWithContext with the scope captured at the top
 // of the handler. This file reads the owner off the AI invocation rows they
@@ -60,7 +61,11 @@ vi.mock("../../server/services/dedupe/index.ts", async (importActual) => {
     ...actual,
     dedupeService: {
       ...actual.dedupeService,
-      incrementalDedupeCheck: async () => {
+      // The import tail runs one scan for the whole batch rather than one
+      // check per contact, so this is the entry point that stands in for the
+      // real matching now. What the test is about is unchanged: whichever
+      // account the tail runs for is the account its rows name.
+      runImportScan: async () => {
         recordInvocation({
           operation: "parse",
           model: "mock",
@@ -69,6 +74,7 @@ vi.mock("../../server/services/dedupe/index.ts", async (importActual) => {
           cached: false,
           description: "import tail: dedupe",
         });
+        return { autoMerged: 0, pending: 0, matchedIds: new Set<string>() };
       },
     },
   };


### PR DESCRIPTION
A bulk import checked each new contact for duplicates on its own, and every one of those checks normalized the whole account. Importing 1,000 contacts into a corpus of 10,000 took 113 seconds of mostly repeated work. It now takes 1.8 seconds.

This is quality story S3 from [15-additional-v2-features.md](docs/multi-tenant-plan/15-additional-v2-features.md) section 7.

## The cost

`incrementalDedupeCheck` calls `normalizeContacts` for the name matcher and `buildPassContext` for the social links, and `buildPassContext` normalizes the corpus a second time. The import called it once per created contact, so an import of `n` into a corpus of `m` cost about `n × m`.

`dedupeService.runImportScan` builds that corpus once and matches every new contact against the one snapshot. The new contacts are the left side of every pair, so nothing compares two contacts that were both already there, which is what a full scan is for.

Measured on this machine with the same fixture, the old code run from a worktree at `origin/v2.0`:

| Corpus | Imported | Before | After |
| ------ | -------- | ------ | ----- |
| 500 | 100 | 583 ms | 33 ms |
| 2,000 | 200 | 4,206 ms | 116 ms |
| 5,000 | 400 | 20,939 ms | 390 ms |
| 10,000 | 1,000 | 113,172 ms | 1,773 ms |

**The gap widens with the corpus**, which is the shape changing rather than a constant factor coming off.

## The two import paths now agree

The streaming import had its own matching, written out in the route: about **250 lines** that found exact names, emails and phone numbers and nothing else. The JSON import ran the stronger check. So what counted as a duplicate depended on whether the client sent `Accept: text/event-stream`.

Both now call the same scan. A streaming import gains the nickname and profile matchers it never had, and `server/routes/contacts.ts` loses 280 lines and ten imports it only needed for dedupe.

### One behaviour changed on purpose

**An imported contact whose name already exists is now a suggestion to review, not an automatic merge.** The streaming branch scored an exact name match at 0.95, above the 0.93 auto-merge threshold, with a comment reasoning that a name that already exists is "almost certainly a duplicate". The other import path has always scored it 0.92 and asked. Two people can share a name, and a merge is how one of them stops existing, so both paths now ask. `tests/integration/dedupe.import.test.ts` pins it at the HTTP boundary.

Two further differences, both deliberate:

- **Duplicates inside one import are found.** The streaming branch skipped any pair where both halves came from the same batch, so the same person on two rows of one spreadsheet went in twice. The JSON path always caught it.
- **A contact merged away part way through the scan stops being a candidate.** Without that, a later contact in the same import can be offered it, and a below-threshold pair would be filed as a suggestion to merge with a contact that is no longer there.

## Not a mode of `runScan`

The plan writes the entry point as `runScan(scope, "incremental-set", ids)`. It is `dedupeService.runImportScan` instead, and the reason is in the code: **`runScan` takes the instance-wide run lock and calls `clearAllPendingSuggestions` before it writes its own.** An import may do neither. It must not empty somebody's review queue, and it must not block or be blocked by a scan somebody asked for. What the two share is the matching, not the lifecycle.

## Testing

`tests/integration/dedupe.import.test.ts`, 18 tests in three groups.

- **The cost is asserted by counting, not by timing.** `normalizeContacts` is called exactly once per import whether the import is one contact or forty, and `buildPassContext` is never called at all. Those cannot pass on a fast machine and fail on a slow one.
- **What it finds has a case per matcher**, at the confidence that matcher is supposed to carry: email 0.99 and merged, phone 0.99 and merged, exact name 0.92 and asked, nickname 0.88 and asked. Plus a pair the account has already separated, which stays separated.
- **The wall clock test** imports 100 into 400 with a deliberately loose five second bound. It is a second opinion, not the gate.

Every new test was checked by breaking the code it covers:

| Change | Result |
| ------ | ------ |
| The corpus rebuilt per contact, the bug this fixes | 3 failures |
| The `retired` set ignored | 1 failure |
| The shared `seen` set made per-contact | 1 failure |
| Nickname confidence moved from 0.88 to 0.90 | 1 failure |
| Negative constraints ignored | 1 failure |

The first two attempts at the `retired` and `seen` tests **passed against the broken code**, because a hydration guard further down silently dropped the bad pair. Both were rewritten to assert the case where the guard does not reach: a below-threshold pair, which is stored as a suggestion with no hydration at all.

```
npm run lint          tenant-lint: clean for 1 glob(s): server/**/*.ts
npm run format:check  All matched files use Prettier code style!
npm test               Test Files  77 passed (77)
                            Tests  1241 passed (1241)
npm run build         ✓ built in 331ms
```
