### PR TITLE
feat(admin): an instance health panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than showing a progress bar at zero. `GET /api/dedupe/active` gained a
   `queued` field, which is the only way a reloaded page can tell a booked scan
   from one that has hung.
+- **Extra S9.** An instance health panel, at Settings, Administration,
+  Instance health. `GET /api/admin/health` answers what an operator needs when
+  several people share one instance: the schema versions this database is
+  actually on, the database and write-ahead log sizes, the newest backup and
+  whether it verified, which account the dedupe scan is running for and who is
+  waiting behind it, how much of each account's contacts the search index
+  covers, the AI cache hit rates, and the provider's tier and paused models.
+  Every one of those was answerable only by reading the server log or opening
+  the database. `/healthz` is unchanged and stays two states and no detail: it
+  answers without a credential, and an unauthenticated endpoint must not
+  describe the instance.
 - **Extra S6.** The daily sweep checkpoints the write-ahead log. The database
   runs in WAL mode and nothing in the codebase had ever called a checkpoint:
   SQLite runs one by itself past a thousand pages, but only when no reader is

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1454,6 +1454,89 @@ An account created or reset by an admin holds a password that admin chose, so
 every route outside the six the sign-in flow needs answers
 `403 PASSWORD_CHANGE_REQUIRED` until the person replaces it.
 
+### `GET /api/admin/health`
+
+Admin only. Everything this instance can say about itself. Read only, safe to
+poll, and deliberately separate from `GET /healthz`, which anybody who can
+reach the port may ask and which therefore stays two states and no detail.
+
+```bash
+curl http://localhost:3210/api/admin/health
+```
+
+```json
+{
+  "uptimeSeconds": 93142,
+  "startedAt": "2026-09-09T18:02:11.004Z",
+  "schema": {
+    "tenancy": 2,
+    "tenancyExpected": 2,
+    "fts": 3,
+    "ftsExpected": 3,
+    "vec": "v0.1.9",
+    "upToDate": true
+  },
+  "database": {
+    "bytes": 18452480,
+    "walBytes": 1204224,
+    "truncateAtBytes": 67108864,
+    "lastCheckpoint": {
+      "at": "…",
+      "mode": "passive",
+      "busy": false,
+      "logPages": 294,
+      "checkpointedPages": 294,
+      "bytesBefore": 1204224,
+      "bytesAfter": 1204224
+    },
+    "busyErrors": 0,
+    "lastBusyErrorAt": null,
+    "rows": { "contacts": 431, "users": 3, "…": 0 }
+  },
+  "backup": {
+    "filename": "…",
+    "sizeBytes": 0,
+    "createdAt": "…",
+    "verification": {}
+  },
+  "queues": {
+    "dedupe": { "running": { "id": "…", "username": "maya" }, "pending": [] },
+    "aiSearch": { "running": null, "activeBatches": 0, "contactsRemaining": 0 }
+  },
+  "embeddings": {
+    "available": true,
+    "byUser": [
+      {
+        "user": { "id": "…", "username": "maya" },
+        "contacts": 431,
+        "embedded": 431
+      }
+    ]
+  },
+  "aiCache": {
+    "briefing": { "entries": 12, "hits": 40, "misses": 8, "hitRate": 0.83 }
+  },
+  "provider": {
+    "aiTier": "FREE",
+    "circuitBreakers": [],
+    "grounding": { "rpd": 12, "limit": 500, "remaining": 488 }
+  }
+}
+```
+
+- `schema.upToDate` is false while a migration has not finished, which
+  explains a great many other symptoms.
+- `queues` names the account each job is running for, and who is waiting
+  behind the dedupe scan. "A scan is running" is not something an operator can
+  act on when several people share an instance.
+- `embeddings.byUser` is two numbers rather than a percentage, because the
+  useful question is which account has contacts search cannot reach yet.
+- `database.busyErrors` counts requests refused with `503 DB_BUSY` since the
+  process started. `startedAt` is the window those counts cover.
+- **No secrets.** No key, no token, no invitation link, no contact of
+  anybody's. The most identifying value is a username beside a queue position,
+  and the caller can already list every account.
+
 ---
 
 ## Trash (Undoable Deletes)

--- a/docs/multi-tenant-plan/13-api-changes.md
+++ b/docs/multi-tenant-plan/13-api-changes.md
@@ -92,6 +92,7 @@ All under `/api/admin`, class `admin`.
 | DELETE | `/invitations/:id` | | `{ revoked: true }` |
 | GET | `/settings` | | `{ registrationOpen, sessionTtlDays, sessionTtlRange: { min, max, default } }` |
 | PUT | `/settings` | `{ registrationOpen?, sessionTtlDays? }` | same shape |
+| GET | `/health` | | The instance as it is now: schema versions, database and write-ahead log sizes, the newest backup and its verification, the dedupe and enrichment queues with the account each is running for, search-index progress per account, AI cache hit rates, and the provider's tier and paused models. Read only, no secrets, safe to poll. Added by quality story S9. |
 | GET | `/audit?limit=&before=` | | `{ entries: [{ id, actor: { id, username } \| null, action, targetType, targetId, details, ip, createdAt }], nextBefore }`. `before` is the opaque cursor a previous page returned as `nextBefore`, which is `<createdAt>\|<id>`: `createdAt` alone has one-second resolution and a bare timestamp cursor would skip every row sharing a second with the last row of the page. |
 
 `AdminUserSummary`:

--- a/docs/multi-tenant-plan/15-additional-v2-features.md
+++ b/docs/multi-tenant-plan/15-additional-v2-features.md
@@ -492,10 +492,10 @@ Fill in as decisions are made, so the release PR can list what shipped.
 | 3 | Nudges | Not accepted for 2.0. Moves to 2.1. | 2026-09-10 |
 | 5 | Reconnect drafts | Not accepted for 2.0. Moves to 2.1. | 2026-09-10 |
 | S2 | Search quality gate | Accepted. Shipped in [#39](https://github.com/arvarik/contrack/pull/39). | 2026-09-10 |
-| S3 | One scan after a bulk import | Accepted. | 2026-09-10 |
-| S5 | Verified backups | Accepted. | 2026-09-10 |
-| S6 | WAL checkpoint and write health | Accepted. | 2026-09-10 |
-| S9 | Admin health panel | Accepted. | 2026-09-10 |
+| S3 | One scan after a bulk import | Accepted. Shipped in [#40](https://github.com/arvarik/contrack/pull/40). | 2026-09-10 |
+| S5 | Verified backups | Accepted. Shipped in [#41](https://github.com/arvarik/contrack/pull/41). | 2026-09-10 |
+| S6 | WAL checkpoint and write health | Accepted. Shipped in [#42](https://github.com/arvarik/contrack/pull/42). | 2026-09-10 |
+| S9 | Admin health panel | Accepted. Shipped in [#43](https://github.com/arvarik/contrack/pull/43). | 2026-09-10 |
 
 The five accepted stories land in the order this table lists them, one pull
 request each, from `v2.0-extra-<slug>`. The rules at the top of this document

--- a/docs/multi-tenant-plan/appendix-b-route-manifest.md
+++ b/docs/multi-tenant-plan/appendix-b-route-manifest.md
@@ -174,3 +174,4 @@ second added the three token routes, `POST /api/auth/register` and the two
 | GET | `/api/admin/settings` | admin | shipped |
 | PUT | `/api/admin/settings` | admin | shipped |
 | GET | `/api/admin/audit` | admin | shipped |
+| GET | `/api/admin/health` | admin | shipped |

--- a/scripts/contrast-audit.mjs
+++ b/scripts/contrast-audit.mjs
@@ -204,6 +204,7 @@ const DEFAULT_ROUTES = [
   ["admin-invites", "/settings/admin/invitations"],
   ["admin-instance", "/settings/admin/instance"],
   ["admin-backups", "/settings/admin/backups"],
+  ["admin-health", "/settings/admin/health"],
   ["admin-audit", "/settings/admin/audit"],
 ];
 /**

--- a/server/db.ts
+++ b/server/db.ts
@@ -145,6 +145,16 @@ const { vec_version } = sqlite
   .get() as { vec_version: string };
 log.info("Database", `sqlite-vec loaded (version ${vec_version})`);
 
+/**
+ * The sqlite-vec build this process loaded.
+ *
+ * Read once at boot and exported for the admin health panel. An operator
+ * confirming that an upgrade actually took effect should not have to open the
+ * database to do it, and this is the one version number that comes from a
+ * native extension rather than from a row we wrote ourselves.
+ */
+export const VEC_VERSION = vec_version;
+
 // Before any migration runs. Partition keys arrived in 0.1.6 and every vector
 // query from Phase 2 on depends on them, so an instance that cannot have them
 // must refuse to start rather than migrate and then fail. `assertVecVersion`
@@ -597,7 +607,14 @@ export function claimUnownedData(ownerId: string): Record<string, number> {
   return claimed;
 }
 
-function readTenancyVersion(): number {
+/**
+ * The tenancy migration this database has reached.
+ *
+ * Exported for the admin health panel. `PRAGMA user_version` already holds
+ * the FTS schema version and is a single 32-bit field, which is why this one
+ * lives in `app_settings` instead.
+ */
+export function readTenancyVersion(): number {
   try {
     const row = sqlite
       .prepare(`SELECT value FROM app_settings WHERE key = 'schema.tenancy'`)

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -43,6 +43,7 @@ import {
   revokeInvitation,
 } from "../services/invitationService.ts";
 import { AUDIT_ACTIONS, auditService } from "../services/auditService.ts";
+import { instanceHealth } from "../services/healthService.ts";
 import {
   getSessionTtlDays,
   setSessionTtlDays,
@@ -86,6 +87,29 @@ function requestOrigin(req: Request): string {
   const host = candidates.find((v) => v && HOST_SHAPE.test(v)) ?? "localhost";
   return `${req.protocol}://${host}`;
 }
+
+// ─── Health ──────────────────────────────────────────────────────────────────
+
+/**
+ * What an operator needs to know about this instance.
+ *
+ * Admin rather than public, and deliberately not part of `/healthz`. That
+ * probe is reachable without a credential and must stay two states and no
+ * detail: an unauthenticated endpoint that describes the instance tells
+ * anybody who can reach the port what version it runs, how big it is, and how
+ * many accounts it has.
+ *
+ * Nothing here is written, so it is safe to poll, and nothing here is a
+ * secret. The most identifying value in the payload is a username beside a
+ * queue position, and the caller can already list every account.
+ */
+router.get(
+  "/health",
+  requireAdmin,
+  asyncHandler(async (_req, res) => {
+    res.json(instanceHealth());
+  }),
+);
 
 // ─── Accounts ────────────────────────────────────────────────────────────────
 

--- a/server/services/aiSearch/jobQueue.ts
+++ b/server/services/aiSearch/jobQueue.ts
@@ -355,6 +355,35 @@ class AISearchJobQueue extends EventEmitter {
     return this.processing;
   }
 
+  /**
+   * Who is enriching and how much is left, across the whole instance.
+   *
+   * For the admin health panel. Unlike the dedupe queue this one has no line:
+   * a second account's batch is refused with a cooldown rather than booked,
+   * so there is a running owner and nothing behind it.
+   */
+  instanceState(): {
+    running: OwnerId | null;
+    activeBatches: number;
+    contactsRemaining: number;
+  } {
+    let running: OwnerId | null = null;
+    let activeBatches = 0;
+    let contactsRemaining = 0;
+    for (const owned of this.batches.values()) {
+      if (owned.batch.status !== "processing") continue;
+      activeBatches += 1;
+      running ??= owned.ownerId;
+      contactsRemaining += owned.batch.jobs.filter(
+        (job) =>
+          job.status === "queued" ||
+          job.status === "searching" ||
+          job.status === "merging",
+      ).length;
+    }
+    return { running, activeBatches, contactsRemaining };
+  }
+
   /** Cleanup completed batches older than GC_TTL_MS. */
   gc(): void {
     const now = Date.now();

--- a/server/services/dedupe/jobQueue.ts
+++ b/server/services/dedupe/jobQueue.ts
@@ -196,6 +196,27 @@ class DedupeJobQueue extends EventEmitter {
     return this.processing;
   }
 
+  /**
+   * Who is scanning and who is waiting, across the whole instance.
+   *
+   * For the admin health panel and nowhere else. Every other reader of this
+   * queue asks about one account, because one account is all a member may
+   * know about. "A scan is running" is not an answer an operator can act on
+   * when four people share an instance and one of them is waiting.
+   */
+  instanceState(): { running: OwnerId | null; pending: OwnerId[] } {
+    let running: OwnerId | null = null;
+    if (this.processing) {
+      for (const owned of this.scans.values()) {
+        if (owned.scan.phase !== "complete" && owned.scan.phase !== "error") {
+          running = owned.ownerId;
+          break;
+        }
+      }
+    }
+    return { running, pending: this.pending.map((p) => p.ownerId) };
+  }
+
   /** Set processing lock — called by the service during scan execution. */
   setProcessing(value: boolean): void {
     this.processing = value;

--- a/server/services/healthService.ts
+++ b/server/services/healthService.ts
@@ -1,0 +1,310 @@
+// =============================================================================
+// Health Service — what an operator needs to know about one instance
+// =============================================================================
+// `/healthz` answers `SELECT 1`, and that is the right answer for the thing
+// it is: an unauthenticated probe that must say whether the process serves
+// requests and nothing else about the instance.
+//
+// An admin needs more when several people depend on one instance, and the
+// questions they have are not "is it up". They are: did the migration run,
+// is the write-ahead log growing, when was the last backup and was it any
+// good, whose scan is everybody else waiting behind, is the vector index
+// built for the account that just complained about search, and is the AI
+// provider refusing us. Every one of those was answerable only by reading the
+// server log or opening the database.
+//
+// Nothing here is a secret. No key, no token, no invitation link, no contact
+// of anybody's. The most identifying thing in the payload is a username
+// beside a queue position, and an admin can already list every account.
+// =============================================================================
+
+import fs from "fs";
+import {
+  OWNED_TABLES,
+  VEC_VERSION,
+  readTenancyVersion,
+  sqlite,
+  TENANCY_SCHEMA_VERSION,
+} from "../db.ts";
+import { ai } from "../ai/index.ts";
+import { aiCache } from "../utils/aiCache.ts";
+import { getErrorMessage } from "../utils/helpers.ts";
+import { FTS_SCHEMA_VERSION } from "./search/ftsIndex.ts";
+import { jobQueue as aiSearchQueue } from "./aiSearch/jobQueue.ts";
+import { dedupeQueue } from "./dedupe/jobQueue.ts";
+import { listBackups, type BackupInfo } from "./backupService.ts";
+import { writeHealth, type WriteHealth } from "./walHealth.ts";
+
+/** An account named by something other than its id. */
+interface Account {
+  id: string;
+  username: string;
+}
+
+export interface SchemaVersions {
+  /** The tenancy migration this database has reached, and the one we expect. */
+  tenancy: number;
+  tenancyExpected: number;
+  /** The FTS schema in `PRAGMA user_version`, and the one we expect. */
+  fts: number;
+  ftsExpected: number;
+  /** The sqlite-vec build this process loaded. */
+  vec: string;
+  /** False when a migration has not finished, which explains a lot of things. */
+  upToDate: boolean;
+}
+
+export interface DatabaseHealth extends WriteHealth {
+  /** The main database file. */
+  bytes: number;
+  /** Rows in each owned table, plus users. Cheap, indexed, and reassuring. */
+  rows: Record<string, number>;
+}
+
+export interface QueueHealth {
+  dedupe: {
+    running: Account | null;
+    /** Accounts waiting for the run lock, in the order they asked. */
+    pending: Account[];
+  };
+  aiSearch: {
+    running: Account | null;
+    activeBatches: number;
+    contactsRemaining: number;
+  };
+}
+
+export interface EmbeddingProgress {
+  user: Account;
+  /** Active contacts this account owns. */
+  contacts: number;
+  /** How many of them have a search vector. */
+  embedded: number;
+}
+
+export interface CacheTierHealth {
+  entries: number;
+  hits: number;
+  misses: number;
+  hitRate: number;
+}
+
+export interface InstanceHealth {
+  /** Seconds since this process started. */
+  uptimeSeconds: number;
+  startedAt: string;
+  schema: SchemaVersions;
+  database: DatabaseHealth;
+  /** The newest snapshot, or null when none has been taken. */
+  backup: BackupInfo | null;
+  queues: QueueHealth;
+  embeddings: {
+    /** False when no embedding model or provider is configured. */
+    available: boolean;
+    byUser: EmbeddingProgress[];
+  };
+  aiCache: Record<string, CacheTierHealth>;
+  provider: {
+    aiTier: string;
+    /** Models a circuit breaker has taken out of rotation. */
+    circuitBreakers: string[];
+    grounding: { rpd: number; limit: number; remaining: number };
+  };
+}
+
+const startedAt = new Date().toISOString();
+
+/** Every account, by id, for putting a name next to a queue position. */
+function accountsById(): Map<string, Account> {
+  const rows = sqlite
+    .prepare(
+      // Every account on purpose: this answers an admin-only route whose
+      // whole subject is the instance.
+      // tenant-lint: allow instance sweep
+      "SELECT id, username FROM users",
+    )
+    .all() as Account[];
+  return new Map(rows.map((row) => [row.id, row]));
+}
+
+/** An id the queue gave us, with the name it belongs to. */
+function name(
+  id: string | null,
+  accounts: Map<string, Account>,
+): Account | null {
+  if (!id) return null;
+  return accounts.get(id) ?? { id, username: "(deleted account)" };
+}
+
+function fileBytes(file: string): number {
+  try {
+    return fs.statSync(file).size;
+  } catch {
+    return 0;
+  }
+}
+
+function rowCounts(): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const table of [...OWNED_TABLES, "users"]) {
+    try {
+      // The names come from the module constant, never from a caller.
+      counts[table] = (
+        sqlite.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get() as {
+          n: number;
+        }
+      ).n;
+    } catch {
+      counts[table] = -1;
+    }
+  }
+  return counts;
+}
+
+function schemaVersions(): SchemaVersions {
+  const tenancy = readTenancyVersion();
+  const fts = Number(sqlite.pragma("user_version", { simple: true }) ?? 0);
+  return {
+    tenancy,
+    tenancyExpected: TENANCY_SCHEMA_VERSION,
+    fts,
+    ftsExpected: FTS_SCHEMA_VERSION,
+    vec: VEC_VERSION,
+    upToDate: tenancy >= TENANCY_SCHEMA_VERSION && fts >= FTS_SCHEMA_VERSION,
+  };
+}
+
+/**
+ * How far the search index has got, per account.
+ *
+ * Two numbers rather than a percentage, because the useful question is "which
+ * account has contacts that search cannot reach yet" and a percentage of zero
+ * contacts is not a number. Counted with the same predicate the backfill uses
+ * so the two agree.
+ */
+function embeddingProgress(
+  accounts: Map<string, Account>,
+): EmbeddingProgress[] {
+  const rows = sqlite
+    .prepare(
+      // tenant-lint: allow instance sweep
+      `SELECT c.ownerId AS ownerId,
+              COUNT(*) AS contacts,
+              SUM(CASE WHEN e.contactId IS NULL THEN 0 ELSE 1 END) AS embedded
+         FROM contacts c
+         LEFT JOIN search_embeddings e ON e.contactId = c.id
+        WHERE c.isGhost = 0 AND COALESCE(c.isArchived, 0) = 0
+          AND c.canonicalId IS NULL AND c.deletedAt IS NULL
+          AND c.ownerId IS NOT NULL
+        GROUP BY c.ownerId`,
+    )
+    .all() as { ownerId: string; contacts: number; embedded: number }[];
+
+  return rows
+    .map((row) => ({
+      user: name(row.ownerId, accounts)!,
+      contacts: row.contacts,
+      embedded: row.embedded,
+    }))
+    .sort((a, b) => b.contacts - a.contacts);
+}
+
+/** The shared in-process cache, per tier, with the "batchMode" entry dropped. */
+function cacheHealth(): Record<string, CacheTierHealth> {
+  const out: Record<string, CacheTierHealth> = {};
+  for (const [tier, stats] of Object.entries(aiCache.getStats())) {
+    if (!("hits" in stats)) continue;
+    const total = stats.hits + stats.misses;
+    out[tier] = {
+      entries: stats.entries,
+      hits: stats.hits,
+      misses: stats.misses,
+      hitRate: total > 0 ? Math.round((stats.hits / total) * 100) / 100 : 0,
+    };
+  }
+  return out;
+}
+
+/**
+ * Everything the admin health panel reports.
+ *
+ * Every part is wrapped, because a panel that answers "something threw" is
+ * worse than useless: the operator opening it is already looking for a
+ * problem, and a blank page is the least informative way to have one.
+ */
+export function instanceHealth(): InstanceHealth {
+  const accounts = accountsById();
+  const dedupe = dedupeQueue.instanceState();
+  const search = aiSearchQueue.instanceState();
+
+  let provider: InstanceHealth["provider"];
+  try {
+    const snapshot = ai.getQuotaSnapshot();
+    provider = {
+      aiTier: snapshot.aiTier,
+      circuitBreakers: snapshot.circuitBreakers,
+      grounding: snapshot.grounding,
+    };
+  } catch (err) {
+    provider = {
+      aiTier: `unavailable (${getErrorMessage(err)})`,
+      circuitBreakers: [],
+      grounding: { rpd: 0, limit: 0, remaining: 0 },
+    };
+  }
+
+  return {
+    uptimeSeconds: Math.round(process.uptime()),
+    startedAt,
+    schema: schemaVersions(),
+    database: {
+      ...writeHealth(),
+      bytes: fileBytes(sqlite.name),
+      rows: rowCounts(),
+    },
+    backup: listBackups()[0] ?? null,
+    queues: {
+      dedupe: {
+        running: name(dedupe.running, accounts),
+        pending: dedupe.pending
+          .map((id) => name(id, accounts))
+          .filter((account): account is Account => account !== null),
+      },
+      aiSearch: {
+        running: name(search.running, accounts),
+        activeBatches: search.activeBatches,
+        contactsRemaining: search.contactsRemaining,
+      },
+    },
+    embeddings: {
+      available: ai.isConfigured || hasSearchVectors(),
+      byUser: embeddingProgress(accounts),
+    },
+    aiCache: cacheHealth(),
+    provider,
+  };
+}
+
+/**
+ * Whether anything has ever been embedded.
+ *
+ * The built-in model needs no key, so "no provider configured" does not mean
+ * "no vectors". One row anywhere is enough to answer, and this is an
+ * instance-wide question on an instance-wide route.
+ */
+function hasSearchVectors(): boolean {
+  try {
+    return (
+      (
+        sqlite
+          .prepare(
+            // tenant-lint: allow instance sweep
+            "SELECT COUNT(*) AS n FROM search_embeddings",
+          )
+          .get() as { n: number }
+      ).n > 0
+    );
+  } catch {
+    return false;
+  }
+}

--- a/server/services/search/ftsIndex.ts
+++ b/server/services/search/ftsIndex.ts
@@ -8,7 +8,14 @@ export const ACTIVE_CONTACT_SQL = `c.isGhost = 0 AND COALESCE(c.isArchived, 0) =
 // Version 3 adds `ownerTok`. The gate below drops and rebuilds the table when
 // the stored user_version differs, so the first boot after upgrade re-indexes
 // every active contact. Measured at 233 ms for 50,000 contacts.
-const VERSION = 3;
+/**
+ * The FTS schema version, kept in `PRAGMA user_version`.
+ *
+ * Exported so the admin health panel can report what this database is on
+ * without opening it, which is the whole point of the panel.
+ */
+export const FTS_SCHEMA_VERSION = 3;
+const VERSION = FTS_SCHEMA_VERSION;
 
 /**
  * Every contacts_fts column, in order. Position 0 is the UNINDEXED contactId.

--- a/server/tenancy/routeManifest.ts
+++ b/server/tenancy/routeManifest.ts
@@ -94,6 +94,12 @@ export const ROUTE_MANIFEST: readonly RouteEntry[] = [
   },
   {
     method: "GET",
+    path: "/api/admin/health",
+    class: "admin",
+    isolated: false,
+  },
+  {
+    method: "GET",
     path: "/api/admin/invitations",
     class: "admin",
     isolated: false,

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -140,6 +140,69 @@ export interface BackupInfo {
 // Query keys
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Instance health
+// ---------------------------------------------------------------------------
+
+/** An account named by something other than its id. */
+export interface HealthAccount {
+  id: string;
+  username: string;
+}
+
+export interface InstanceHealth {
+  uptimeSeconds: number;
+  startedAt: string;
+  schema: {
+    tenancy: number;
+    tenancyExpected: number;
+    fts: number;
+    ftsExpected: number;
+    vec: string;
+    upToDate: boolean;
+  };
+  database: {
+    bytes: number;
+    walBytes: number;
+    truncateAtBytes: number;
+    lastCheckpoint: {
+      at: string;
+      mode: "passive" | "truncate";
+      busy: boolean;
+      logPages: number;
+      checkpointedPages: number;
+      bytesBefore: number;
+      bytesAfter: number;
+    } | null;
+    busyErrors: number;
+    lastBusyErrorAt: string | null;
+    startedAt: string;
+    rows: Record<string, number>;
+  };
+  backup: BackupInfo | null;
+  queues: {
+    dedupe: { running: HealthAccount | null; pending: HealthAccount[] };
+    aiSearch: {
+      running: HealthAccount | null;
+      activeBatches: number;
+      contactsRemaining: number;
+    };
+  };
+  embeddings: {
+    available: boolean;
+    byUser: { user: HealthAccount; contacts: number; embedded: number }[];
+  };
+  aiCache: Record<
+    string,
+    { entries: number; hits: number; misses: number; hitRate: number }
+  >;
+  provider: {
+    aiTier: string;
+    circuitBreakers: string[];
+    grounding: { rpd: number; limit: number; remaining: number };
+  };
+}
+
 export const adminKeys = {
   users: ["admin", "users"] as const,
   user: (id: string) => ["admin", "users", id] as const,
@@ -147,6 +210,7 @@ export const adminKeys = {
   settings: ["admin", "settings"] as const,
   audit: ["admin", "audit"] as const,
   backups: ["admin", "backups"] as const,
+  health: ["admin", "health"] as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -504,6 +568,23 @@ export const useBackups = () =>
         (data) => data.backups,
       ),
     staleTime: 30_000,
+  });
+
+/**
+ * The instance health panel.
+ *
+ * Refetched on an interval, because the numbers that matter most are the ones
+ * that move: whose scan is running, how big the write-ahead log is, how many
+ * requests were refused. Fifteen seconds is slow enough to be free on a page
+ * only admins open and fast enough that watching it is useful.
+ */
+export const useInstanceHealth = () =>
+  useQuery({
+    queryKey: adminKeys.health,
+    queryFn: ({ signal }) =>
+      apiJson<InstanceHealth>("/admin/health", { signal }),
+    staleTime: 5_000,
+    refetchInterval: 15_000,
   });
 
 export const useCreateBackup = () => {

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -19,6 +19,7 @@ import {
   useNavigate,
 } from "react-router-dom";
 import {
+  Activity,
   Archive,
   Brain,
   ChevronLeft,
@@ -55,8 +56,8 @@ import { usePageTitle } from "../hooks/usePageTitle";
 // The administration area, loaded only for the people who can open it
 // ---------------------------------------------------------------------------
 // Every other subpage here is a static import, so all eight share the one
-// Settings chunk. These five are not, and the reason is not size: a member
-// can never open any of them, and a member should not download five pages of
+// Settings chunk. These six are not, and the reason is not size: a member
+// can never open any of them, and a member should not download six pages of
 // account management to be told they may not. The split shows up in the build
 // output as chunks of their own, which is the check.
 
@@ -89,6 +90,10 @@ const BackupsView = lazyAdmin(
 const AuditView = lazyAdmin(
   () => import("./settings/admin/AuditView"),
   "AuditView",
+);
+const HealthView = lazyAdmin(
+  () => import("./settings/admin/HealthView"),
+  "HealthView",
 );
 
 // ---------------------------------------------------------------------------
@@ -168,6 +173,12 @@ const SUBPAGES: SubpageMeta[] = [
     segment: "admin/audit",
     title: "Audit log",
     icon: ScrollText,
+    tone: "text-primary",
+  },
+  {
+    segment: "admin/health",
+    title: "Instance health",
+    icon: Activity,
     tone: "text-primary",
   },
 ];
@@ -361,6 +372,14 @@ export const SettingsView = () => {
             element={
               <AdminRoute>
                 <AuditView />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="/admin/health"
+            element={
+              <AdminRoute>
+                <HealthView />
               </AdminRoute>
             }
           />

--- a/src/views/settings/SettingsHome.tsx
+++ b/src/views/settings/SettingsHome.tsx
@@ -22,6 +22,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import {
+  Activity,
   Archive,
   ChevronRight,
   Copy,
@@ -354,6 +355,14 @@ export const SettingsHome = () => {
     ),
     adminBackups: hit("backups", "snapshot", "database", "restore", "admin"),
     adminAudit: hit("audit", "log", "history", "who did", "admin"),
+    adminHealth: hit(
+      "health",
+      "instance",
+      "status",
+      "uptime",
+      "diagnostics",
+      "admin",
+    ),
     aiSearch: hit(
       "contact enrichment",
       "ai search",
@@ -384,7 +393,8 @@ export const SettingsHome = () => {
         show.adminInvitations ||
         show.adminInstance ||
         show.adminBackups ||
-        show.adminAudit),
+        show.adminAudit ||
+        show.adminHealth),
   };
   const nothingMatches = !Object.values(groupShown).some(Boolean);
 
@@ -680,6 +690,13 @@ export const SettingsHome = () => {
               icon={ScrollText}
               title="Audit log"
               description="Every administrative action and every sign-in, newest first."
+            />
+            <SettingsLink
+              show={show.adminHealth}
+              to="/settings/admin/health"
+              icon={Activity}
+              title="Instance health"
+              description="Schema, database, backups, queues, and the AI provider."
             />
           </div>
         </section>

--- a/src/views/settings/admin/HealthView.tsx
+++ b/src/views/settings/admin/HealthView.tsx
@@ -1,0 +1,404 @@
+/**
+ * HealthView — one instance, at a glance.
+ *
+ * `/healthz` answers "ok" or nothing, which is the right answer for a probe
+ * anybody who can reach the port may ask. This page is the other half: the
+ * questions somebody has when four people share an instance and one of them
+ * says it is slow.
+ *
+ * Every card answers one of those questions and says what the answer means.
+ * A number with no sense of what it should be is not an answer: 18 MB of
+ * write-ahead log means nothing until you know the sweep truncates at 64, and
+ * "0 embedded" means nothing until you can see it is 0 of 431.
+ *
+ * The page refetches every fifteen seconds. The numbers worth opening it for
+ * are the ones that move.
+ */
+import {
+  Activity,
+  AlertTriangle,
+  Check,
+  Clock,
+  Copy,
+  Database,
+  HardDriveDownload,
+  Layers,
+  Search,
+  Sparkles,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import {
+  useInstanceHealth,
+  type HealthAccount,
+  type InstanceHealth,
+} from "../../../api/admin";
+import { Badge } from "../../../components/ui/Badge";
+import { formatBytes, formatRelative, formatWhen } from "../../../lib/datetime";
+import { cn } from "../../../lib/utils";
+import { AdminPage } from "./AdminShell";
+
+// ---------------------------------------------------------------------------
+// The card, and the one row inside it
+// ---------------------------------------------------------------------------
+
+const Card = ({
+  title,
+  icon,
+  badge,
+  children,
+}: {
+  title: string;
+  icon: ReactNode;
+  badge?: ReactNode;
+  children: ReactNode;
+}) => (
+  <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-5 space-y-3">
+    <header className="flex items-center gap-2.5">
+      <span className="shrink-0 w-8 h-8 rounded-xl bg-primary/10 text-primary flex items-center justify-center">
+        {icon}
+      </span>
+      <h2 className="text-sm font-bold text-on-surface flex-1 min-w-0 truncate">
+        {title}
+      </h2>
+      {badge}
+    </header>
+    <dl className="space-y-2">{children}</dl>
+  </section>
+);
+
+/**
+ * A label and a value.
+ *
+ * `dt`/`dd` rather than two spans: this is a list of terms and their
+ * definitions, which is what a screen reader should be told it is reading.
+ */
+const Row = ({
+  label,
+  children,
+  tone,
+}: {
+  label: string;
+  children: ReactNode;
+  tone?: "normal" | "warning" | "error";
+}) => (
+  <div className="flex items-baseline justify-between gap-4 text-xs">
+    <dt className="text-on-surface-variant shrink-0">{label}</dt>
+    <dd
+      className={cn(
+        "text-right tabular-nums font-medium min-w-0 truncate",
+        tone === "error" && "text-error",
+        tone === "warning" && "text-warning",
+        (!tone || tone === "normal") && "text-on-surface",
+      )}
+    >
+      {children}
+    </dd>
+  </div>
+);
+
+/** Seconds, as something a person reads without counting zeros. */
+function formatUptime(seconds: number): string {
+  const days = Math.floor(seconds / 86_400);
+  const hours = Math.floor((seconds % 86_400) / 3_600);
+  const minutes = Math.floor((seconds % 3_600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m`;
+  return `${seconds}s`;
+}
+
+const account = (who: HealthAccount | null): string =>
+  who?.username ?? "Nobody";
+
+// ---------------------------------------------------------------------------
+// The cards
+// ---------------------------------------------------------------------------
+
+const SchemaCard = ({ health }: { health: InstanceHealth }) => {
+  const { schema } = health;
+  return (
+    <Card
+      title="Schema"
+      icon={<Layers className="w-4 h-4" />}
+      badge={
+        schema.upToDate ? (
+          <Badge tone="success" icon={<Check className="w-3 h-3" />}>
+            Migrated
+          </Badge>
+        ) : (
+          <Badge tone="warning" icon={<AlertTriangle className="w-3 h-3" />}>
+            Behind
+          </Badge>
+        )
+      }
+    >
+      <Row
+        label="Tenancy"
+        tone={schema.tenancy < schema.tenancyExpected ? "warning" : "normal"}
+      >
+        v{schema.tenancy}
+        {schema.tenancy < schema.tenancyExpected &&
+          ` of v${schema.tenancyExpected}`}
+      </Row>
+      <Row
+        label="Search index"
+        tone={schema.fts < schema.ftsExpected ? "warning" : "normal"}
+      >
+        v{schema.fts}
+        {schema.fts < schema.ftsExpected && ` of v${schema.ftsExpected}`}
+      </Row>
+      <Row label="sqlite-vec">{schema.vec}</Row>
+      <Row label="Uptime">{formatUptime(health.uptimeSeconds)}</Row>
+    </Card>
+  );
+};
+
+const DatabaseCard = ({ health }: { health: InstanceHealth }) => {
+  const { database } = health;
+  const walIsLarge = database.walBytes > database.truncateAtBytes;
+  const contacts = database.rows.contacts ?? 0;
+  return (
+    <Card
+      title="Database"
+      icon={<Database className="w-4 h-4" />}
+      badge={
+        database.busyErrors > 0 ? (
+          <Badge tone="warning" icon={<AlertTriangle className="w-3 h-3" />}>
+            {database.busyErrors} busy
+          </Badge>
+        ) : undefined
+      }
+    >
+      <Row label="File">{formatBytes(database.bytes)}</Row>
+      <Row label="Write-ahead log" tone={walIsLarge ? "warning" : "normal"}>
+        {formatBytes(database.walBytes)}
+      </Row>
+      <Row label="Last checkpoint">
+        {database.lastCheckpoint ? (
+          <span title={formatWhen(database.lastCheckpoint.at)}>
+            {database.lastCheckpoint.mode},{" "}
+            {database.lastCheckpoint.checkpointedPages} pages
+          </span>
+        ) : (
+          "None since boot"
+        )}
+      </Row>
+      <Row
+        label="Writes refused"
+        tone={database.busyErrors > 0 ? "warning" : "normal"}
+      >
+        {database.busyErrors}
+        {database.lastBusyErrorAt &&
+          `, last ${formatRelative(database.lastBusyErrorAt, "unknown")}`}
+      </Row>
+      <Row label="Contacts">{contacts.toLocaleString()}</Row>
+    </Card>
+  );
+};
+
+const BackupCard = ({ health }: { health: InstanceHealth }) => {
+  const { backup } = health;
+  const verification = backup?.verification ?? null;
+  return (
+    <Card
+      title="Last backup"
+      icon={<HardDriveDownload className="w-4 h-4" />}
+      badge={
+        !backup ? (
+          <Badge tone="warning" icon={<AlertTriangle className="w-3 h-3" />}>
+            None
+          </Badge>
+        ) : verification?.ok ? (
+          <Badge tone="success" icon={<Check className="w-3 h-3" />}>
+            Verified
+          </Badge>
+        ) : verification ? (
+          <Badge tone="danger" icon={<AlertTriangle className="w-3 h-3" />}>
+            Failed
+          </Badge>
+        ) : (
+          <Badge>Not checked</Badge>
+        )
+      }
+    >
+      {backup ? (
+        <>
+          <Row label="Taken">
+            <span title={formatWhen(backup.createdAt)}>
+              {formatRelative(backup.createdAt, "Unknown")}
+            </span>
+          </Row>
+          <Row label="Size">{formatBytes(backup.sizeBytes)}</Row>
+          <Row label="Checked">
+            {verification
+              ? formatRelative(verification.checkedAt, "Unknown")
+              : "Never"}
+          </Row>
+          {verification?.problem && (
+            <p className="text-xs text-error text-pretty pt-1">
+              {verification.problem}
+            </p>
+          )}
+        </>
+      ) : (
+        <p className="text-xs text-on-surface-variant text-pretty">
+          No snapshot has been taken. Check that scheduled backups are switched
+          on, or take one from the Backups page.
+        </p>
+      )}
+    </Card>
+  );
+};
+
+const QueuesCard = ({ health }: { health: InstanceHealth }) => {
+  const { dedupe, aiSearch } = health.queues;
+  return (
+    <Card title="Queues" icon={<Copy className="w-4 h-4" />}>
+      <Row label="Dedupe scan" tone={dedupe.running ? "warning" : "normal"}>
+        {account(dedupe.running)}
+      </Row>
+      <Row label="Waiting behind it">
+        {dedupe.pending.length > 0
+          ? dedupe.pending.map((who) => who.username).join(", ")
+          : "Nobody"}
+      </Row>
+      <Row label="Enrichment" tone={aiSearch.running ? "warning" : "normal"}>
+        {account(aiSearch.running)}
+      </Row>
+      <Row label="Contacts left">{aiSearch.contactsRemaining}</Row>
+    </Card>
+  );
+};
+
+const EmbeddingsCard = ({ health }: { health: InstanceHealth }) => {
+  const { byUser } = health.embeddings;
+  const behind = byUser.filter((row) => row.embedded < row.contacts);
+  return (
+    <Card
+      title="Search index"
+      icon={<Search className="w-4 h-4" />}
+      badge={
+        behind.length > 0 ? (
+          <Badge tone="warning">{behind.length} behind</Badge>
+        ) : (
+          <Badge tone="success" icon={<Check className="w-3 h-3" />}>
+            Complete
+          </Badge>
+        )
+      }
+    >
+      {byUser.length === 0 && (
+        <p className="text-xs text-on-surface-variant">
+          No account owns a contact yet.
+        </p>
+      )}
+      {byUser.map((row) => (
+        <Row
+          key={row.user.id}
+          label={row.user.username}
+          tone={row.embedded < row.contacts ? "warning" : "normal"}
+        >
+          {row.embedded.toLocaleString()} of {row.contacts.toLocaleString()}
+        </Row>
+      ))}
+    </Card>
+  );
+};
+
+const ProviderCard = ({ health }: { health: InstanceHealth }) => {
+  const { provider } = health;
+  const { grounding } = provider;
+  return (
+    <Card
+      title="AI provider"
+      icon={<Sparkles className="w-4 h-4" />}
+      badge={
+        provider.circuitBreakers.length > 0 ? (
+          <Badge tone="danger" icon={<AlertTriangle className="w-3 h-3" />}>
+            {provider.circuitBreakers.length} paused
+          </Badge>
+        ) : undefined
+      }
+    >
+      <Row label="Tier">{provider.aiTier}</Row>
+      <Row label="Grounding today">
+        {grounding.rpd} of {grounding.limit}
+      </Row>
+      <Row
+        label="Models paused"
+        tone={provider.circuitBreakers.length > 0 ? "error" : "normal"}
+      >
+        {provider.circuitBreakers.length > 0
+          ? provider.circuitBreakers.join(", ")
+          : "None"}
+      </Row>
+    </Card>
+  );
+};
+
+const CacheCard = ({ health }: { health: InstanceHealth }) => {
+  const tiers = Object.entries(health.aiCache).filter(
+    ([, stats]) => stats.hits + stats.misses > 0,
+  );
+  return (
+    <Card title="AI cache" icon={<Activity className="w-4 h-4" />}>
+      {tiers.length === 0 && (
+        <p className="text-xs text-on-surface-variant">
+          Nothing has been cached since this process started.
+        </p>
+      )}
+      {tiers.map(([tier, stats]) => (
+        <Row key={tier} label={tier}>
+          {Math.round(stats.hitRate * 100)}% of {stats.hits + stats.misses}
+        </Row>
+      ))}
+    </Card>
+  );
+};
+
+// ---------------------------------------------------------------------------
+
+export const HealthView = () => {
+  const { data: health, isLoading, isError, refetch } = useInstanceHealth();
+
+  return (
+    <AdminPage lead="Everything this instance can tell you about itself. Nothing here is written and nothing here is secret, so it is safe to leave open. It refreshes every fifteen seconds.">
+      {isLoading && (
+        <p className="text-sm text-on-surface-variant">Reading the instance…</p>
+      )}
+
+      {isError && (
+        <div className="bg-surface-container-lowest rounded-2xl shadow-sm p-5 space-y-3">
+          <p className="text-sm text-error">
+            The instance could not be read. That is itself worth knowing.
+          </p>
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            className="text-sm font-bold text-primary min-h-[44px]"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {health && (
+        <>
+          <div className="flex items-center gap-2 text-xs text-on-surface-variant">
+            <Clock className="w-3.5 h-3.5" />
+            Started {formatRelative(health.startedAt, "unknown")}
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <SchemaCard health={health} />
+            <DatabaseCard health={health} />
+            <BackupCard health={health} />
+            <QueuesCard health={health} />
+            <EmbeddingsCard health={health} />
+            <ProviderCard health={health} />
+            <CacheCard health={health} />
+          </div>
+        </>
+      )}
+    </AdminPage>
+  );
+};

--- a/tests/integration/api.admin.test.ts
+++ b/tests/integration/api.admin.test.ts
@@ -214,7 +214,9 @@ describe("every admin route", () => {
   });
 
   it("covers the whole admin class, so the loops below miss nothing", () => {
-    expect(ADMIN_ROUTES).toHaveLength(29);
+    // Twenty-nine in Phase 3, and thirty with the instance health route in
+    // quality story S9.
+    expect(ADMIN_ROUTES).toHaveLength(30);
   });
 
   it.each(ADMIN_ROUTES.map((r) => [`${r.method} ${r.path}`, r] as const))(
@@ -251,6 +253,7 @@ describe("every admin route", () => {
       "/api/admin/users",
       "/api/admin/invitations",
       "/api/admin/audit",
+      "/api/admin/health",
     ]) {
       const res = await as(admin)(request(app).get(url));
       expect(res.status, url).toBe(200);

--- a/tests/integration/api.adminHealth.test.ts
+++ b/tests/integration/api.adminHealth.test.ts
@@ -1,0 +1,257 @@
+// =============================================================================
+// Integration Tests — GET /api/admin/health
+// =============================================================================
+// `/healthz` answers `SELECT 1`, which is the right answer for a probe that
+// anybody who can reach the port may ask. This route is the other half: the
+// questions an operator has when four people share an instance, and which
+// until now were answerable only by reading the server log or opening the
+// database.
+//
+// Two things are tested and they are different in kind. That a member cannot
+// reach it is a guard. That the numbers in it are real is the reason it
+// exists: a health panel full of zeros because every query threw is worse
+// than no panel, because somebody will believe it.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+
+const { makeTestApp } = await import("./helpers.ts");
+const { sqlite, TENANCY_SCHEMA_VERSION } = await import("../../server/db.ts");
+const { FTS_SCHEMA_VERSION } =
+  await import("../../server/services/search/ftsIndex.ts");
+const { dedupeQueue } =
+  await import("../../server/services/dedupe/jobQueue.ts");
+const { scopeForOwnerId } = await import("../../server/tenancy/scope.ts");
+const { createActor, asUser, resetAccounts } =
+  await import("./tenancy/helpers.ts");
+
+const app = makeTestApp();
+
+interface Actor {
+  user: { id: string; email: string; username: string };
+  cookie: string[];
+  scope: ReturnType<typeof scopeForOwnerId>;
+}
+
+let admin: Actor;
+let member: Awaited<ReturnType<typeof createActor>>;
+
+/**
+ * The first admin, made the way production makes one.
+ *
+ * `POST /api/auth/setup` converts the local owner into the first admin rather
+ * than adding a second account. `createActor` cannot do it: it only reaches
+ * setup when the instance holds no accounts at all, and `resetAccounts` puts
+ * the local owner back, so every actor it makes is a member.
+ */
+async function setUpAdmin(username: string): Promise<Actor> {
+  const res = await request(app)
+    .post("/api/auth/setup")
+    .send({
+      email: `${username}@example.com`,
+      username,
+      password: "correct horse battery staple",
+      displayName: username,
+    });
+  expect(res.status, JSON.stringify(res.body)).toBe(201);
+  expect(res.body.user.role).toBe("admin");
+  return {
+    user: { id: res.body.user.id, email: `${username}@example.com`, username },
+    cookie: (res.headers["set-cookie"] as unknown as string[]) ?? [],
+    scope: scopeForOwnerId(res.body.user.id),
+  };
+}
+
+beforeAll(async () => {
+  resetAccounts();
+  process.env.AUTH_REQUIRED = "true";
+  admin = await setUpAdmin("healthadmin");
+  member = await createActor(app, { username: "healthmember" });
+  sqlite
+    .prepare("UPDATE users SET role = 'member' WHERE id = ?")
+    .run(member.user.id);
+});
+
+afterAll(() => {
+  process.env.AUTH_REQUIRED = "";
+  dedupeQueue.__resetForTests();
+  resetAccounts();
+});
+
+/** The payload, as an admin. */
+async function health(): Promise<Record<string, never>> {
+  const res = await asUser(admin)(request(app).get("/api/admin/health"));
+  expect(res.status).toBe(200);
+  return res.body;
+}
+
+describe("who can read it", () => {
+  it("refuses a member", async () => {
+    const res = await asUser(member)(request(app).get("/api/admin/health"));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("ADMIN_REQUIRED");
+  });
+
+  it("refuses a caller with no credential at all", async () => {
+    const res = await request(app).get("/api/admin/health");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("answers an admin", async () => {
+    const res = await asUser(admin)(request(app).get("/api/admin/health"));
+
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("what it says", () => {
+  it("reports the schema this database is actually on", async () => {
+    const body = (await health()) as unknown as {
+      schema: {
+        tenancy: number;
+        tenancyExpected: number;
+        fts: number;
+        ftsExpected: number;
+        vec: string;
+        upToDate: boolean;
+      };
+    };
+
+    expect(body.schema.tenancy).toBe(TENANCY_SCHEMA_VERSION);
+    expect(body.schema.tenancyExpected).toBe(TENANCY_SCHEMA_VERSION);
+    expect(body.schema.fts).toBe(FTS_SCHEMA_VERSION);
+    expect(body.schema.ftsExpected).toBe(FTS_SCHEMA_VERSION);
+    // The one version that comes from a native extension rather than a row we
+    // wrote. Anything is acceptable except nothing.
+    expect(body.schema.vec).toMatch(/^v?\d+\.\d+\.\d+/);
+    expect(body.schema.upToDate).toBe(true);
+  });
+
+  it("reports a database that is really there", async () => {
+    const body = (await health()) as unknown as {
+      database: {
+        bytes: number;
+        walBytes: number;
+        busyErrors: number;
+        rows: Record<string, number>;
+      };
+    };
+
+    // Every one of these is a number the panel prints. A zero would be
+    // printed just as confidently as the truth.
+    expect(body.database.bytes).toBeGreaterThan(0);
+    expect(body.database.rows.users).toBeGreaterThanOrEqual(2);
+    expect(body.database.rows.contacts).toBeGreaterThanOrEqual(0);
+    expect(Object.keys(body.database.rows)).toHaveLength(9);
+    expect(body.database.busyErrors).toBe(0);
+  });
+
+  it("names the account a scan is running for, and who is behind it", async () => {
+    dedupeQueue.setProcessing(true);
+    dedupeQueue.createScan(admin.scope, "quick");
+    dedupeQueue.enqueue(member.scope, "queued-scan", () => undefined);
+
+    try {
+      const body = (await health()) as unknown as {
+        queues: {
+          dedupe: {
+            running: { id: string; username: string } | null;
+            pending: { id: string; username: string }[];
+          };
+        };
+      };
+
+      // "A scan is running" is not an answer an operator can act on when four
+      // people share an instance and one of them is waiting.
+      expect(body.queues.dedupe.running?.username).toBe("healthadmin");
+      expect(body.queues.dedupe.pending.map((p) => p.username)).toEqual([
+        "healthmember",
+      ]);
+    } finally {
+      dedupeQueue.__resetForTests();
+    }
+  });
+
+  it("says nothing is running when nothing is", async () => {
+    dedupeQueue.__resetForTests();
+
+    const body = (await health()) as unknown as {
+      queues: {
+        dedupe: { running: unknown; pending: unknown[] };
+        aiSearch: { running: unknown; activeBatches: number };
+      };
+    };
+
+    expect(body.queues.dedupe.running).toBeNull();
+    expect(body.queues.dedupe.pending).toEqual([]);
+    expect(body.queues.aiSearch.running).toBeNull();
+    expect(body.queues.aiSearch.activeBatches).toBe(0);
+  });
+
+  it("counts each account's contacts against its search vectors", async () => {
+    await asUser(admin)(
+      request(app)
+        .post("/api/contacts")
+        .send({ name: "Health Contact" })
+        .expect(201),
+    );
+
+    const body = (await health()) as unknown as {
+      embeddings: {
+        available: boolean;
+        byUser: {
+          user: { username: string };
+          contacts: number;
+          embedded: number;
+        }[];
+      };
+    };
+
+    const row = body.embeddings.byUser.find(
+      (entry) => entry.user.username === "healthadmin",
+    );
+    expect(row?.contacts).toBeGreaterThan(0);
+    // No model is loaded in a test, so nothing is embedded. The point of the
+    // pair is that an operator can see exactly that.
+    expect(row?.embedded).toBe(0);
+  });
+
+  it("reports uptime and the cache", async () => {
+    const body = (await health()) as unknown as {
+      uptimeSeconds: number;
+      startedAt: string;
+      aiCache: Record<string, { entries: number; hitRate: number }>;
+      provider: { aiTier: string; circuitBreakers: string[] };
+    };
+
+    expect(body.uptimeSeconds).toBeGreaterThanOrEqual(0);
+    expect(Date.parse(body.startedAt)).not.toBeNaN();
+    expect(Object.keys(body.aiCache).length).toBeGreaterThan(0);
+    // The tier bucket is not a cache tier and must not be reported as one.
+    expect(body.aiCache.batchMode).toBeUndefined();
+    expect(body.provider.circuitBreakers).toEqual([]);
+  });
+
+  it("carries no secret", async () => {
+    const res = await asUser(admin)(request(app).get("/api/admin/health"));
+    const text = JSON.stringify(res.body).toLowerCase();
+
+    // The payload describes an instance to somebody who administers it. It
+    // must not describe a credential to anybody.
+    for (const forbidden of [
+      "apikey",
+      "api_key",
+      "password",
+      "passwordhash",
+      "tokenhash",
+      "secret",
+      "ctk_",
+      "sessionid",
+    ]) {
+      expect(text, forbidden).not.toContain(forbidden);
+    }
+  });
+});

--- a/tests/integration/tenancy.routeManifest.test.ts
+++ b/tests/integration/tenancy.routeManifest.test.ts
@@ -145,15 +145,16 @@ describe("route manifest", () => {
     }
   });
 
-  it("counts the routes Phase 3 added", () => {
+  it("counts the admin surface", () => {
     // A cheap tripwire: the admin surface grew from fourteen classified rows
-    // to twenty-nine guarded ones, and a route added without a decision moves
-    // this number.
+    // to twenty-nine guarded ones in Phase 3, and to thirty with the health
+    // route in quality story S9. A route added without a decision moves this
+    // number.
     const admin = ROUTE_MANIFEST.filter((r) => r.class === "admin");
-    expect(admin).toHaveLength(29);
+    expect(admin).toHaveLength(30);
     expect(
       ROUTE_MANIFEST.filter((r) => r.path.startsWith("/api/admin/")),
-    ).toHaveLength(15);
+    ).toHaveLength(16);
 
     // The three token routes act on the caller's own account, so a token
     // cannot reach them and neither can the implicit local owner.


### PR DESCRIPTION
`/healthz` answers `SELECT 1`. That is the right answer for a probe anybody who can reach the port may ask, and it is no answer at all to the questions somebody has when four people share an instance and one of them says it is slow.

This is quality story S9 from [15-additional-v2-features.md](docs/multi-tenant-plan/15-additional-v2-features.md) section 7, the last of the five accepted for 2.0.

## What `GET /api/admin/health` answers

Every one of these was previously answerable only by reading the server log or opening the database.

| Card | Question it answers |
| ---- | ------------------- |
| Schema | Did the migration run? Tenancy and FTS versions against what this build expects, plus the sqlite-vec build and uptime |
| Database | File and write-ahead log sizes, the last checkpoint, and how many requests were refused as busy |
| Last backup | When, how big, and **did it verify** |
| Queues | **Which account** the dedupe scan is running for and **who is waiting behind it**, plus the enrichment batch |
| Search index | Contacts against search vectors, per account |
| AI provider | Tier, grounding used today, and which models a circuit breaker has paused |
| AI cache | Hit rate per tier |

Two design choices worth the review:

- **The queues name accounts, not booleans.** "A scan is running" is not something an operator can act on when several people share an instance and one of them is waiting. Both job queues gained an `instanceState()` for this, separate from every existing reader, which asks about one account because one account is all a member may know about.
- **Search index progress is two numbers, not a percentage.** The useful question is which account has contacts search cannot reach yet, and a percentage of zero contacts is not a number.

## What is deliberately not here

- **`/healthz` is untouched.** It answers without a credential, so it stays two states and no detail. An unauthenticated endpoint that describes the instance tells anybody who can reach the port what version it runs, how big it is, and how many accounts it has.
- **Extra F4** wanted the schema versions on `/healthz`. F4 was not accepted, and the S9 paragraph puts the versions here anyway, so that is where they are: behind the admin guard. The decision record says so.
- **No secrets.** No key, no token, no invitation link, no contact of anybody's. The most identifying value in the payload is a username beside a queue position, and the caller can already list every account. A test asserts the serialised body contains none of `apikey`, `password`, `passwordhash`, `tokenhash`, `secret`, `ctk_`, or `sessionid`.

## The view

A card grid under Administration, lazy like every other administration page, refetching every fifteen seconds. It builds as its own 7.45 kB chunk, so a member never downloads it.

Each card says what its numbers mean. **A number with no sense of what it should be is not an answer**: 18 MB of write-ahead log means nothing until the reader can see the sweep truncates at 64 MB, and "0 embedded" means nothing until it says 0 of 431. Values that have crossed a line are toned, so a growing log, a refused write, a failed backup and a paused model are visible without reading every row.

## Testing

`tests/integration/api.adminHealth.test.ts`, 10 tests. Two kinds: that a member cannot reach it, and that the numbers in it are real. **A health panel full of zeros because every query threw is worse than no panel, because somebody will believe it**, so each assertion names a value that must not be zero.

The route also joins the existing loops in `api.admin.test.ts`, which drive **every** route in the `admin` class and assert a member gets `403 ADMIN_REQUIRED` and an admin gets past the guard. Those loops are driven off `ROUTE_MANIFEST`, so the new row is covered the moment it exists; the count tripwire moves from 29 to 30.

Every test was checked by breaking the code it covers:

| Change | Result |
| ------ | ------ |
| `requireAdmin` removed from the route | 1 failure |
| Queue owners not resolved to names | 1 failure |
| The cache's `batchMode` bucket reported as a cache tier | 1 failure |

```
npm run lint           tenant-lint: clean for 1 glob(s): server/**/*.ts
npm run format:check   All matched files use Prettier code style!
npm test                Test Files  80 passed (80)
                             Tests  1286 passed (1286)
npm run build          ✓ built in 296ms  (HealthView 7.45 kB, its own chunk)
npm run tenancy:verify tenancy-verify: all 25 checks passed
npm run audit:contrast -- --routes /settings/admin/health,/settings
                       TOTAL failing text elements: 0
```

The panel was checked in a browser at 1400 px and at 390 px against a live instance with twelve contacts and one verified snapshot: three columns of cards on a desktop, one on a phone. `/settings/admin/health` is added to the contrast audit's default sweep.
