### PR TITLE
docs: bring the README up to date with 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![React 19](https://img.shields.io/badge/Frontend-React_19-61DAFB?logo=react)](https://react.dev/)
 [![Tailwind v4](https://img.shields.io/badge/Styling-Tailwind_v4-38B2AC?logo=tailwind-css)](https://tailwindcss.com/)
 [![TypeScript](https://img.shields.io/badge/Language-TypeScript-3178C6?logo=typescript)](https://www.typescriptlang.org/)
-[![Tests](https://img.shields.io/badge/Tests-518_passing-brightgreen)](https://vitest.dev/)
+[![Tests](https://img.shields.io/badge/Tests-1695_passing-brightgreen)](https://vitest.dev/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 </div>
 
@@ -136,9 +136,13 @@ Multi-pass engine utilizing Double Metaphone phonetic matching, Levenshtein dist
 - **Quick Note** (`Cmd+Shift+I`) — Log interactions from anywhere
 - **Link Unfurling** — Zero-Chromium OpenGraph extraction via Cheerio
 - **Logo Proxy** — Heuristic company logo discovery with local caching
+- **Themes** — Light, dark, or follow the machine, plus an accent colour that derives a readable palette of its own
 - **Trash & Undo** — Deletes are soft: restore from Settings → Trash within 30 days
-- **Automatic Backups** — Scheduled SQLite snapshots with rotation, plus one-click JSON/CSV export
-- **Accounts** — Optional sign-in with username/password, server-side sessions you can revoke per device, plus a bearer token for scripts and MCP
+- **Export** — vCard, CSV and JSON, each covering only your own contacts. vCard reads back in, so moving out and back in is honest
+- **Automatic Backups** — Scheduled SQLite snapshots with rotation. Every snapshot is reopened, checked and counted against the live database, and the answer shows per file
+- **Accounts** — Optional sign-in with username/password, server-side sessions you can revoke per device, plus personal API tokens for scripts and MCP
+- **Administration** — Member and admin roles, invitations, instance settings, an audit log and a health panel. Every query is scoped to one account, which a lint rule and a verification script both enforce
+- **Settings follow the account** — Theme, accent, list density, recent contacts, search history and dedupe thresholds live on the server, so a phone and a laptop agree
 
 ---
 
@@ -195,13 +199,13 @@ Open **http://localhost:3210**. The server auto-initializes the database, loads 
 
 | Domain       | Technology                                                            |
 | ------------ | --------------------------------------------------------------------- |
-| **Frontend** | React 19, Vite 6, React Query v5, Tailwind CSS v4, Tiptap, Motion     |
+| **Frontend** | React 19, Vite 8, React Query v5, Tailwind CSS v4, Tiptap, Motion     |
 | **Backend**  | Node.js 22, Express, TypeScript (tsx), Zod validation                 |
 | **Database** | SQLite3 (WAL mode), Drizzle ORM, FTS5, sqlite-vec                     |
 | **AI**       | Gemini / OpenAI / Anthropic / any OpenAI-compatible endpoint          |
 | **Search**   | Hybrid RAG: FTS5 keyword + 384-dim local vector KNN (Transformers.js) |
 | **Mapping**  | React Leaflet + Leaflet Cluster, Mapbox/Nominatim geocoding           |
-| **Testing**  | Vitest — 500+ unit & integration tests, no API keys needed            |
+| **Testing**  | Vitest — 1,695 unit, integration and eval tests, no API keys needed   |
 
 ---
 
@@ -233,21 +237,21 @@ Full documentation lives in the [`docs/`](docs/) directory:
 
 ## 🔐 Environment Variables
 
-| Variable                | Description                                               | Default      |
-| ----------------------- | --------------------------------------------------------- | ------------ |
-| `AI_PROVIDER`           | Preferred provider for capabilities set to Auto           | `gemini`     |
-| `GEMINI_API_KEY`        | Gemini API key                                            | —            |
-| `OPENAI_API_KEY`        | OpenAI API key                                            | —            |
-| `ANTHROPIC_API_KEY`     | Anthropic API key                                         | —            |
-| `AI_TIER`               | `FREE` or `PAID` rate limit profile                       | `FREE`       |
-| `PORT`                  | Express listening port                                    | `3210`       |
-| `HOST`                  | Bind interface (`0.0.0.0` to expose on LAN)               | `127.0.0.1`  |
-| `AUTH_REQUIRED`         | `true` = require sign-in with an account                  | `false`      |
-| `API_TOKEN`             | Machine credential for scripts/MCP (`Bearer`); also gates | — (off)      |
-| `DATA_DIR`              | Root for runtime data (DB, uploads, backups, model cache) | project root |
-| `MAPBOX_API_KEY`        | Mapbox geocoding (optional, higher accuracy)              | —            |
-| `BACKUP_INTERVAL_HOURS` | Hours between automatic DB snapshots (`0` disables)       | `24`         |
-| `BACKUP_KEEP`           | Rotation depth for automatic snapshots                    | `7`          |
+| Variable                | Description                                                                                                                                       | Default      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `AI_PROVIDER`           | Preferred provider for capabilities set to Auto                                                                                                   | `gemini`     |
+| `GEMINI_API_KEY`        | Gemini API key                                                                                                                                    | —            |
+| `OPENAI_API_KEY`        | OpenAI API key                                                                                                                                    | —            |
+| `ANTHROPIC_API_KEY`     | Anthropic API key                                                                                                                                 | —            |
+| `AI_TIER`               | `FREE` or `PAID` rate limit profile                                                                                                               | `FREE`       |
+| `PORT`                  | Express listening port                                                                                                                            | `3210`       |
+| `HOST`                  | Bind interface (`0.0.0.0` to expose on LAN)                                                                                                       | `127.0.0.1`  |
+| `AUTH_REQUIRED`         | `true` = require sign-in with an account                                                                                                          | `false`      |
+| `API_TOKEN`             | **Deprecated.** Instance-wide machine credential, and setting it gates the instance. Removed in 3.0, use a personal token from Settings → Account | — (off)      |
+| `DATA_DIR`              | Root for runtime data (DB, uploads, backups, model cache)                                                                                         | project root |
+| `MAPBOX_API_KEY`        | Mapbox geocoding (optional, higher accuracy)                                                                                                      | —            |
+| `BACKUP_INTERVAL_HOURS` | Hours between automatic DB snapshots (`0` disables)                                                                                               | `24`         |
+| `BACKUP_KEEP`           | Rotation depth for automatic snapshots                                                                                                            | `7`          |
 
 More variables (per-capability model pins, CORS, trash retention, background-job control) in the [Configuration Guide](docs/configuration.md). A liveness probe lives at `GET /healthz` — always reachable without a credential, used by the Docker `HEALTHCHECK`, and safe to point an uptime monitor at.
 


### PR DESCRIPTION
The README described the app before this branch. Four things shipped on `v2.0` that it never mentioned, and three stated numbers had drifted.

## What was missing

- **Themes.** Light, dark, or follow the machine, plus the accent picker.
- **vCard.** Export reads back in, which is the part worth saying: a move out and back in is honest, not a one-way door.
- **The administration area.** Roles, invitations, instance settings, the audit log and the health panel. Scoping is mentioned in the same line, because on a self-hosted tool with more than one account it is the thing a reader wants to know is enforced rather than intended.
- **Preferences that follow the account.** Named as what it does for a person, not as a schema change.

Backups also verify themselves now. The old one-line entry said "snapshots with rotation", which was true when nothing ever reopened the file.

## What had drifted

| | said | is |
| --- | --- | --- |
| test badge | 518 | 1,695 |
| stack table | 500+ tests | 1,695 |
| Vite | 6 | 8 |

None of those is load bearing. A number nobody maintains is still worse than no number.

`API_TOKEN` is now marked deprecated in the environment table, matching what `docs/configuration.md` already said: it is removed in 3.0 and a personal token replaces it. A reader who set it from the README would have had no way to learn that.

## What I checked rather than assumed

- Every environment variable in the table exists in `.env.example`, and the ones absent from the table are exactly the four groups the following paragraph says live in the configuration guide.
- Every local link in the file resolves.
- The documentation index matches `docs/README.md`. No guide exists for accounts or administration, so nothing links to one.
- `Levenshtein`, `Double Metaphone`, `sqlite-vec` at 768 for dedupe and 384 for search, and Node 22 all still match the code. Left alone.

Screenshots are still the light palette. Regenerating them for dark mode is a bigger job than this and did not belong in it.

## Testing

- `npm run format:check`, clean
- Local link check, no missing targets

Documentation only. No source file is touched.
