### PR TITLE
feat(backups): verify every snapshot and show the answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than showing a progress bar at zero. `GET /api/dedupe/active` gained a
   `queued` field, which is the only way a reloaded page can tell a booked scan
   from one that has hung.
+- **Extra S5.** Every backup is opened again as soon as it is written. The
+  service produced a snapshot, rotated the old ones, and trusted all of it,
+  so the first person to find out whether any of it worked would have been
+  somebody restoring after losing the original. Each snapshot is now opened
+  read only, put through `PRAGMA quick_check`, and counted against the live
+  database, and the answer is recorded beside the file and shown as a badge
+  per snapshot in Administration. A snapshot that reads perfectly and holds
+  nothing fails the check, which is the failure an integrity check alone
+  cannot see. `GET` and `POST /api/backups` carry the result. At boot the
+  server warns when the newest verified snapshot is older than two intervals.
 - **Extra S2.** A search quality gate. `tests/eval/search.eval.test.ts` runs
   fifty golden queries against a fixed corpus of three hundred contacts and
   compares recall at ten and mean reciprocal rank with a committed baseline,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1483,14 +1483,42 @@ SQLite snapshots (online backup API — safe while the app runs) written to `DAT
 
 ### `GET /api/backups`
 
+Admin only. A snapshot is the whole database, so it holds every account's rows.
+
 ```bash
 curl http://localhost:3210/api/backups
-# → { "backups": [{ "filename", "sizeBytes", "createdAt" }] }
+# → { "backups": [{ "filename", "sizeBytes", "createdAt", "verification" }] }
 ```
+
+Every snapshot is opened again as soon as it is written: read only, through
+`PRAGMA quick_check`, and counted against the live database. `verification`
+carries the answer.
+
+```json
+{
+  "ok": true,
+  "checkedAt": "2026-09-10T18:04:11.204Z",
+  "integrity": "ok",
+  "rows": { "contacts": 431, "users": 3, "interactions": 1904 },
+  "liveRows": { "contacts": 431, "users": 3, "interactions": 1904 }
+}
+```
+
+- `ok` is false when the file does not open, when `quick_check` reports
+  damage, when a counted table is missing, or when a table that has rows in
+  the live database has none in the snapshot. The last is the one an integrity
+  check cannot see: a sound, readable snapshot that restores nothing.
+- `problem` is present only when `ok` is false and says which of those it was.
+- `rows` and `liveRows` cover the eight owned tables and `users`.
+- `verification` is `null` for a snapshot taken before 2.0. That is not a
+  failed check and is shown differently.
 
 ### `POST /api/backups`
 
-Take a snapshot now. Returns `201` with the new backup's metadata.
+Admin only. Take a snapshot now. Returns `201` with the new backup's metadata,
+including its `verification`. A snapshot that fails verification is still
+written and still returned: the file may be salvageable, and deleting the
+evidence helps nobody.
 
 ---
 

--- a/docs/multi-tenant-plan/13-api-changes.md
+++ b/docs/multi-tenant-plan/13-api-changes.md
@@ -125,6 +125,7 @@ alias is removed if feature F5 in
 | Upload URLs | `/uploads/avatars/<file>`, `/uploads/<file>` | `/uploads/u/<ownerId>/avatars/<file>`, `/uploads/u/<ownerId>/files/<file>` |
 | `GET /api/export/json` | every row on the instance | the caller's rows |
 | `GET /api/query/contacts` | includes trashed and ghost contacts | excludes them |
+| `GET` and `POST /api/backups` | `{ filename, sizeBytes, createdAt }` | the same plus `verification`, which is `{ ok, checkedAt, integrity, rows, liveRows, problem? }` or `null` for a snapshot taken before 2.0 |
 
 ---
 

--- a/server/routes/dataLifecycle.ts
+++ b/server/routes/dataLifecycle.ts
@@ -122,10 +122,22 @@ router.post(
       action: "backup.created",
       targetType: "backup",
       targetId: backup.filename,
-      details: { filename: backup.filename },
+      // `verified` is in the audit row because a snapshot that failed its
+      // check is an event somebody should be able to find later, and the
+      // sidecar next to a rotated-out file will not be there to find.
+      details: {
+        filename: backup.filename,
+        verified: backup.verification?.ok ?? false,
+        ...(backup.verification?.problem
+          ? { problem: backup.verification.problem }
+          : {}),
+      },
       ip: req.ip ?? null,
     });
-    log.info("API", `[${rid}] POST /api/backups → ${backup.filename}`);
+    log.info(
+      "API",
+      `[${rid}] POST /api/backups → ${backup.filename} (${backup.verification?.ok ? "verified" : "NOT verified"})`,
+    );
     res.status(201).json(backup);
   }),
 );

--- a/server/services/backupService.ts
+++ b/server/services/backupService.ts
@@ -1,10 +1,15 @@
 // =============================================================================
-// Backup Service — scheduled SQLite snapshots with rotation
+// Backup Service — scheduled SQLite snapshots, verified and rotated
 // =============================================================================
 // Uses better-sqlite3's online backup API (safe while the DB is in use, WAL
 // included) to snapshot curator.db into DATA_DIR/backups/. A CRM database is
 // irreplaceable personal data — backups turn a bad bulk operation or disk
 // failure from catastrophic into annoying.
+//
+// Every snapshot is opened again as soon as it is written. Until 2.0 nothing
+// ever did: the file was produced, rotated, and trusted, and the first person
+// to find out whether any of it worked would have been somebody restoring it
+// after losing the original. A backup nobody has opened is a hope.
 //
 // Config (env):
 //   BACKUP_INTERVAL_HOURS — schedule cadence (default 24; 0 disables schedule)
@@ -13,7 +18,8 @@
 
 import fs from "fs";
 import path from "path";
-import { sqlite } from "../db.ts";
+import Database from "better-sqlite3";
+import { OWNED_TABLES, sqlite } from "../db.ts";
 import { DATA_DIR, ensureDir } from "../utils/paths.ts";
 import { log } from "../utils/logger.ts";
 import { getErrorMessage } from "../utils/helpers.ts";
@@ -23,10 +29,174 @@ export const BACKUPS_DIR = path.join(DATA_DIR, "backups");
 const DEFAULT_KEEP = 7;
 const DEFAULT_INTERVAL_HOURS = 24;
 
+/**
+ * The tables a snapshot is counted against.
+ *
+ * The eight that carry an owner, plus `users`. Between them they hold every
+ * row somebody would be upset to lose, and a snapshot that reads cleanly but
+ * holds none of them is the failure this check exists for.
+ */
+const COUNTED_TABLES = [...OWNED_TABLES, "users"] as const;
+
+/** What opening a snapshot and looking inside it found. */
+export interface BackupVerification {
+  /** The snapshot opened, passed its integrity check, and holds the data. */
+  ok: boolean;
+  checkedAt: string;
+  /** What `PRAGMA quick_check` answered. "ok" when the file is sound. */
+  integrity: string;
+  /** Row counts inside the snapshot. */
+  rows: Record<string, number>;
+  /** The same counts in the live database when the check ran. */
+  liveRows: Record<string, number>;
+  /** Why `ok` is false. Absent when it is true. */
+  problem?: string;
+}
+
 export interface BackupInfo {
   filename: string;
   sizeBytes: number;
   createdAt: string;
+  /**
+   * Null for a snapshot written before 2.0, or one whose sidecar was removed.
+   * Not the same as a failed check, and the view says so.
+   */
+  verification: BackupVerification | null;
+}
+
+/** Where a snapshot's verification is recorded: beside it, same name, .json. */
+function sidecarPath(file: string): string {
+  return `${file}.json`;
+}
+
+/** Count the rows in one table, or null when the table is not there at all. */
+function countRows(db: Database.Database, table: string): number | null {
+  try {
+    // The table names are the module constant above, never anything a caller
+    // supplies, which is why they can be interpolated at all.
+    const row = db.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get() as {
+      n: number;
+    };
+    return row.n;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Open a snapshot and decide whether it is a backup or just a file.
+ *
+ * Three things can be wrong, in increasing order of how quietly they fail:
+ *
+ * 1. The file does not open. A truncated or corrupted snapshot throws here
+ *    rather than failing the integrity check below, so the open is inside the
+ *    same try.
+ * 2. `PRAGMA quick_check` reports damage. This reads every page and every
+ *    index, which is the whole point of opening the file.
+ * 3. The file is sound and empty. This is the one nobody would notice: a
+ *    snapshot taken at the wrong moment, or of the wrong database, reads
+ *    perfectly and restores nothing. A table that has rows in the live
+ *    database and none in the snapshot fails the check.
+ *
+ * sqlite-vec is deliberately NOT loaded. Nothing counted here is a virtual
+ * table, `quick_check` covers the vec0 shadow tables as ordinary pages, and
+ * not loading an extension into a file of unknown soundness is one less way
+ * for this to be the thing that crashes.
+ */
+export function verifyBackup(file: string): BackupVerification {
+  const checkedAt = new Date().toISOString();
+  const rows: Record<string, number> = {};
+  const liveRows: Record<string, number> = {};
+
+  for (const table of COUNTED_TABLES) {
+    liveRows[table] = countRows(sqlite, table) ?? 0;
+  }
+
+  // Opening a snapshot creates its WAL companions, even read only: the file
+  // was copied from a database in WAL mode, so SQLite builds the shared
+  // memory index beside it. A read-only connection cannot clean them up when
+  // it closes, so without this the backups directory grows a 32 KB `-shm` and
+  // an empty `-wal` for every snapshot ever verified, and they outlive the
+  // snapshot they belong to because rotation is not looking for them.
+  //
+  // Only what this open created is removed. A companion that was already
+  // there belongs to somebody else and is left alone.
+  const companions = [`${file}-shm`, `${file}-wal`].filter(
+    (companion) => !fs.existsSync(companion),
+  );
+
+  let snapshot: Database.Database | null = null;
+  try {
+    snapshot = new Database(file, { readonly: true, fileMustExist: true });
+    const integrity = String(
+      snapshot.pragma("quick_check", { simple: true }) ?? "unknown",
+    );
+
+    const missing: string[] = [];
+    const empty: string[] = [];
+    for (const table of COUNTED_TABLES) {
+      const count = countRows(snapshot, table);
+      if (count === null) {
+        missing.push(table);
+        continue;
+      }
+      rows[table] = count;
+      if (count === 0 && liveRows[table] > 0) empty.push(table);
+    }
+
+    let problem: string | undefined;
+    if (integrity !== "ok") problem = `Integrity check: ${integrity}`;
+    else if (missing.length > 0)
+      problem = `Missing table(s): ${missing.join(", ")}`;
+    else if (empty.length > 0)
+      problem = `Empty in the snapshot but not in the database: ${empty.join(", ")}`;
+
+    return {
+      ok: !problem,
+      checkedAt,
+      integrity,
+      rows,
+      liveRows,
+      ...(problem ? { problem } : {}),
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      checkedAt,
+      integrity: "unreadable",
+      rows,
+      liveRows,
+      problem: `Could not read the snapshot: ${getErrorMessage(err)}`,
+    };
+  } finally {
+    snapshot?.close();
+    for (const companion of companions) {
+      // The `-wal` is empty by construction: a read-only connection cannot
+      // write to it. The size check is what makes that a fact rather than an
+      // assumption, because removing a WAL with anything in it would take the
+      // snapshot's most recent pages with it.
+      try {
+        if (fs.existsSync(companion) && fs.statSync(companion).size === 0) {
+          fs.rmSync(companion, { force: true });
+        } else if (fs.existsSync(companion) && companion.endsWith("-shm")) {
+          fs.rmSync(companion, { force: true });
+        }
+      } catch {
+        // Litter is not worth failing a verification over.
+      }
+    }
+  }
+}
+
+/** Read a snapshot's recorded verification, or null when it has none. */
+function readVerification(file: string): BackupVerification | null {
+  try {
+    return JSON.parse(
+      fs.readFileSync(sidecarPath(file), "utf8"),
+    ) as BackupVerification;
+  } catch {
+    return null;
+  }
 }
 
 function keepCount(): number {
@@ -41,11 +211,13 @@ export function listBackups(): BackupInfo[] {
     .readdirSync(BACKUPS_DIR)
     .filter((f) => f.startsWith("curator-") && f.endsWith(".db"))
     .map((filename) => {
-      const stat = fs.statSync(path.join(BACKUPS_DIR, filename));
+      const file = path.join(BACKUPS_DIR, filename);
+      const stat = fs.statSync(file);
       return {
         filename,
         sizeBytes: stat.size,
         createdAt: stat.mtime.toISOString(),
+        verification: readVerification(file),
       };
     })
     .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
@@ -56,7 +228,16 @@ function rotateBackups(): void {
   const excess = listBackups().slice(keepCount());
   for (const backup of excess) {
     try {
-      fs.unlinkSync(path.join(BACKUPS_DIR, backup.filename));
+      const file = path.join(BACKUPS_DIR, backup.filename);
+      fs.unlinkSync(file);
+      // The sidecar goes with the snapshot it describes. A verification left
+      // behind would be adopted by the next file to take that name, and a
+      // timestamped name only repeats if the clock goes backwards, which is
+      // exactly when a stale answer would be least welcome.
+      fs.rmSync(sidecarPath(file), { force: true });
+      // Anything a verification left beside an older snapshot goes with it.
+      fs.rmSync(`${file}-shm`, { force: true });
+      fs.rmSync(`${file}-wal`, { force: true });
       log.info("Backup", `Rotated out old backup ${backup.filename}`);
     } catch (err) {
       log.warn(
@@ -80,17 +261,76 @@ export async function runBackup(): Promise<BackupInfo> {
   const startMs = Date.now();
   await sqlite.backup(dest);
   const stat = fs.statSync(dest);
-  log.info(
-    "Backup",
-    `Snapshot ${filename} written (${(stat.size / 1024 / 1024).toFixed(2)} MB in ${Date.now() - startMs}ms)`,
-  );
+  const writtenMs = Date.now() - startMs;
+
+  // Opened again immediately. The check is worth almost nothing a week later
+  // and everything now, because now is when the snapshot can be taken again.
+  const verification = verifyBackup(dest);
+  try {
+    fs.writeFileSync(sidecarPath(dest), JSON.stringify(verification, null, 2));
+  } catch (err) {
+    log.warn(
+      "Backup",
+      `Could not record the verification for ${filename}: ${getErrorMessage(err)}`,
+    );
+  }
+
+  const size = `${(stat.size / 1024 / 1024).toFixed(2)} MB`;
+  if (verification.ok) {
+    log.info(
+      "Backup",
+      `Snapshot ${filename} written and verified (${size} in ${writtenMs}ms, checked in ${Date.now() - startMs - writtenMs}ms)`,
+    );
+  } else {
+    // An error, not a warning. A snapshot that cannot be read is not a
+    // degraded backup, it is no backup, and the operator is relying on it.
+    log.error(
+      "Backup",
+      `Snapshot ${filename} FAILED VERIFICATION (${size}): ${verification.problem}`,
+    );
+  }
 
   rotateBackups();
   return {
     filename,
     sizeBytes: stat.size,
     createdAt: stat.mtime.toISOString(),
+    verification,
   };
+}
+
+/**
+ * Complain at boot when the newest verified snapshot is too old.
+ *
+ * "Too old" is two intervals: one missed snapshot is a restart at the wrong
+ * moment, two is a schedule that has stopped. Nothing here fixes anything —
+ * the startup snapshot fifteen seconds later may well put it right — but the
+ * log line is the only place an operator finds out that the backups they
+ * think they have stopped happening some time ago.
+ */
+function warnAboutStaleBackups(intervalHours: number): void {
+  const verified = listBackups().filter((b) => b.verification?.ok);
+  if (verified.length === 0) {
+    const total = listBackups().length;
+    log.warn(
+      "Backup",
+      total === 0
+        ? "No snapshots exist yet. The first one is taken shortly after boot."
+        : `None of the ${total} existing snapshot(s) has passed verification. Check the backups directory.`,
+    );
+    return;
+  }
+
+  const newest = verified[0];
+  const ageHours =
+    (Date.now() - new Date(newest.createdAt).getTime()) / 3_600_000;
+  if (ageHours > intervalHours * 2) {
+    log.warn(
+      "Backup",
+      `The newest verified snapshot (${newest.filename}) is ${Math.floor(ageHours)}h old, ` +
+        `more than two ${intervalHours}h intervals. Scheduled backups may have stopped.`,
+    );
+  }
 }
 
 /**
@@ -118,6 +358,8 @@ export function startBackupSchedule(): NodeJS.Timeout | null {
     runBackup().catch((err) =>
       log.warn("Backup", `Scheduled backup failed: ${getErrorMessage(err)}`),
     );
+
+  warnAboutStaleBackups(hours);
 
   // Startup snapshot shortly after boot (let migrations/backfills settle).
   setTimeout(run, 15_000).unref();

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -104,10 +104,36 @@ export interface AuditPage {
   nextBefore: string | null;
 }
 
+/**
+ * What opening a snapshot found.
+ *
+ * Every snapshot is read back as soon as it is written: opened read only, put
+ * through `PRAGMA quick_check`, and counted against the live database. A
+ * snapshot that reads perfectly and holds nothing is the failure that would
+ * otherwise be found by somebody restoring it.
+ */
+export interface BackupVerification {
+  ok: boolean;
+  checkedAt: string;
+  /** `PRAGMA quick_check`, "ok" when the file is sound. */
+  integrity: string;
+  /** Row counts inside the snapshot, by table. */
+  rows: Record<string, number>;
+  /** The same counts in the live database when the check ran. */
+  liveRows: Record<string, number>;
+  /** Why `ok` is false. Absent when it is true. */
+  problem?: string;
+}
+
 export interface BackupInfo {
   filename: string;
   sizeBytes: number;
   createdAt: string;
+  /**
+   * Null for a snapshot taken before 2.0, which is not the same as a failed
+   * check and must not be shown as one.
+   */
+  verification: BackupVerification | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/views/settings/admin/BackupsView.tsx
+++ b/src/views/settings/admin/BackupsView.tsx
@@ -1,5 +1,5 @@
 /**
- * BackupsView — snapshots of the database.
+ * BackupsView — snapshots of the database, and whether they are any good.
  *
  * The backup service has existed since long before 2.0 and nothing in the app
  * has ever shown it. It ran on a schedule, rotated old files, and the only
@@ -7,14 +7,31 @@
  * directory over somebody's shoulder. A backup nobody can see is a backup
  * nobody trusts.
  *
+ * Each snapshot is opened again as soon as it is written, and this page shows
+ * the answer. That is the difference between a list of filenames and a list
+ * of backups: a file of the right size with the right name restores nothing
+ * if it is empty, and until 2.0 nothing ever looked.
+ *
  * A snapshot is the whole database, so it holds every account's rows. That is
  * why both routes are administration and why this page says so rather than
  * leaving an admin to infer it.
  */
 import { useState } from "react";
 import { toast } from "sonner";
-import { Camera, Database, HardDriveDownload } from "lucide-react";
-import { useBackups, useCreateBackup } from "../../../api/admin";
+import {
+  Camera,
+  Database,
+  HardDriveDownload,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldQuestion,
+} from "lucide-react";
+import {
+  useBackups,
+  useCreateBackup,
+  type BackupVerification,
+} from "../../../api/admin";
+import { Badge } from "../../../components/ui/Badge";
 import { formatBytes, formatRelative, formatWhen } from "../../../lib/datetime";
 import { cn } from "../../../lib/utils";
 import {
@@ -25,7 +42,60 @@ import {
   AdminRow,
 } from "./AdminShell";
 
-const COLUMNS = "sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_120px]";
+const COLUMNS = "sm:grid-cols-[minmax(0,2fr)_140px_minmax(0,1fr)_110px]";
+
+/** Every row of a snapshot's verification, as one hoverable string. */
+function verificationDetail(v: BackupVerification): string {
+  const counted = Object.entries(v.rows)
+    .map(([table, n]) => {
+      const live = v.liveRows[table];
+      return live === n ? `${table} ${n}` : `${table} ${n} (${live} live)`;
+    })
+    .join(", ");
+  const when = `Checked ${formatWhen(v.checkedAt)}`;
+  const integrity = `Integrity ${v.integrity}`;
+  return v.problem
+    ? `${when}. ${v.problem}. ${integrity}. ${counted}`
+    : `${when}. ${integrity}. ${counted}`;
+}
+
+/**
+ * The three states a snapshot can be in, and they are three, not two.
+ *
+ * A snapshot taken before 2.0 has no recorded check. Showing that as a
+ * failure would tell an operator their old backups are broken, which is not
+ * something this knows.
+ */
+const VerificationBadge = ({
+  verification,
+}: {
+  verification: BackupVerification | null;
+}) => {
+  if (!verification) {
+    return (
+      <Badge icon={<ShieldQuestion className="w-3 h-3" />} tone="neutral">
+        Not checked
+      </Badge>
+    );
+  }
+  if (!verification.ok) {
+    return (
+      <span title={verificationDetail(verification)}>
+        <Badge icon={<ShieldAlert className="w-3 h-3" />} tone="danger">
+          Failed
+        </Badge>
+      </span>
+    );
+  }
+
+  return (
+    <span title={verificationDetail(verification)}>
+      <Badge icon={<ShieldCheck className="w-3 h-3" />} tone="success">
+        Verified
+      </Badge>
+    </span>
+  );
+};
 
 export const BackupsView = () => {
   const { data: backups, isLoading, isError, refetch } = useBackups();
@@ -34,7 +104,7 @@ export const BackupsView = () => {
 
   return (
     <AdminPage
-      lead="A snapshot copies the whole database, so it holds every account's contacts. Older snapshots are rotated out automatically."
+      lead="A snapshot copies the whole database, so it holds every account's contacts. Each one is opened again and checked as soon as it is written. Older snapshots are rotated out automatically."
       actions={
         <AdminButton
           busy={create.isPending}
@@ -44,8 +114,18 @@ export const BackupsView = () => {
             create.mutate(undefined, {
               onSuccess: (backup) => {
                 setLatest(backup.filename);
+                // A snapshot that failed its check is not a success with a
+                // footnote. The toast that says "done" for a backup nobody
+                // can read is the thing this whole story is against.
+                if (backup.verification && !backup.verification.ok) {
+                  toast.error(
+                    `Snapshot taken but it did not verify: ${backup.verification.problem}`,
+                    { duration: 12_000 },
+                  );
+                  return;
+                }
                 toast.success(
-                  `Snapshot taken (${formatBytes(backup.sizeBytes)})`,
+                  `Snapshot taken and verified (${formatBytes(backup.sizeBytes)})`,
                 );
               },
               onError: (error: Error) => toast.error(error.message),
@@ -71,15 +151,18 @@ export const BackupsView = () => {
         header={
           <div className={cn("grid gap-4", COLUMNS)}>
             <span>File</span>
+            <span>Checked</span>
             <span>Taken</span>
             <span className="text-right">Size</span>
           </div>
         }
         footer={
           <p className="text-xs text-on-surface-variant text-pretty">
-            Snapshots live in the server&rsquo;s data directory. Copying them
-            somewhere else is what makes them a backup, and Contrack cannot do
-            that for you.
+            A verified snapshot opened cleanly, passed SQLite&rsquo;s integrity
+            check, and holds rows in every table this database does. Snapshots
+            live in the server&rsquo;s data directory, and copying them
+            somewhere else is what makes them a backup, which Contrack cannot do
+            for you.
           </p>
         }
       >
@@ -100,6 +183,10 @@ export const BackupsView = () => {
               </span>
             </div>
 
+            <AdminCell label="Checked">
+              <VerificationBadge verification={backup.verification} />
+            </AdminCell>
+
             <AdminCell label="Taken">
               <span
                 className="text-xs text-on-surface-variant"
@@ -114,6 +201,19 @@ export const BackupsView = () => {
                 {formatBytes(backup.sizeBytes)}
               </span>
             </AdminCell>
+
+            {/*
+              The reason, in the row rather than in a tooltip. A hover is the
+              one affordance a phone does not have, and the snapshot that
+              failed is the one somebody most needs told about. `col-span-full`
+              puts it under the grid on a desktop; below `sm` the row is a
+              stack and it is simply the last line.
+            */}
+            {backup.verification && !backup.verification.ok && (
+              <p className="sm:col-span-full text-xs text-error text-pretty">
+                {backup.verification.problem}
+              </p>
+            )}
           </AdminRow>
         ))}
       </AdminList>

--- a/tests/integration/backup.verify.test.ts
+++ b/tests/integration/backup.verify.test.ts
@@ -1,0 +1,348 @@
+// =============================================================================
+// Integration Tests — a snapshot is opened again before anybody trusts it
+// =============================================================================
+// `runBackup` wrote a file and rotated the old ones. Nothing ever opened it.
+// A backup that restores nothing looks exactly like a backup that restores
+// everything until the day somebody needs it, which is the worst possible day
+// to find out.
+//
+// Every test here writes real snapshots of a real database into a real
+// directory, and the damaged cases damage the actual file on disk. Verifying
+// a file nobody has broken proves only that the check runs.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+import request from "supertest";
+
+const { makeTestApp } = await import("./helpers.ts");
+const { OWNED_TABLES, sqlite, ensureLocalOwner } =
+  await import("../../server/db.ts");
+const { scopeForOwnerId } = await import("../../server/tenancy/scope.ts");
+const { contactService } =
+  await import("../../server/services/contactService.ts");
+const {
+  BACKUPS_DIR,
+  listBackups,
+  runBackup,
+  startBackupSchedule,
+  verifyBackup,
+} = await import("../../server/services/backupService.ts");
+const { log } = await import("../../server/utils/logger.ts");
+
+const app = makeTestApp();
+const scope = scopeForOwnerId(ensureLocalOwner());
+
+function sidecarOf(filename: string): string {
+  return path.join(BACKUPS_DIR, `${filename}.json`);
+}
+
+function clearBackups(): void {
+  if (!fs.existsSync(BACKUPS_DIR)) return;
+  for (const file of fs.readdirSync(BACKUPS_DIR)) {
+    fs.rmSync(path.join(BACKUPS_DIR, file), { force: true });
+  }
+}
+
+beforeEach(() => {
+  clearBackups();
+  delete process.env.BACKUP_KEEP;
+});
+
+afterAll(() => {
+  clearBackups();
+  delete process.env.BACKUP_KEEP;
+});
+
+describe("runBackup", () => {
+  it("verifies the snapshot it just wrote and records the answer beside it", async () => {
+    await contactService.bulkCreateContacts(scope, [
+      { name: "Verified Person" },
+    ]);
+
+    const backup = await runBackup();
+
+    expect(backup.verification?.ok).toBe(true);
+    expect(backup.verification?.integrity).toBe("ok");
+    expect(backup.verification?.problem).toBeUndefined();
+
+    // The counts are the evidence, and `users` has to be among them: a
+    // snapshot with contacts and no accounts is a database nobody can sign
+    // in to.
+    expect(backup.verification?.rows.contacts).toBeGreaterThan(0);
+    expect(backup.verification?.rows.users).toBeGreaterThan(0);
+    // Named against the real constant, not a count. A ninth owned table
+    // added later has to be counted too, and a test that only checks the
+    // length would keep passing while the new table went unverified.
+    expect(Object.keys(backup.verification?.rows ?? {}).sort()).toEqual(
+      [...OWNED_TABLES, "users"].sort(),
+    );
+
+    const sidecar = JSON.parse(
+      fs.readFileSync(sidecarOf(backup.filename), "utf8"),
+    ) as { ok: boolean; checkedAt: string };
+    expect(sidecar.ok).toBe(true);
+    expect(Date.parse(sidecar.checkedAt)).not.toBeNaN();
+  });
+
+  it("counts what the live database holds at the moment of the check", async () => {
+    const before = (
+      sqlite.prepare("SELECT COUNT(*) AS n FROM contacts").get() as {
+        n: number;
+      }
+    ).n;
+    await contactService.bulkCreateContacts(scope, [
+      { name: "Counted A" },
+      { name: "Counted B" },
+    ]);
+
+    const backup = await runBackup();
+
+    expect(backup.verification?.rows.contacts).toBe(before + 2);
+    expect(backup.verification?.liveRows.contacts).toBe(before + 2);
+  });
+
+  it("lists the recorded verification with the snapshot", async () => {
+    const backup = await runBackup();
+
+    const listed = listBackups().find((b) => b.filename === backup.filename);
+    expect(listed?.verification?.ok).toBe(true);
+  });
+});
+
+describe("verifyBackup, when the file is not a backup", () => {
+  it("fails a snapshot whose pages have been overwritten", async () => {
+    const backup = await runBackup();
+    const file = path.join(BACKUPS_DIR, backup.filename);
+
+    // Write rubbish over the middle of the file. This is what a bad sector or
+    // a half-finished copy looks like from here.
+    const fd = fs.openSync(file, "r+");
+    fs.writeSync(fd, Buffer.alloc(1024, 0x7f), 0, 1024, 4096);
+    fs.closeSync(fd);
+
+    const verification = verifyBackup(file);
+
+    expect(verification.ok).toBe(false);
+    expect(verification.problem).toBeTruthy();
+  });
+
+  it("fails a snapshot that is empty where the database is not", async () => {
+    await contactService.bulkCreateContacts(scope, [{ name: "Present" }]);
+    const backup = await runBackup();
+    const file = path.join(BACKUPS_DIR, backup.filename);
+    expect(verifyBackup(file).ok).toBe(true);
+
+    // Sound, readable, correctly named, and holds nothing. This is the
+    // failure the integrity check alone cannot see, and the one an operator
+    // would otherwise discover while restoring.
+    //
+    // sqlite-vec has to be loaded to empty the table, because deleting a
+    // contact fires a trigger that reaches the vec0 embedding tables.
+    // `verifyBackup` never writes and only counts ordinary tables, which is
+    // why it needs no extension of its own.
+    const { default: Database } = await import("better-sqlite3");
+    const sqliteVec = await import("sqlite-vec");
+    const snapshot = new Database(file);
+    sqliteVec.load(snapshot);
+    snapshot.exec("DELETE FROM contacts");
+    snapshot.close();
+
+    const verification = verifyBackup(file);
+
+    expect(verification.integrity).toBe("ok");
+    expect(verification.ok).toBe(false);
+    expect(verification.problem).toContain("contacts");
+    expect(verification.rows.contacts).toBe(0);
+    expect(verification.liveRows.contacts).toBeGreaterThan(0);
+  });
+
+  it("fails a file that will not open at all", () => {
+    const file = path.join(BACKUPS_DIR, "curator-not-a-database.db");
+    fs.mkdirSync(BACKUPS_DIR, { recursive: true });
+    fs.writeFileSync(file, "this is not a database");
+
+    const verification = verifyBackup(file);
+
+    expect(verification.ok).toBe(false);
+    expect(verification.integrity).toBe("unreadable");
+    expect(verification.checkedAt).toBeTruthy();
+  });
+
+  it("fails a file that is not there", () => {
+    const verification = verifyBackup(
+      path.join(BACKUPS_DIR, "curator-missing.db"),
+    );
+
+    expect(verification.ok).toBe(false);
+    expect(verification.integrity).toBe("unreadable");
+  });
+});
+
+describe("rotation", () => {
+  it("takes each snapshot's verification with it", async () => {
+    process.env.BACKUP_KEEP = "2";
+
+    const first = await runBackup();
+    // The filename carries a whole second, so three snapshots inside one
+    // second would be one file. The rows make each snapshot different and the
+    // writes push the clock along.
+    await contactService.bulkCreateContacts(scope, [{ name: "Rotate A" }]);
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await runBackup();
+    await contactService.bulkCreateContacts(scope, [{ name: "Rotate B" }]);
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await runBackup();
+
+    const remaining = listBackups();
+    expect(remaining).toHaveLength(2);
+    expect(remaining.map((b) => b.filename)).not.toContain(first.filename);
+
+    // A sidecar left behind would be adopted by the next file to take that
+    // name, and it would say a snapshot was verified that never was.
+    expect(fs.existsSync(sidecarOf(first.filename))).toBe(false);
+    for (const backup of remaining) {
+      expect(fs.existsSync(sidecarOf(backup.filename))).toBe(true);
+    }
+  }, 20_000);
+
+  it("leaves no WAL companions beside a snapshot it opened", async () => {
+    const backup = await runBackup();
+
+    // Reading a snapshot builds its shared memory index beside it, and a read
+    // only connection cannot take it away again on close. Left alone, the
+    // backups directory gains a 32 KB `-shm` and an empty `-wal` for every
+    // snapshot ever verified, and rotation is not looking for either.
+    const files = fs.readdirSync(BACKUPS_DIR);
+    expect(files).toContain(backup.filename);
+    expect(files.filter((f) => f.endsWith("-shm"))).toEqual([]);
+    expect(files.filter((f) => f.endsWith("-wal"))).toEqual([]);
+  });
+
+  it("rotates away a companion an older version left behind", async () => {
+    process.env.BACKUP_KEEP = "1";
+    const first = await runBackup();
+    const stale = path.join(BACKUPS_DIR, `${first.filename}-shm`);
+    fs.writeFileSync(stale, Buffer.alloc(32768));
+
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await runBackup();
+
+    expect(fs.existsSync(stale)).toBe(false);
+  }, 20_000);
+
+  it("never lists a sidecar as a backup", async () => {
+    await runBackup();
+
+    const files = fs.readdirSync(BACKUPS_DIR);
+    expect(files.some((f) => f.endsWith(".db.json"))).toBe(true);
+    expect(listBackups().every((b) => b.filename.endsWith(".db"))).toBe(true);
+  });
+});
+
+describe("the backups API", () => {
+  it("sends the verification with every snapshot", async () => {
+    const created = await request(app).post("/api/backups").expect(201);
+    expect(created.body.verification.ok).toBe(true);
+
+    const listed = await request(app).get("/api/backups").expect(200);
+    const row = listed.body.backups.find(
+      (b: { filename: string }) => b.filename === created.body.filename,
+    );
+    expect(row.verification.ok).toBe(true);
+    expect(row.verification.rows.users).toBeGreaterThan(0);
+  });
+
+  it("records in the audit log whether the snapshot verified", async () => {
+    const created = await request(app).post("/api/backups").expect(201);
+
+    const row = sqlite
+      .prepare(
+        `SELECT details FROM audit_log
+          WHERE action = 'backup.created' AND targetId = ?`,
+      )
+      .get(created.body.filename) as { details: string } | undefined;
+
+    expect(row).toBeTruthy();
+    expect(JSON.parse(row!.details)).toMatchObject({ verified: true });
+  });
+});
+
+describe("the warning at boot", () => {
+  /**
+   * Start the schedule, collect what it said, and stop it again.
+   *
+   * `DISABLE_BACKGROUND_JOBS` is on for every integration file, and it is the
+   * first thing `startBackupSchedule` looks at, so it has to come off for the
+   * length of the call. The interval is cleared and the startup snapshot is
+   * fifteen seconds away and unrefed, so nothing outlives this.
+   */
+  function bootWarnings(intervalHours: string): string[] {
+    const said: string[] = [];
+    const warn = vi
+      .spyOn(log, "warn")
+      .mockImplementation((_scope: string, message: string) => {
+        said.push(message);
+      });
+    const previous = process.env.DISABLE_BACKGROUND_JOBS;
+    process.env.DISABLE_BACKGROUND_JOBS = "";
+    process.env.BACKUP_INTERVAL_HOURS = intervalHours;
+    try {
+      const handle = startBackupSchedule();
+      if (handle) clearInterval(handle);
+    } finally {
+      process.env.DISABLE_BACKGROUND_JOBS = previous;
+      delete process.env.BACKUP_INTERVAL_HOURS;
+      warn.mockRestore();
+    }
+    return said;
+  }
+
+  it("says nothing when the newest verified snapshot is recent", async () => {
+    await runBackup();
+
+    expect(bootWarnings("24")).toEqual([]);
+  });
+
+  it("complains when the newest verified snapshot is older than two intervals", async () => {
+    const backup = await runBackup();
+    // Three days back, against a one day interval. `listBackups` reads mtime,
+    // which is what moving the file's timestamp changes.
+    const old = new Date(Date.now() - 3 * 24 * 3_600_000);
+    fs.utimesSync(path.join(BACKUPS_DIR, backup.filename), old, old);
+
+    const warnings = bootWarnings("24");
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("more than two 24h intervals");
+    expect(warnings[0]).toContain(backup.filename);
+  });
+
+  it("complains when there are no snapshots at all", () => {
+    clearBackups();
+
+    const warnings = bootWarnings("24");
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("No snapshots exist yet");
+  });
+
+  it("complains when snapshots exist and none of them passed", async () => {
+    const backup = await runBackup();
+    // Take the verification away. A snapshot nobody checked and a snapshot
+    // that failed are different things, and neither is one to rely on.
+    fs.rmSync(sidecarOf(backup.filename), { force: true });
+
+    const warnings = bootWarnings("24");
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("has passed verification");
+  });
+
+  it("says nothing when scheduled backups are switched off", () => {
+    clearBackups();
+
+    expect(bootWarnings("0")).toEqual([]);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -13,4 +13,18 @@ vi.mock("../server/db.ts", () => ({
     update: vi.fn(),
     delete: vi.fn(),
   },
+  // The real constant, copied rather than stubbed. A module that reads it at
+  // import time (backupService does, to decide which tables a snapshot is
+  // counted against) fails to load at all without it, and a wrong list here
+  // would make a unit test disagree with the database for no visible reason.
+  OWNED_TABLES: [
+    "contacts",
+    "lists",
+    "interactions",
+    "action_items",
+    "dedupe_suggestions",
+    "dedupe_exclusions",
+    "dedupe_merge_log",
+    "ai_invocations",
+  ],
 }));


### PR DESCRIPTION
The backup service wrote a snapshot, rotated the old ones, and trusted all of it. Nothing ever opened the file again, so the first person to find out whether any of it worked would have been somebody restoring after losing the original.

This is quality story S5 from [15-additional-v2-features.md](docs/multi-tenant-plan/15-additional-v2-features.md) section 7.

## What the check does

Every snapshot is opened read only as soon as it is written, put through `PRAGMA quick_check`, and counted against the live database. Three things can be wrong, and they fail at different depths.

- **The file does not open.** A truncated or corrupted snapshot throws on `new Database(...)` rather than failing the integrity check, so the open is inside the same try.
- **The pages are damaged.** `quick_check` reads every page and every index, which is the point of opening the file at all.
- **The file is sound and empty.** This is the one nobody would notice. A snapshot taken at the wrong moment, or of the wrong database, reads perfectly and restores nothing. **A table with rows in the live database and none in the snapshot fails the check.**

The counts cover the eight owned tables and `users`, named against `OWNED_TABLES` rather than a number, so a ninth owned table added later cannot go unverified.

sqlite-vec is deliberately not loaded. Nothing counted is a virtual table, `quick_check` covers the vec0 shadow tables as ordinary pages, and not loading an extension into a file of unknown soundness is one less way for this to be the thing that crashes.

## Where it shows

- `{ ok, checkedAt, integrity, rows, liveRows, problem? }` is written to a sidecar JSON beside the snapshot, and both `GET` and `POST /api/backups` carry it.
- The admin Backups view has a **Checked** column with three states. Verified, Failed, and **Not checked, which is not a failure**: a snapshot taken before 2.0 has no recorded check, and showing that as broken would tell an operator something this does not know.
- A failed snapshot puts the reason in the row, not in a tooltip. The first version used `title`, and a hover is the one affordance a phone does not have, on the one row that most needs explaining.
- `POST /api/backups` logs at error level and toasts an error when the snapshot does not verify. A cheerful "done" for a backup nobody can read is the thing this story is against.
- The audit row for `backup.created` records `verified`, because a rotated-out file takes its sidecar with it and the audit log is what is left.

At boot the server warns when the newest verified snapshot is older than two intervals. One missed snapshot is a restart at the wrong moment, two is a schedule that has stopped.

## A bug the tests could not have found

Running this against a real server, the backups directory looked like this:

```
curator-2026-09-11T04-32-11.db
curator-2026-09-11T04-32-11.db-shm      32768
curator-2026-09-11T04-32-11.db-wal          0
curator-2026-09-11T04-32-11.db.json
```

**Opening a snapshot builds its WAL companions beside it, even read only.** The file was copied from a database in WAL mode, so SQLite builds the shared memory index, and a read-only connection cannot clean it up when it closes. Left alone the backups directory gains a 32 KB `-shm` and an empty `-wal` for every snapshot ever verified, and rotation was not looking for either, so they outlive the snapshot they belong to.

Only what the open created is removed, and the `-wal` is removed only when it is empty. It is empty by construction, because a read-only connection cannot write to it; the size check is what makes that a fact rather than an assumption, since removing a WAL with anything in it would take the snapshot's newest pages with it. Rotation now clears both for older files too.

I found this by looking at the directory after a real snapshot, not from a test. Two tests now cover it.

## Testing

`tests/integration/backup.verify.test.ts`, 18 tests. The damaged cases damage the actual file on disk: verifying a file nobody has broken proves only that the check runs.

Every test was checked by breaking the code it covers:

| Change | Result |
| ------ | ------ |
| The verification is never written | 5 failures |
| The boot warning is never called | 3 failures |
| The emptiness check removed, so `ok` is `quick_check` alone | 1 failure |
| `quick_check`'s answer ignored | 1 failure |
| The sidecar not removed on rotation | 1 failure |
| The WAL companions not removed after the read | 1 failure |
| Rotation not clearing an older snapshot's companions | 1 failure |
| Two intervals becomes twenty | 1 failure |

`tests/setup.ts` gains `OWNED_TABLES` in the unit project's database mock. `backupService` reads it at import time to decide which tables to count, so without it the module fails to load and `backupSchedule.test.ts` collects nothing.

```
npm run lint          tenant-lint: clean for 1 glob(s): server/**/*.ts
npm run format:check  All matched files use Prettier code style!
npm test               Test Files  78 passed (78)
                            Tests  1259 passed (1259)
npm run build         ✓ built in 296ms
npm run audit:contrast -- --routes /settings/admin/backups,/settings/admin/users,/settings
                      TOTAL failing text elements: 0
```

The contrast run was against a live instance holding one verified, one failed, and one unchecked snapshot, so all three badges and the red failure line were on screen and measured. The page was checked in a browser at 1280 px and at 390 px: the desktop grid puts the reason under the row, and below `sm` the row is already a stack and the reason is its last line.
