### PR TITLE
feat(db): checkpoint the write-ahead log and count refused writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than showing a progress bar at zero. `GET /api/dedupe/active` gained a
   `queued` field, which is the only way a reloaded page can tell a booked scan
   from one that has hung.
+- **Extra S6.** The daily sweep checkpoints the write-ahead log. The database
+  runs in WAL mode and nothing in the codebase had ever called a checkpoint:
+  SQLite runs one by itself past a thousand pages, but only when no reader is
+  looking at an older version of the database, so a dedupe scan or a full
+  export holds every checkpoint off for as long as it runs and the log grows
+  for the whole time. The sweep now runs a passive checkpoint always, and a
+  truncating one when the log is over 64 MB and no scan is running, because a
+  truncating checkpoint behind a scan would hold the write lock until the scan
+  finished. Requests refused with a database-busy error are counted, which is
+  the symptom people report and the one nobody could previously measure.
 - **Extra S5.** Every backup is opened again as soon as it is written. The
   service produced a snapshot, rotated the old ones, and trusted all of it,
   so the first person to find out whether any of it worked would have been

--- a/server/middleware/errorHandler.ts
+++ b/server/middleware/errorHandler.ts
@@ -21,6 +21,7 @@ import type { Request, Response, NextFunction } from "express";
 import { ZodError } from "zod";
 import { AppError } from "../utils/AppError.ts";
 import { log } from "../utils/logger.ts";
+import { recordBusyError } from "../services/walHealth.ts";
 
 interface SqliteLikeError {
   code?: string;
@@ -123,6 +124,13 @@ function translate(err: unknown): {
     e?.code?.startsWith("SQLITE_BUSY") ||
     e?.code?.startsWith("SQLITE_LOCKED")
   ) {
+    // Counted here and nowhere else. This is the one place that knows a
+    // request was actually turned away, rather than a lock better-sqlite3
+    // waited out inside its five second busy timeout and nobody noticed. The
+    // admin health panel reports the count, because "it told me to try again"
+    // is the symptom people report and one unlucky moment looks exactly like
+    // a pattern until somebody can see how many there have been.
+    recordBusyError();
     return {
       statusCode: 503,
       code: "DB_BUSY",

--- a/server/services/maintenanceService.ts
+++ b/server/services/maintenanceService.ts
@@ -6,6 +6,11 @@
 // ago that nobody is going to ask about them, invitations that were revoked
 // or expired a month back, and AI invocations outside the stats window.
 //
+// The sweep also checkpoints the write-ahead log, which is a different kind of
+// growth with the same shape: nothing removes it in the ordinary course of
+// things and it only becomes visible once it is a problem. `walHealth.ts` has
+// the reasoning.
+//
 // Before Phase 3 there was nothing to attach this to. `cleanupOldInvocations`
 // ran once at boot and the session sweep was boot-only, so an instance left
 // running for a year swept twice.
@@ -22,6 +27,7 @@ import { sqlite } from "../db.ts";
 import { log } from "../utils/logger.ts";
 import { getErrorMessage } from "../utils/helpers.ts";
 import { cleanupOldInvocations } from "./aiStatsService.ts";
+import { runWalMaintenance } from "./walHealth.ts";
 
 /** How long each kind of row is kept. */
 export const AUDIT_RETENTION_DAYS = 90;
@@ -34,6 +40,8 @@ export interface MaintenanceCounts {
   agedTokens: number;
   deadInvitations: number;
   oldInvocations: number;
+  /** Pages the checkpoint moved back into the database. */
+  walPagesCheckpointed: number;
 }
 
 /**
@@ -59,6 +67,7 @@ export function runDailyMaintenance(): MaintenanceCounts {
     agedTokens: 0,
     deadInvitations: 0,
     oldInvocations: 0,
+    walPagesCheckpointed: 0,
   };
 
   try {
@@ -104,6 +113,11 @@ export function runDailyMaintenance(): MaintenanceCounts {
       `Daily sweep failed part way through: ${getErrorMessage(err)}`,
     );
   }
+
+  // Outside the try above on purpose. A delete that throws must not take the
+  // checkpoint with it: the two have nothing to do with each other beyond
+  // sharing a schedule, and the WAL is the one that grows without bound.
+  counts.walPagesCheckpointed = runWalMaintenance()?.checkpointedPages ?? 0;
 
   const total =
     counts.auditRows +

--- a/server/services/walHealth.ts
+++ b/server/services/walHealth.ts
@@ -1,0 +1,205 @@
+// =============================================================================
+// Write health — the WAL file, its checkpoints, and refused writes
+// =============================================================================
+// The database runs in WAL mode. Every write goes to `curator.db-wal` first
+// and is folded back into the database by a checkpoint, and SQLite runs one
+// by itself once the WAL passes a thousand pages.
+//
+// "Once it passes a thousand pages" is doing a lot of work in that sentence.
+// An automatic checkpoint only completes when no reader is still looking at
+// an older version of the database, so one long reader — a dedupe scan, a
+// full export — holds every checkpoint off for as long as it runs, and the
+// WAL grows for the whole time. Nothing in this codebase has ever called a
+// checkpoint, so the only defence was that single-user instances rarely have
+// a long reader and a busy writer at the same time. A shared instance does.
+//
+// Two numbers come out of here, and both are for the admin health panel:
+// how big the WAL is, and how many requests have been refused because the
+// database was busy. The second is the symptom a person actually reports
+// ("it said try again"), and without a count nobody can tell one unlucky
+// moment from a pattern.
+// =============================================================================
+
+import fs from "fs";
+import { sqlite } from "../db.ts";
+import { log } from "../utils/logger.ts";
+import { getErrorMessage } from "../utils/helpers.ts";
+import { jobQueue as aiSearchQueue } from "./aiSearch/jobQueue.ts";
+import { dedupeQueue } from "./dedupe/jobQueue.ts";
+
+/**
+ * The size at which a passive checkpoint has clearly not been enough.
+ *
+ * 64 MB is roughly sixteen thousand pages, sixteen times SQLite's own
+ * threshold. Reaching it means checkpoints have been blocked for a long time
+ * rather than that the instance is busy.
+ */
+export const WAL_TRUNCATE_BYTES = 64 * 1024 * 1024;
+
+export interface CheckpointResult {
+  at: string;
+  mode: "passive" | "truncate";
+  /** True when SQLite could not finish, which a reader is the usual cause of. */
+  busy: boolean;
+  /** Pages in the WAL when the checkpoint ran. */
+  logPages: number;
+  /** Pages it managed to move back into the database. */
+  checkpointedPages: number;
+  /** The WAL file size before and after, in bytes. */
+  bytesBefore: number;
+  bytesAfter: number;
+}
+
+export interface WriteHealth {
+  /** The `-wal` file right now. */
+  walBytes: number;
+  /** The size at which the daily sweep stops asking nicely. */
+  truncateAtBytes: number;
+  /** The last checkpoint this process ran, or null when it has run none. */
+  lastCheckpoint: CheckpointResult | null;
+  /** Requests refused with a database-busy error since this process started. */
+  busyErrors: number;
+  /** When the last one of those happened. */
+  lastBusyErrorAt: string | null;
+  /** The window the counts cover. */
+  startedAt: string;
+}
+
+const startedAt = new Date().toISOString();
+let busyErrors = 0;
+let lastBusyErrorAt: string | null = null;
+let lastCheckpoint: CheckpointResult | null = null;
+
+/**
+ * One more request refused because the database was busy.
+ *
+ * Called from the error middleware, which is the only place that knows a
+ * request was actually turned away rather than retried internally. A count
+ * that also included every `SQLITE_BUSY` better-sqlite3 recovered from would
+ * measure something nobody experienced.
+ */
+export function recordBusyError(): void {
+  busyErrors += 1;
+  lastBusyErrorAt = new Date().toISOString();
+}
+
+/** The write-ahead log's size in bytes, or 0 when there is no WAL file. */
+export function walBytes(): number {
+  try {
+    return fs.statSync(`${sqlite.name}-wal`).size;
+  } catch {
+    // No file means no WAL, which is the state right after a truncate.
+    return 0;
+  }
+}
+
+/** Whether a long reader is running that a checkpoint would have to wait for. */
+function longReaderRunning(): boolean {
+  // A dedupe scan reads the whole corpus and an AI search batch reads and
+  // writes across minutes. Both are exactly the reader that keeps a
+  // checkpoint from completing, and a TRUNCATE that has to wait for one takes
+  // the write lock with it.
+  return dedupeQueue.isProcessing() || aiSearchQueue.isProcessing();
+}
+
+/**
+ * Fold the write-ahead log back into the database.
+ *
+ * PASSIVE never waits: it moves what it can and reports what it could not,
+ * which is why it is safe to run on a schedule. TRUNCATE takes the write lock
+ * and empties the file, which is what actually reclaims the disk, and is only
+ * worth its cost when the log has grown past the point where PASSIVE is
+ * evidently not keeping up.
+ */
+export function checkpoint(mode: "passive" | "truncate"): CheckpointResult {
+  const bytesBefore = walBytes();
+  const rows = sqlite.pragma(
+    `wal_checkpoint(${mode === "truncate" ? "TRUNCATE" : "PASSIVE"})`,
+  ) as { busy: number; log: number; checkpointed: number }[];
+  const row = rows[0] ?? { busy: 1, log: -1, checkpointed: -1 };
+
+  const result: CheckpointResult = {
+    at: new Date().toISOString(),
+    mode,
+    busy: row.busy !== 0,
+    logPages: row.log,
+    checkpointedPages: row.checkpointed,
+    bytesBefore,
+    bytesAfter: walBytes(),
+  };
+  lastCheckpoint = result;
+  return result;
+}
+
+/**
+ * The checkpoint half of the daily sweep.
+ *
+ * Always PASSIVE first, because it costs nothing and usually finishes. Then
+ * TRUNCATE only when the log is still over the threshold and nothing long is
+ * reading, because a TRUNCATE behind a dedupe scan would sit on the write
+ * lock waiting for it and every writer would queue behind that.
+ *
+ * Never throws. This runs inside the daily sweep, which is a best-effort job.
+ */
+export function runWalMaintenance(
+  // An argument with a default rather than a constant read inside, so a test
+  // can exercise the truncating branch without first writing 64 MB of rows.
+  // The daily sweep passes nothing and gets the real threshold.
+  truncateAtBytes: number = WAL_TRUNCATE_BYTES,
+): CheckpointResult | null {
+  try {
+    const passive = checkpoint("passive");
+
+    if (passive.bytesAfter <= truncateAtBytes) {
+      if (passive.busy) {
+        log.debug(
+          "Maintenance",
+          `WAL checkpoint incomplete: ${passive.checkpointedPages}/${passive.logPages} pages, ${(passive.bytesAfter / 1e6).toFixed(1)} MB left`,
+        );
+      }
+      return passive;
+    }
+
+    if (longReaderRunning()) {
+      log.warn(
+        "Maintenance",
+        `The write-ahead log is ${(passive.bytesAfter / 1e6).toFixed(0)} MB and a scan is running, so it was left alone. ` +
+          `A truncating checkpoint would hold the write lock until the scan finished.`,
+      );
+      return passive;
+    }
+
+    const truncated = checkpoint("truncate");
+    log.info(
+      "Maintenance",
+      `The write-ahead log was ${(truncated.bytesBefore / 1e6).toFixed(0)} MB; ` +
+        `a truncating checkpoint left it at ${(truncated.bytesAfter / 1e6).toFixed(1)} MB` +
+        (truncated.busy
+          ? " (SQLite reported busy, so it may be incomplete)"
+          : ""),
+    );
+    return truncated;
+  } catch (err) {
+    log.warn("Maintenance", `WAL checkpoint failed: ${getErrorMessage(err)}`);
+    return null;
+  }
+}
+
+/** Everything the health panel reports about writing. */
+export function writeHealth(): WriteHealth {
+  return {
+    walBytes: walBytes(),
+    truncateAtBytes: WAL_TRUNCATE_BYTES,
+    lastCheckpoint,
+    busyErrors,
+    lastBusyErrorAt,
+    startedAt,
+  };
+}
+
+/** Reset the counters. Tests only. */
+export function __resetWriteHealth(): void {
+  busyErrors = 0;
+  lastBusyErrorAt = null;
+  lastCheckpoint = null;
+}

--- a/tests/integration/maintenance.test.ts
+++ b/tests/integration/maintenance.test.ts
@@ -304,6 +304,11 @@ describe("the daily sweep", () => {
       agedTokens: 1,
       deadInvitations: 1,
       oldInvocations: 1,
+      // The sweep also checkpoints the write-ahead log, and how many pages
+      // that moves depends on everything written before this test ran.
+      // `expect.any` keeps the shape exhaustive, so a field added later still
+      // fails here, without pinning a number nobody can predict.
+      walPagesCheckpointed: expect.any(Number),
     });
     for (const table of [
       "audit_log",
@@ -324,6 +329,7 @@ describe("the daily sweep", () => {
       agedTokens: 0,
       deadInvitations: 0,
       oldInvocations: 0,
+      walPagesCheckpointed: expect.any(Number),
     });
     expect(ids("audit_log")).toEqual(["new"]);
   });

--- a/tests/integration/wal.health.test.ts
+++ b/tests/integration/wal.health.test.ts
@@ -1,0 +1,249 @@
+// =============================================================================
+// Integration Tests — the write-ahead log is checkpointed, and refusals counted
+// =============================================================================
+// Every write goes to `curator.db-wal` first. SQLite folds it back once the
+// log passes a thousand pages, but only when no reader is still looking at an
+// older version of the database, so one long reader holds every checkpoint
+// off for as long as it runs. Nothing in this codebase called a checkpoint
+// before 2.0.
+//
+// The database here is real and so is its WAL: the tests write rows, read the
+// file off disk, and check that the number went down.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+
+const { makeTestApp } = await import("./helpers.ts");
+const { sqlite, ensureLocalOwner } = await import("../../server/db.ts");
+const { scopeForOwnerId } = await import("../../server/tenancy/scope.ts");
+const { contactService } =
+  await import("../../server/services/contactService.ts");
+const { dedupeQueue } =
+  await import("../../server/services/dedupe/jobQueue.ts");
+const { runDailyMaintenance } =
+  await import("../../server/services/maintenanceService.ts");
+const {
+  WAL_TRUNCATE_BYTES,
+  __resetWriteHealth,
+  checkpoint,
+  recordBusyError,
+  runWalMaintenance,
+  walBytes,
+  writeHealth,
+} = await import("../../server/services/walHealth.ts");
+
+const app = makeTestApp();
+const scope = scopeForOwnerId(ensureLocalOwner());
+
+/** Write enough rows that the WAL is unmistakably not empty. */
+async function fillTheWal(): Promise<number> {
+  await contactService.bulkCreateContacts(
+    scope,
+    Array.from({ length: 250 }, (_, i) => ({
+      name: `WAL Person ${i}`,
+      about: "x".repeat(400),
+      emails: [`wal${i}@example.com`],
+    })),
+  );
+  return walBytes();
+}
+
+beforeEach(() => {
+  __resetWriteHealth();
+  dedupeQueue.setProcessing(false);
+});
+
+afterEach(() => {
+  dedupeQueue.setProcessing(false);
+});
+
+describe("the write-ahead log", () => {
+  it("is in WAL mode, so there is something to checkpoint", () => {
+    expect(sqlite.pragma("journal_mode", { simple: true })).toBe("wal");
+  });
+
+  it("grows when rows are written", async () => {
+    checkpoint("truncate");
+    const before = walBytes();
+
+    const after = await fillTheWal();
+
+    expect(after).toBeGreaterThan(before);
+  });
+
+  it("shrinks when a passive checkpoint runs", async () => {
+    await fillTheWal();
+    const before = walBytes();
+    expect(before).toBeGreaterThan(0);
+
+    const result = checkpoint("passive");
+
+    // PASSIVE folds the pages back but leaves the file at its high-water
+    // mark, ready to be written into again. What it moves is the measure.
+    expect(result.checkpointedPages).toBeGreaterThan(0);
+    expect(result.logPages).toBeGreaterThan(0);
+    expect(result.busy).toBe(false);
+    expect(result.bytesBefore).toBe(before);
+  });
+
+  it("empties the file when a truncating checkpoint runs", async () => {
+    await fillTheWal();
+    expect(walBytes()).toBeGreaterThan(0);
+
+    const result = checkpoint("truncate");
+
+    expect(result.mode).toBe("truncate");
+    expect(result.bytesAfter).toBe(0);
+    expect(walBytes()).toBe(0);
+  });
+});
+
+describe("runWalMaintenance", () => {
+  it("runs a passive checkpoint and records it", async () => {
+    await fillTheWal();
+
+    const result = runWalMaintenance();
+
+    expect(result?.mode).toBe("passive");
+    expect(writeHealth().lastCheckpoint?.mode).toBe("passive");
+    expect(writeHealth().lastCheckpoint?.checkpointedPages).toBeGreaterThan(0);
+  });
+
+  it("does not truncate a log under the threshold", async () => {
+    await fillTheWal();
+    // Nowhere near 64 MB. A few hundred contacts is a few hundred kilobytes.
+    expect(walBytes()).toBeLessThan(WAL_TRUNCATE_BYTES);
+
+    runWalMaintenance();
+
+    expect(writeHealth().lastCheckpoint?.mode).toBe("passive");
+  });
+
+  it("truncates a log over the threshold", async () => {
+    await fillTheWal();
+    expect(walBytes()).toBeGreaterThan(1024);
+
+    // The threshold is an argument so this can reach the branch without
+    // first writing 64 MB. Everything else is the real path.
+    const result = runWalMaintenance(1024);
+
+    expect(result?.mode).toBe("truncate");
+    expect(result?.bytesAfter).toBe(0);
+    expect(walBytes()).toBe(0);
+  });
+
+  it("leaves an over-threshold log alone while a scan is running", async () => {
+    await fillTheWal();
+    const before = walBytes();
+    expect(before).toBeGreaterThan(1024);
+    dedupeQueue.setProcessing(true);
+
+    const result = runWalMaintenance(1024);
+
+    // A passive checkpoint still runs, because it never waits for anybody.
+    // What the scan prevents is the truncating one, which would hold the
+    // write lock until the scan finished and queue every writer behind it.
+    expect(result?.mode).toBe("passive");
+    expect(walBytes()).toBeGreaterThan(0);
+  });
+
+  it("is part of the daily sweep", async () => {
+    await fillTheWal();
+
+    const counts = runDailyMaintenance();
+
+    expect(counts.walPagesCheckpointed).toBeGreaterThan(0);
+    expect(writeHealth().lastCheckpoint).not.toBeNull();
+  });
+
+  it("checkpoints even when the row deletes fail", () => {
+    // The sweep's deletes and its checkpoint share a schedule and nothing
+    // else. A failure in one must not skip the other, and the WAL is the half
+    // that grows without a bound.
+    sqlite.exec("ALTER TABLE audit_log RENAME TO audit_log_hidden");
+    try {
+      const counts = runDailyMaintenance();
+      expect(counts.auditRows).toBe(0);
+      expect(writeHealth().lastCheckpoint).not.toBeNull();
+    } finally {
+      sqlite.exec("ALTER TABLE audit_log_hidden RENAME TO audit_log");
+    }
+  });
+});
+
+describe("write health", () => {
+  it("starts with no refused writes", () => {
+    const health = writeHealth();
+
+    expect(health.busyErrors).toBe(0);
+    expect(health.lastBusyErrorAt).toBeNull();
+    expect(health.truncateAtBytes).toBe(WAL_TRUNCATE_BYTES);
+    expect(Date.parse(health.startedAt)).not.toBeNaN();
+  });
+
+  it("counts a refused write and remembers when", () => {
+    recordBusyError();
+    recordBusyError();
+
+    const health = writeHealth();
+    expect(health.busyErrors).toBe(2);
+    expect(Date.parse(health.lastBusyErrorAt!)).not.toBeNaN();
+  });
+
+  it("counts a request the error middleware turned away as busy", async () => {
+    // The real middleware, with the error better-sqlite3 throws when it gives
+    // up waiting for the write lock. The count belongs here and nowhere else:
+    // a lock the driver waited out inside its five second busy timeout is one
+    // nobody experienced, and counting it would measure the wrong thing.
+    const { errorHandler } =
+      await import("../../server/middleware/errorHandler.ts");
+    const busy = Object.assign(new Error("database is locked"), {
+      code: "SQLITE_BUSY",
+    });
+    const sent: { status?: number; body?: { error?: { code?: string } } } = {};
+    const res = {
+      headersSent: false,
+      getHeader: () => undefined,
+      setHeader: () => undefined,
+      status(code: number) {
+        sent.status = code;
+        return this;
+      },
+      json(body: { error?: { code?: string } }) {
+        sent.body = body;
+        return this;
+      },
+    };
+
+    errorHandler(
+      busy,
+      {
+        method: "GET",
+        originalUrl: "/api/contacts",
+        path: "/api/contacts",
+      } as never,
+      res as never,
+      (() => undefined) as never,
+    );
+
+    expect(sent.status).toBe(503);
+    expect(sent.body?.error?.code).toBe("DB_BUSY");
+    expect(writeHealth().busyErrors).toBe(1);
+  });
+
+  it("does not count an ordinary error", async () => {
+    await request(app).get("/api/contacts/does-not-exist").expect(404);
+
+    expect(writeHealth().busyErrors).toBe(0);
+  });
+
+  it("reports the log's size now", async () => {
+    checkpoint("truncate");
+    expect(writeHealth().walBytes).toBe(0);
+
+    await fillTheWal();
+
+    expect(writeHealth().walBytes).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
The database runs in WAL mode and nothing in the codebase had ever called a checkpoint. Every write goes to `curator.db-wal` first, and only a checkpoint folds it back.

This is quality story S6 from [15-additional-v2-features.md](docs/multi-tenant-plan/15-additional-v2-features.md) section 7.

## Why an automatic checkpoint is not enough

SQLite runs one by itself once the log passes a thousand pages, and that sentence is doing a lot of work. **An automatic checkpoint only completes when no reader is still looking at an older version of the database.** One long reader holds every checkpoint off for as long as it runs, and the log grows for the whole time. A dedupe scan reads the whole corpus; a full export reads every table.

On a single-user instance a long reader and a busy writer rarely meet. On a shared one they do, which is why this is a 2.0 story rather than a 1.x one.

## What the daily sweep does now

- **A passive checkpoint, always.** PASSIVE never waits for anybody: it moves what it can and reports what it could not, so it is safe on a schedule whatever else is running.
- **A truncating checkpoint, only over 64 MB and only when no scan is running.** TRUNCATE is what actually reclaims the disk, and it takes the write lock to do it. Behind a dedupe scan it would hold that lock until the scan finished, **queueing every writer behind a job nobody asked to wait for**. When a scan is running the log is left alone and the reason is logged.
- 64 MB is sixteen times SQLite's own threshold. Reaching it means checkpoints have been blocked for a long time, not that the instance is busy.

**The checkpoint sits outside the sweep's delete block on purpose.** The two share a schedule and nothing else, and a delete that throws must not take the checkpoint with it, because the log is the half that grows without a bound.

## Counting refused writes

`SQLITE_BUSY` and `SQLITE_LOCKED` already became `503 DB_BUSY` in the error middleware. They are now counted there, and **there only**: that is the one place that knows a request was actually turned away, rather than a lock better-sqlite3 waited out inside its five second busy timeout and nobody noticed. A count that included those would measure something no person experienced.

"It told me to try again" is what people report. One unlucky moment looks exactly like a pattern until somebody can see how many there have been.

## Where the numbers go

`writeHealth()` returns the WAL size, the threshold, the last checkpoint this process ran, the refused-write count, and the window those counts cover. **S9 puts them on the admin health panel**, which is the next pull request in this sequence. Nothing user-facing changes here.

## Testing

`tests/integration/wal.health.test.ts`, 15 tests against a real database and its real WAL: the tests write rows, read the file off disk, and check the number went down.

Every test was checked by breaking the code it covers:

| Change | Result |
| ------ | ------ |
| No checkpoint in the daily sweep | 2 failures |
| The checkpoint moved inside the delete block, so a failed delete skips it | 1 failure |
| The scan guard removed, so a truncate runs behind a scan | 1 failure |
| The busy count removed from the error middleware | 1 failure |
| The truncating branch never chosen | 1 failure |

The truncating branch is reached by passing the threshold as an argument rather than by writing 64 MB of rows. `runWalMaintenance()` takes `truncateAtBytes` with the real constant as its default, the daily sweep passes nothing, and everything else on that path is the real thing.

`tests/integration/maintenance.test.ts` had two assertions on the exact shape of `MaintenanceCounts`. They now carry `walPagesCheckpointed: expect.any(Number)`, which keeps the shape exhaustive — a field added later still fails there — without pinning a number that depends on everything written before the test ran.

```
npm run lint          tenant-lint: clean for 1 glob(s): server/**/*.ts
npm run format:check  All matched files use Prettier code style!
npm test               Test Files  79 passed (79)
                            Tests  1274 passed (1274)
npm run build         ✓ built in 297ms
```
